### PR TITLE
Set default number of splits to 1

### DIFF
--- a/aurora-mysql-plugin/widgets/AuroraMysql-batchsource.json
+++ b/aurora-mysql-plugin/widgets/AuroraMysql-batchsource.json
@@ -85,7 +85,10 @@
         {
           "widget-type": "textbox",
           "label": "Number of Splits to Generate",
-          "name": "numSplits"
+          "name": "numSplits",
+          "widget-attributes": {
+            "default": "1"
+          }
         }
       ]
     },

--- a/aurora-postgresql-plugin/widgets/AuroraPostgres-batchsource.json
+++ b/aurora-postgresql-plugin/widgets/AuroraPostgres-batchsource.json
@@ -85,7 +85,10 @@
         {
           "widget-type": "textbox",
           "label": "Number of Splits to Generate",
-          "name": "numSplits"
+          "name": "numSplits",
+          "widget-attributes": {
+            "default": "1"
+          }
         }
       ]
     },

--- a/db2-plugin/widgets/Db2-batchsource.json
+++ b/db2-plugin/widgets/Db2-batchsource.json
@@ -88,7 +88,10 @@
         {
           "widget-type": "textbox",
           "label": "Number of Splits to Generate",
-          "name": "numSplits"
+          "name": "numSplits",
+          "widget-attributes": {
+            "default": "1"
+          }
         }
       ]
     },

--- a/generic-database-plugin/widgets/Database-batchsource.json
+++ b/generic-database-plugin/widgets/Database-batchsource.json
@@ -69,7 +69,10 @@
         {
           "widget-type": "textbox",
           "label": "Number of Splits to Generate",
-          "name": "numSplits"
+          "name": "numSplits",
+          "widget-attributes": {
+            "default": "1"
+          }
         }
       ]
     },

--- a/mssql-plugin/widgets/SqlServer-batchsource.json
+++ b/mssql-plugin/widgets/SqlServer-batchsource.json
@@ -88,7 +88,10 @@
         {
           "widget-type": "textbox",
           "label": "Number of Splits to Generate",
-          "name": "numSplits"
+          "name": "numSplits",
+          "widget-attributes": {
+            "default": "1"
+          }
         }
       ]
     },

--- a/mysql-plugin/widgets/Mysql-batchsource.json
+++ b/mysql-plugin/widgets/Mysql-batchsource.json
@@ -88,7 +88,10 @@
         {
           "widget-type": "textbox",
           "label": "Number of Splits to Generate",
-          "name": "numSplits"
+          "name": "numSplits",
+          "widget-attributes": {
+            "default": "1"
+          }
         }
       ]
     },

--- a/netezza-plugin/widgets/Netezza-batchsource.json
+++ b/netezza-plugin/widgets/Netezza-batchsource.json
@@ -88,7 +88,10 @@
         {
           "widget-type": "textbox",
           "label": "Number of Splits to Generate",
-          "name": "numSplits"
+          "name": "numSplits",
+          "widget-attributes": {
+            "default": "1"
+          }
         }
       ]
     },

--- a/oracle-plugin/widgets/Oracle-batchsource.json
+++ b/oracle-plugin/widgets/Oracle-batchsource.json
@@ -107,7 +107,10 @@
         {
           "widget-type": "textbox",
           "label": "Number of Splits to Generate",
-          "name": "numSplits"
+          "name": "numSplits",
+          "widget-attributes": {
+            "default": "1"
+          }
         }
       ]
     },

--- a/postgresql-plugin/widgets/Postgres-batchsource.json
+++ b/postgresql-plugin/widgets/Postgres-batchsource.json
@@ -88,7 +88,10 @@
         {
           "widget-type": "textbox",
           "label": "Number of Splits to Generate",
-          "name": "numSplits"
+          "name": "numSplits",
+          "widget-attributes": {
+            "default": "1"
+          }
         }
       ]
     },


### PR DESCRIPTION
Set the default number of splits for every source plugin to 1.
Without this, the get schema button will fail with a very
confusing message about the query needing a $CONDITIONS clause.