### PR TITLE
CDAP-15100 Improve performance of DBRecord class

### DIFF
--- a/database-commons/src/main/java/io/cdap/plugin/db/CommonSchemaReader.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/CommonSchemaReader.java
@@ -35,41 +35,6 @@ import javax.annotation.Nullable;
 public class CommonSchemaReader implements SchemaReader {
 
   @Override
-  public List<Schema.Field> getSchemaFields(ResultSet resultSet, @Nullable String schemaStr)
-    throws SQLException {
-    Schema resultsetSchema = Schema.recordOf("resultset", getSchemaFields(resultSet));
-    Schema schema;
-
-    if (!Strings.isNullOrEmpty(schemaStr)) {
-      try {
-        schema = Schema.parseJson(schemaStr);
-      } catch (IOException e) {
-        throw new IllegalArgumentException(String.format("Unable to parse schema string %s", schemaStr), e);
-      }
-      for (Schema.Field field : schema.getFields()) {
-        Schema.Field resultsetField = resultsetSchema.getField(field.getName());
-        if (resultsetField == null) {
-          throw new IllegalArgumentException(String.format("Schema field %s is not present in input record",
-                                                           field.getName()));
-        }
-        Schema resultsetFieldSchema = resultsetField.getSchema().isNullable() ?
-          resultsetField.getSchema().getNonNullable() : resultsetField.getSchema();
-        Schema simpleSchema = field.getSchema().isNullable() ? field.getSchema().getNonNullable() : field.getSchema();
-
-        if (!resultsetFieldSchema.equals(simpleSchema)) {
-          throw new IllegalArgumentException(String.format("Schema field %s has type %s but in input record found " +
-                                                             "type %s ",
-                                                           field.getName(), simpleSchema.getType(),
-                                                           resultsetFieldSchema.getType()));
-        }
-      }
-      return schema.getFields();
-
-    }
-    return resultsetSchema.getFields();
-  }
-
-  @Override
   public List<Schema.Field> getSchemaFields(ResultSet resultSet) throws SQLException {
     List<Schema.Field> schemaFields = Lists.newArrayList();
     ResultSetMetaData metadata = resultSet.getMetaData();

--- a/database-commons/src/main/java/io/cdap/plugin/db/SchemaReader.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/SchemaReader.java
@@ -30,18 +30,6 @@ import javax.annotation.Nullable;
 public interface SchemaReader {
 
   /**
-   *  Given the result set, get the metadata of the result set and return
-   *  list of {@link io.cdap.cdap.api.data.schema.Schema.Field},
-   *  where name of the field is same as column name and type of the field is obtained using
-   *  {@link SchemaReader#getSchema(ResultSetMetaData, int)}
-   * @param resultSet Sql query result set
-   * @param schemaStr schema string to override resultant schema
-   * @return list of schema fields
-   * @throws SQLException
-   */
-  List<Schema.Field> getSchemaFields(ResultSet resultSet, @Nullable String schemaStr) throws SQLException;
-
-  /**
    * Given the result set, get the metadata of the result set and return
    * list of {@link io.cdap.cdap.api.data.schema.Schema.Field},
    * where name of the field is same as column name and type of the field is obtained using

--- a/database-commons/src/main/java/io/cdap/plugin/util/Lazy.java
+++ b/database-commons/src/main/java/io/cdap/plugin/util/Lazy.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.util;
+
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Helper class for lazy field initialization. Implementation is thread-safe.
+ *
+ * @param <T> value type
+ */
+public final class Lazy<T> {
+  private final Supplier<T> supplier;
+  private volatile T value;
+
+  public Lazy(Supplier<T> supplier) {
+    this.supplier = supplier;
+  }
+
+  public T getOrCompute() {
+    final T result = value; // Just one volatile read
+    return result == null ? compute() : result;
+  }
+
+  private synchronized T compute() {
+    if (value == null) {
+      value = requireNonNull(supplier.get());
+    }
+    return value;
+  }
+}


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15100
WIKI: https://wiki.cask.co/display/CE/Database+plugin+enhancements

In scope of this PR:
- Removed input schema parsing on each incoming row
- Removed field validation on each incoming row
- Added schema validation on pipeline deployment
- Schema parsing changed to lazy computation with cache
- Actual DB schema resolving was moved to "prepareRun" stage

Attachments ([CDAP-15100_report.zip](https://github.com/data-integrations/database-plugins/files/3088404/CDAP-15100_report.zip)):
- CPU utilization flamegraphs before and after improvement
- CDAP report for 500k records read before and after improvement for same pipeline
- Test pipeline




