### PR TITLE
CDAP-15264 Investigate the reason of database plugins performance gap…

### DIFF
--- a/aurora-postgresql-plugin/src/main/java/io/cdap/plugin/auroradb/postgres/AuroraPostgresDBRecord.java
+++ b/aurora-postgresql-plugin/src/main/java/io/cdap/plugin/auroradb/postgres/AuroraPostgresDBRecord.java
@@ -41,17 +41,17 @@ public class AuroraPostgresDBRecord extends DBRecord {
 
   @Override
   protected void handleField(ResultSet resultSet, StructuredRecord.Builder recordBuilder, Schema.Field field,
-                             int sqlType, int sqlPrecision, int sqlScale) throws SQLException {
+                             int columnIndex, int sqlType, int sqlPrecision, int sqlScale) throws SQLException {
     if (AuroraPostgresSchemaReader.POSTGRES_TYPES.contains(sqlType)) {
-      handleSpecificType(resultSet, recordBuilder, field);
+      handleSpecificType(resultSet, recordBuilder, field, columnIndex);
     } else {
-      setField(resultSet, recordBuilder, field, sqlType, sqlPrecision, sqlScale);
+      setField(resultSet, recordBuilder, field, columnIndex, sqlType, sqlPrecision, sqlScale);
     }
   }
 
-  private void handleSpecificType(ResultSet resultSet,
-                                  StructuredRecord.Builder recordBuilder, Schema.Field field) throws SQLException {
-    setFieldAccordingToSchema(resultSet, recordBuilder, field);
+  private void handleSpecificType(ResultSet resultSet, StructuredRecord.Builder recordBuilder, Schema.Field field,
+                                  int columnIndex) throws SQLException {
+    setFieldAccordingToSchema(resultSet, recordBuilder, field, columnIndex);
   }
 
   @Override

--- a/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
+++ b/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
@@ -254,8 +254,8 @@ public final class DBUtils {
 
   @Nullable
   public static Object transformValue(int sqlType, int precision, int scale,
-                                      ResultSet resultSet, String fieldName) throws SQLException {
-    Object original = resultSet.getObject(fieldName);
+                                      ResultSet resultSet, int columnIndex) throws SQLException {
+    Object original = resultSet.getObject(columnIndex);
     if (original != null) {
       switch (sqlType) {
         case Types.SMALLINT:
@@ -274,27 +274,19 @@ public final class DBUtils {
             return decimal.intValue();
           }
         case Types.DATE:
-          return resultSet.getDate(fieldName);
+          return resultSet.getDate(columnIndex);
         case Types.TIME:
-          return resultSet.getTime(fieldName);
+          return resultSet.getTime(columnIndex);
         case Types.TIMESTAMP:
-          return resultSet.getTimestamp(fieldName);
+          return resultSet.getTimestamp(columnIndex);
         case Types.ROWID:
-          return resultSet.getString(fieldName);
+          return resultSet.getString(columnIndex);
         case Types.BLOB:
           Blob blob = (Blob) original;
-          try {
-            return blob.getBytes(1, (int) blob.length());
-          } finally {
-            blob.free();
-          }
+          return blob.getBytes(1, (int) blob.length());
         case Types.CLOB:
           Clob clob = (Clob) original;
-          try {
-            return clob.getSubString(1, (int) clob.length());
-          } finally {
-            clob.free();
-          }
+          return clob.getSubString(1, (int) clob.length());
       }
     }
     return original;

--- a/db2-plugin/src/main/java/io/cdap/plugin/db2/DB2Record.java
+++ b/db2-plugin/src/main/java/io/cdap/plugin/db2/DB2Record.java
@@ -48,24 +48,24 @@ public class DB2Record extends DBRecord {
 
   @Override
   protected void handleField(ResultSet resultSet, StructuredRecord.Builder recordBuilder, Schema.Field field,
-                             int sqlType, int sqlPrecision, int sqlScale) throws SQLException {
+                             int columnIndex, int sqlType, int sqlPrecision, int sqlScale) throws SQLException {
     if (DB2SchemaReader.DB2_TYPES.contains(sqlType)) {
-      handleSpecificType(resultSet, recordBuilder, field,  resultSet.findColumn(field.getName()));
+      handleSpecificType(resultSet, recordBuilder, field, columnIndex);
     } else {
-      setField(resultSet, recordBuilder, field, sqlType, sqlPrecision, sqlScale);
+      setField(resultSet, recordBuilder, field, columnIndex, sqlType, sqlPrecision, sqlScale);
     }
   }
 
   private void handleSpecificType(ResultSet resultSet,
                                   StructuredRecord.Builder recordBuilder,
-                                  Schema.Field field, int index) throws SQLException {
+                                  Schema.Field field, int columnIndex) throws SQLException {
 
     ResultSetMetaData metaData = resultSet.getMetaData();
 
-    String columnTypeName = metaData.getColumnTypeName(index);
+    String columnTypeName = metaData.getColumnTypeName(columnIndex);
 
     if (DB2SchemaReader.DB2_DECFLOAT.equals(columnTypeName)) {
-      recordBuilder.set(field.getName(), resultSet.getBigDecimal("DECFLOAT_COL").doubleValue());
+      recordBuilder.set(field.getName(), resultSet.getBigDecimal(columnIndex).doubleValue());
     }
   }
 }

--- a/netezza-plugin/src/main/java/io/cdap/plugin/netezza/NetezzaDBRecord.java
+++ b/netezza-plugin/src/main/java/io/cdap/plugin/netezza/NetezzaDBRecord.java
@@ -51,24 +51,23 @@ public class NetezzaDBRecord extends DBRecord {
 
   @Override
   protected void handleField(ResultSet resultSet, StructuredRecord.Builder recordBuilder, Schema.Field field,
-                             int sqlType, int sqlPrecision, int sqlScale) throws SQLException {
+                             int columnIndex, int sqlType, int sqlPrecision, int sqlScale) throws SQLException {
     if (netezzaTypes.contains(sqlType)) {
-      handleNetezzaSpecificType(resultSet, recordBuilder, field, sqlType);
+      handleNetezzaSpecificType(resultSet, recordBuilder, field, columnIndex, sqlType);
     } else {
-      setField(resultSet, recordBuilder, field, sqlType, sqlPrecision, sqlScale);
+      setField(resultSet, recordBuilder, field, columnIndex, sqlType, sqlPrecision, sqlScale);
     }
   }
 
-  private void handleNetezzaSpecificType(ResultSet resultSet,
-                                         StructuredRecord.Builder recordBuilder, Schema.Field field,
-                                         int sqlType) throws SQLException {
+  private void handleNetezzaSpecificType(ResultSet resultSet, StructuredRecord.Builder recordBuilder,
+                                         Schema.Field field, int columnIndex, int sqlType) throws SQLException {
 
     switch (sqlType) {
       case Types.VARBINARY:
-        recordBuilder.set(field.getName(), resultSet.getBytes(field.getName()));
+        recordBuilder.set(field.getName(), resultSet.getBytes(columnIndex));
         break;
       case INTERVAL:
-        recordBuilder.set(field.getName(), resultSet.getString(field.getName()));
+        recordBuilder.set(field.getName(), resultSet.getString(columnIndex));
         break;
     }
   }

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleDBRecord.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleDBRecord.java
@@ -51,26 +51,26 @@ public class OracleDBRecord extends DBRecord {
 
   @Override
   protected void handleField(ResultSet resultSet, StructuredRecord.Builder recordBuilder, Schema.Field field,
-                             int sqlType, int sqlPrecision, int sqlScale) throws SQLException {
+                             int columnIndex, int sqlType, int sqlPrecision, int sqlScale) throws SQLException {
     if (OracleSchemaReader.ORACLE_TYPES.contains(sqlType)) {
-      handleOracleSpecificType(resultSet, recordBuilder, field, sqlType);
+      handleOracleSpecificType(resultSet, recordBuilder, field, columnIndex, sqlType);
     } else {
-      setField(resultSet, recordBuilder, field, sqlType, sqlPrecision, sqlScale);
+      setField(resultSet, recordBuilder, field, columnIndex, sqlType, sqlPrecision, sqlScale);
     }
   }
 
   private void handleOracleSpecificType(ResultSet resultSet,
                                         StructuredRecord.Builder recordBuilder, Schema.Field field,
-                                        int sqlType) throws SQLException {
+                                        int columnIndex, int sqlType) throws SQLException {
 
     switch (sqlType) {
       case OracleSchemaReader.INTERVAL_YM:
       case OracleSchemaReader.INTERVAL_DS:
-        recordBuilder.set(field.getName(), resultSet.getString(field.getName()));
+        recordBuilder.set(field.getName(), resultSet.getString(columnIndex));
         break;
       case OracleSchemaReader.TIMESTAMP_LTZ:
       case OracleSchemaReader.TIMESTAMP_TZ:
-        Instant instant = resultSet.getTimestamp(field.getName()).toInstant();
+        Instant instant = resultSet.getTimestamp(columnIndex).toInstant();
         recordBuilder.setTimestamp(field.getName(), instant.atZone(ZoneId.ofOffset("UTC", ZoneOffset.UTC)));
         break;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- version properties -->
-    <cdap.version>6.0.0-SNAPSHOT</cdap.version>
+    <cdap.version>6.1.0-SNAPSHOT</cdap.version>
     <cdap.plugin.version>2.2.0-SNAPSHOT</cdap.plugin.version>
     <guava.version>13.0.1</guava.version>
     <hadoop.version>2.3.0</hadoop.version>

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresDBRecord.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresDBRecord.java
@@ -41,17 +41,17 @@ public class PostgresDBRecord extends DBRecord {
 
   @Override
   protected void handleField(ResultSet resultSet, StructuredRecord.Builder recordBuilder, Schema.Field field,
-                             int sqlType, int sqlPrecision, int sqlScale) throws SQLException {
+                             int columnIndex, int sqlType, int sqlPrecision, int sqlScale) throws SQLException {
     if (PostgresSchemaReader.POSTGRES_TYPES.contains(sqlType)) {
-      handleSpecificType(resultSet, recordBuilder, field);
+      handleSpecificType(resultSet, recordBuilder, field, columnIndex);
     } else {
-      setField(resultSet, recordBuilder, field, sqlType, sqlPrecision, sqlScale);
+      setField(resultSet, recordBuilder, field, columnIndex, sqlType, sqlPrecision, sqlScale);
     }
   }
 
-  private void handleSpecificType(ResultSet resultSet,
-                                  StructuredRecord.Builder recordBuilder, Schema.Field field) throws SQLException {
-    setFieldAccordingToSchema(resultSet, recordBuilder, field);
+  private void handleSpecificType(ResultSet resultSet, StructuredRecord.Builder recordBuilder, Schema.Field field,
+                                  int columnIndex) throws SQLException {
+    setFieldAccordingToSchema(resultSet, recordBuilder, field, columnIndex);
   }
 
   @Override


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15264

### In scope of this PR
- improved performance of operations with LOB type values
- improved performance of DBRecord.handleField operation

### What was done
- removed "free()" method call for BLOB/CLOB types so it work the same way as in sqoop and Spring framework (see: [spring issue](https://github.com/spring-projects/spring-framework/issues/16042))
- reworked ResultSet.get* methods to use column index instead of column key to get rid of lookup time

### Test results for Oracle DB
- 500k rows (before patch) = 52 sec
- 500k rows (after patch) = 14 sec
- 500k rows (sqoop-libs branch) = 54 sec
- 10kk rows (before patch) = 17:57 min
- 10kk rows (after patch) = 3:05 min
- 10kk rows (sqoop-libs branch) = 15:55 min

### Attachments
- CPU and allocation flamegraphs: [oracle-flamegraphs.zip](https://github.com/data-integrations/database-plugins/files/3204627/oracle-flamegraphs.zip)

### Results explanation
**Why does plugin perform that much faster after patch?**
Comparing db plugins and sqoop CPU utilization we can see that Sqoop does not call "free()" method call for BLOB/CLOB types (see oracle_sqoop-cpu.svg from attached flamegraphs). The reason of performance improvement is shown comparing "oracle-cpu (before).svg" and "oracle-cpu (after).svg".

**What is the difference between CDAP plugin and Sqoop application?**
After applying this PR the only difference between CDAP and Sqoop logic will be in StructuredRecord creation and CDAP core related logic. See "oracle-cpu (after).svg" and "oracle_sqoop-cpu.svg".

**Why do we have old bad results after migrating to sqoop in sqoop-libs branch?**
See "oracle-cpu (after).svg" and "oracle-cdap-sqoop-cpu_flamegraph.svg".
We can not really tell that changing implemented interface from "org.apache.hadoop.mapreduce.lib.db.DBWritable" to "org.apache.sqoop.mapreduce.DBWritable" is a migration to Sqoop. The main differences between CDAP plugins and Sqoop are:
- Sqoop generates its own optimized QueryResults class to get rid of SQL schema inspection on each raw. But we still use our DBRecord class in sqoop-libs branch.
- Sqoop does not generate StructuredRecords and just copies bytes from BLOBs to output file (which is way faster)

### Conclusion
- we will achieve almost maximum possible performance after applying this PR without any migrations
- we will not have any benefits from migration to Sqoop




