### PR TITLE
CDAP-15479 - Add tests for LOB types for DB Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ mvn clean test \
 -Dpostgresql.host=localhost -Dpostgresql.port=54032 -Dpostgresql.database=test -Dpostgresql.username=postgres \ 
 -Dpostgresql.password=cdap \
 -Doracle.host=localhost -Doracle.port=1521 -Doracle.username=ora -Doracle.password=cdap -Doracle.database=EE \
+-Doracle.connectionType=SID \
 -Ddb2.host=localhost -Ddb2.port=50000 -Ddb2.database=SAMPLE -Ddb2.username=DB2INST -Db2.password=DB2INST1-pwd \
 -Dnetezza.host=localhost -Dnetezza.port=5480 -Dnetezza.database=test -Dnetezza.username=admin \
 -Dnetezza.password=password \

--- a/aurora-mysql-plugin/src/test/java/io/cdap/plugin/aurora/mysql/AuroraMysqlSinkTestRun.java
+++ b/aurora-mysql-plugin/src/test/java/io/cdap/plugin/aurora/mysql/AuroraMysqlSinkTestRun.java
@@ -19,6 +19,7 @@ package io.cdap.plugin.aurora.mysql;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.table.Table;
@@ -80,6 +81,10 @@ public class AuroraMysqlSinkTestRun extends AuroraMysqlPluginTestBase {
       Assert.assertEquals(new Timestamp(CURRENT_TS),
                           resultSet.getTimestamp("TIMESTAMP_COL"));
       Assert.assertTrue(resultSet.next());
+      Assert.assertEquals("user2", Bytes.toString(resultSet.getBytes("BLOB_COL"), 0, 5));
+      Assert.assertEquals("user2", Bytes.toString(resultSet.getBytes("TINYBLOB_COL"), 0, 5));
+      Assert.assertEquals("user2", Bytes.toString(resultSet.getBytes("MEDIUMBLOB_COL"), 0, 5));
+      Assert.assertEquals("user2", Bytes.toString(resultSet.getBytes("LONGBLOB_COL"), 0, 5));
       users.add(resultSet.getString("NAME"));
       Assert.assertEquals(ImmutableSet.of("user1", "user2"), users);
     }
@@ -106,7 +111,14 @@ public class AuroraMysqlSinkTestRun extends AuroraMysqlPluginTestBase {
       Schema.Field.of("TIME_COL", Schema.of(Schema.LogicalType.TIME_MICROS)),
       Schema.Field.of("TIMESTAMP_COL", Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)),
       Schema.Field.of("BINARY_COL", Schema.of(Schema.Type.BYTES)),
-      Schema.Field.of("BLOB_COL", Schema.of(Schema.Type.BYTES))
+      Schema.Field.of("BLOB_COL", Schema.of(Schema.Type.BYTES)),
+      Schema.Field.of("TINYBLOB_COL", Schema.of(Schema.Type.BYTES)),
+      Schema.Field.of("MEDIUMBLOB_COL", Schema.of(Schema.Type.BYTES)),
+      Schema.Field.of("LONGBLOB_COL", Schema.of(Schema.Type.BYTES)),
+      Schema.Field.of("TEXT_COL", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("TINYTEXT_COL", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("MEDIUMTEXT_COL", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("LONGTEXT_COL", Schema.of(Schema.Type.STRING))
     );
     List<StructuredRecord> inputRecords = new ArrayList<>();
     LocalDateTime localDateTime = new Timestamp(CURRENT_TS).toLocalDateTime();
@@ -130,6 +142,13 @@ public class AuroraMysqlSinkTestRun extends AuroraMysqlPluginTestBase {
                          .setTimestamp("TIMESTAMP_COL", localDateTime.atZone(ZoneId.ofOffset("UTC", ZoneOffset.UTC)))
                          .set("BINARY_COL", name.getBytes(Charsets.UTF_8))
                          .set("BLOB_COL", name.getBytes(Charsets.UTF_8))
+                         .set("TINYBLOB_COL", name.getBytes(Charsets.UTF_8))
+                         .set("MEDIUMBLOB_COL", name.getBytes(Charsets.UTF_8))
+                         .set("LONGBLOB_COL", name.getBytes(Charsets.UTF_8))
+                         .set("TEXT_COL", name)
+                         .set("TINYTEXT_COL", name)
+                         .set("MEDIUMTEXT_COL", name)
+                         .set("LONGTEXT_COL", name)
                          .build());
     }
     MockSource.writeInput(inputManager, inputRecords);

--- a/aurora-mysql-plugin/src/test/java/io/cdap/plugin/aurora/mysql/AuroraMysqlSourceTestRun.java
+++ b/aurora-mysql-plugin/src/test/java/io/cdap/plugin/aurora/mysql/AuroraMysqlSourceTestRun.java
@@ -89,8 +89,8 @@ public class AuroraMysqlSourceTestRun extends AuroraMysqlPluginTestBase {
   public void testDBSource() throws Exception {
     String importQuery = "SELECT ID, NAME, SCORE, GRADUATED, TINY, MEDIUMINT_COL, SMALL, BIG, FLOAT_COL, " +
       "REAL_COL, NUMERIC_COL, CHAR_COL, DECIMAL_COL, BIT_COL, BINARY_COL, DATE_COL, TIME_COL, TIMESTAMP_COL, " +
-      "VARBINARY_COL, BLOB_COL, MEDIUMBLOB_COL, TINYBLOB_COL, YEAR_COL, LONGBLOB_COL, TEXT_COL FROM my_table " +
-      "WHERE ID < 3 AND $CONDITIONS";
+      "VARBINARY_COL, BLOB_COL, MEDIUMBLOB_COL, TINYBLOB_COL, YEAR_COL, LONGBLOB_COL, TEXT_COL, TINYTEXT_COL, " +
+      "MEDIUMTEXT_COL, LONGTEXT_COL FROM my_table WHERE ID < 3 AND $CONDITIONS";
     String boundingQuery = "SELECT MIN(ID),MAX(ID) from my_table";
     String splitBy = "ID";
     ETLPlugin sourceConfig = new ETLPlugin(
@@ -127,6 +127,12 @@ public class AuroraMysqlSourceTestRun extends AuroraMysqlPluginTestBase {
     Assert.assertEquals("user2", row2.get("NAME"));
     Assert.assertEquals("user1", row1.get("TEXT_COL"));
     Assert.assertEquals("user2", row2.get("TEXT_COL"));
+    Assert.assertEquals("user1", row1.get("TINYTEXT_COL"));
+    Assert.assertEquals("user2", row2.get("TINYTEXT_COL"));
+    Assert.assertEquals("user1", row1.get("MEDIUMTEXT_COL"));
+    Assert.assertEquals("user2", row2.get("MEDIUMTEXT_COL"));
+    Assert.assertEquals("user1", row1.get("LONGTEXT_COL"));
+    Assert.assertEquals("user2", row2.get("LONGTEXT_COL"));
     Assert.assertEquals("char1", ((String) row1.get("CHAR_COL")).trim());
     Assert.assertEquals("char2", ((String) row2.get("CHAR_COL")).trim());
     Assert.assertEquals(124.45, row1.get("SCORE"), 0.000001);

--- a/aurora-postgresql-plugin/src/test/java/io/cdap/plugin/auroradb/postgres/AuroraPostgresSinkTestRun.java
+++ b/aurora-postgresql-plugin/src/test/java/io/cdap/plugin/auroradb/postgres/AuroraPostgresSinkTestRun.java
@@ -103,7 +103,8 @@ public class AuroraPostgresSinkTestRun extends AuroraPostgresPluginTestBase {
       Schema.Field.of("TIME_COL", Schema.of(Schema.LogicalType.TIME_MICROS)),
       Schema.Field.of("TIMESTAMP_COL", Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)),
       Schema.Field.of("CHAR_COL", Schema.of(Schema.Type.STRING)),
-      Schema.Field.of("BYTEA_COL", Schema.of(Schema.Type.BYTES))
+      Schema.Field.of("BYTEA_COL", Schema.of(Schema.Type.BYTES)),
+      Schema.Field.of("TEXT_COL", Schema.of(Schema.Type.STRING))
     );
     List<StructuredRecord> inputRecords = new ArrayList<>();
     LocalDateTime localDateTime = new Timestamp(CURRENT_TS).toLocalDateTime();
@@ -124,6 +125,7 @@ public class AuroraPostgresSinkTestRun extends AuroraPostgresPluginTestBase {
                          .setTimestamp("TIMESTAMP_COL", localDateTime.atZone(ZoneId.ofOffset("UTC", ZoneOffset.UTC)))
                          .set("BYTEA_COL", name.getBytes())
                          .set("CHAR_COL", name)
+                         .set("TEXT_COL", name)
                          .build());
     }
     MockSource.writeInput(inputManager, inputRecords);

--- a/aurora-postgresql-plugin/src/test/java/io/cdap/plugin/auroradb/postgres/AuroraPostgresSourceTestRun.java
+++ b/aurora-postgresql-plugin/src/test/java/io/cdap/plugin/auroradb/postgres/AuroraPostgresSourceTestRun.java
@@ -88,7 +88,7 @@ public class AuroraPostgresSourceTestRun extends AuroraPostgresPluginTestBase {
   public void testDBSource() throws Exception {
     String importQuery = "SELECT \"ID\", \"NAME\", \"SCORE\", \"GRADUATED\", \"SMALLINT_COL\", \"BIG\", " +
       "\"NUMERIC_COL\", \"CHAR_COL\", \"DECIMAL_COL\", \"BYTEA_COL\", \"DATE_COL\", \"TIME_COL\", \"TIMESTAMP_COL\", " +
-      "\"TEXT_COL\" FROM my_table " +
+      "\"TEXT_COL\", \"DOUBLE_PREC_COL\" FROM my_table " +
       "WHERE \"ID\" < 3 AND $CONDITIONS";
     String boundingQuery = "SELECT MIN(\"ID\"),MAX(\"ID\") from my_table";
     String splitBy = "ID";
@@ -142,6 +142,9 @@ public class AuroraPostgresSourceTestRun extends AuroraPostgresPluginTestBase {
     Assert.assertEquals(124.45, (double) row1.get("NUMERIC_COL"), 0.000001);
     Assert.assertEquals(125.45, (double) row2.get("NUMERIC_COL"), 0.000001);
     Assert.assertEquals(124.45, (double) row1.get("DECIMAL_COL"), 0.000001);
+
+    Assert.assertEquals(124.45, (double) row1.get("DOUBLE_PREC_COL"), 0.000001);
+    Assert.assertEquals(125.45, (double) row2.get("DOUBLE_PREC_COL"), 0.000001);
     // Verify time columns
     java.util.Date date = new java.util.Date(CURRENT_TS);
     SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");

--- a/db2-plugin/src/test/java/io/cdap/plugin/db2/Db2SinkTestRun.java
+++ b/db2-plugin/src/test/java/io/cdap/plugin/db2/Db2SinkTestRun.java
@@ -18,6 +18,7 @@ package io.cdap.plugin.db2;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.table.Table;
@@ -78,6 +79,8 @@ public class Db2SinkTestRun extends Db2PluginTestBase {
       Assert.assertEquals(new Time(CURRENT_TS).toString(), resultSet.getTime("TIME_COL").toString());
       Assert.assertEquals(new Timestamp(CURRENT_TS), resultSet.getTimestamp("TIMESTAMP_COL"));
       Assert.assertTrue(resultSet.next());
+      Assert.assertEquals("user2", Bytes.toString(resultSet.getBytes("BLOB_COL"), 0, 5));
+      Assert.assertEquals("user2", resultSet.getString("CLOB_COL"));
       users.add(resultSet.getString("VARCHAR_COL"));
       Assert.assertEquals(ImmutableSet.of("user1", "user2"), users);
 

--- a/generic-database-plugin/src/test/java/io/cdap/plugin/db/batch/sink/DBSinkTestRun.java
+++ b/generic-database-plugin/src/test/java/io/cdap/plugin/db/batch/sink/DBSinkTestRun.java
@@ -20,6 +20,7 @@ import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.cdap.GenericDatabasePluginTestBase;
+import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.table.Table;
@@ -109,6 +110,8 @@ public class DBSinkTestRun extends GenericDatabasePluginTestBase {
         Assert.assertEquals(new Timestamp(CURRENT_TS).toString(),
                             resultSet.getTimestamp("TIMESTAMP_COL").toString());
         Assert.assertTrue(resultSet.next());
+        Assert.assertEquals("user2", resultSet.getString("CLOB_COL"));
+        Assert.assertEquals("user2", Bytes.toString(resultSet.getBytes("BLOB_COL"), 0, 5));
         users.add(resultSet.getString("NAME"));
         Assert.assertFalse(resultSet.next());
         Assert.assertEquals(ImmutableSet.of("user1", "user2"), users);

--- a/mssql-plugin/src/test/java/io/cdap/plugin/mssql/SqlServerSinkTestRun.java
+++ b/mssql-plugin/src/test/java/io/cdap/plugin/mssql/SqlServerSinkTestRun.java
@@ -19,6 +19,7 @@ package io.cdap.plugin.mssql;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.table.Table;
@@ -80,6 +81,7 @@ public class SqlServerSinkTestRun extends SqlServerPluginTestBase {
       Assert.assertEquals(new Timestamp(CURRENT_TS),
                           resultSet.getTimestamp("DATETIME_COL"));
       Assert.assertTrue(resultSet.next());
+      Assert.assertEquals("user2", Bytes.toString(resultSet.getBytes("BINARY_COL"), 0, 5));
       users.add(resultSet.getString("NAME"));
       Assert.assertEquals(ImmutableSet.of("user1", "user2"), users);
 

--- a/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlSinkTestRun.java
+++ b/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlSinkTestRun.java
@@ -19,6 +19,7 @@ package io.cdap.plugin.mysql;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.table.Table;
@@ -84,6 +85,10 @@ public class MysqlSinkTestRun extends MysqlPluginTestBase {
       Assert.assertEquals(new Timestamp(CURRENT_TS),
                           resultSet.getTimestamp("TIMESTAMP_COL"));
       Assert.assertTrue(resultSet.next());
+      Assert.assertEquals("user2", Bytes.toString(resultSet.getBytes("BLOB_COL"), 0, 5));
+      Assert.assertEquals("user2", Bytes.toString(resultSet.getBytes("TINYBLOB_COL"), 0, 5));
+      Assert.assertEquals("user2", Bytes.toString(resultSet.getBytes("MEDIUMBLOB_COL"), 0, 5));
+      Assert.assertEquals("user2", Bytes.toString(resultSet.getBytes("LONGBLOB_COL"), 0, 5));
       users.add(resultSet.getString("NAME"));
       Assert.assertEquals(ImmutableSet.of("user1", "user2"), users);
 
@@ -111,7 +116,14 @@ public class MysqlSinkTestRun extends MysqlPluginTestBase {
       Schema.Field.of("TIME_COL", Schema.of(Schema.LogicalType.TIME_MICROS)),
       Schema.Field.of("TIMESTAMP_COL", Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)),
       Schema.Field.of("BINARY_COL", Schema.of(Schema.Type.BYTES)),
-      Schema.Field.of("BLOB_COL", Schema.of(Schema.Type.BYTES))
+      Schema.Field.of("BLOB_COL", Schema.of(Schema.Type.BYTES)),
+      Schema.Field.of("TINYBLOB_COL", Schema.of(Schema.Type.BYTES)),
+      Schema.Field.of("MEDIUMBLOB_COL", Schema.of(Schema.Type.BYTES)),
+      Schema.Field.of("LONGBLOB_COL", Schema.of(Schema.Type.BYTES)),
+      Schema.Field.of("TEXT_COL", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("TINYTEXT_COL", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("MEDIUMTEXT_COL", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("LONGTEXT_COL", Schema.of(Schema.Type.STRING))
     );
     List<StructuredRecord> inputRecords = new ArrayList<>();
     LocalDateTime localDateTime = new Timestamp(CURRENT_TS).toLocalDateTime();
@@ -135,6 +147,13 @@ public class MysqlSinkTestRun extends MysqlPluginTestBase {
                          .setTimestamp("TIMESTAMP_COL", localDateTime.atZone(ZoneId.ofOffset("UTC", ZoneOffset.UTC)))
                          .set("BINARY_COL", name.getBytes(Charsets.UTF_8))
                          .set("BLOB_COL", name.getBytes(Charsets.UTF_8))
+                         .set("TINYBLOB_COL", name.getBytes(Charsets.UTF_8))
+                         .set("MEDIUMBLOB_COL", name.getBytes(Charsets.UTF_8))
+                         .set("LONGBLOB_COL", name.getBytes(Charsets.UTF_8))
+                         .set("TEXT_COL", name)
+                         .set("TINYTEXT_COL", name)
+                         .set("MEDIUMTEXT_COL", name)
+                         .set("LONGTEXT_COL", name)
                          .build());
     }
     MockSource.writeInput(inputManager, inputRecords);

--- a/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlSourceTestRun.java
+++ b/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlSourceTestRun.java
@@ -90,8 +90,8 @@ public class MysqlSourceTestRun extends MysqlPluginTestBase {
   public void testDBSource() throws Exception {
     String importQuery = "SELECT ID, NAME, SCORE, GRADUATED, TINY, MEDIUMINT_COL, SMALL, BIG, FLOAT_COL, " +
       "REAL_COL, NUMERIC_COL, CHAR_COL, DECIMAL_COL, BIT_COL, BINARY_COL, DATE_COL, TIME_COL, TIMESTAMP_COL, " +
-      "VARBINARY_COL, BLOB_COL, MEDIUMBLOB_COL, TINYBLOB_COL, YEAR_COL, LONGBLOB_COL, TEXT_COL FROM my_table " +
-      "WHERE ID < 3 AND $CONDITIONS";
+      "VARBINARY_COL, BLOB_COL, MEDIUMBLOB_COL, TINYBLOB_COL, YEAR_COL, LONGBLOB_COL, TEXT_COL, TINYTEXT_COL, " +
+      "MEDIUMTEXT_COL, LONGTEXT_COL FROM my_table WHERE ID < 3 AND $CONDITIONS";
     String boundingQuery = "SELECT MIN(ID),MAX(ID) from my_table";
     String splitBy = "ID";
     ETLPlugin sourceConfig = new ETLPlugin(
@@ -130,6 +130,12 @@ public class MysqlSourceTestRun extends MysqlPluginTestBase {
     Assert.assertEquals("user2", row2.get("NAME"));
     Assert.assertEquals("user1", row1.get("TEXT_COL"));
     Assert.assertEquals("user2", row2.get("TEXT_COL"));
+    Assert.assertEquals("user1", row1.get("TINYTEXT_COL"));
+    Assert.assertEquals("user2", row2.get("TINYTEXT_COL"));
+    Assert.assertEquals("user1", row1.get("MEDIUMTEXT_COL"));
+    Assert.assertEquals("user2", row2.get("MEDIUMTEXT_COL"));
+    Assert.assertEquals("user1", row1.get("LONGTEXT_COL"));
+    Assert.assertEquals("user2", row2.get("LONGTEXT_COL"));
     Assert.assertEquals("char1", ((String) row1.get("CHAR_COL")).trim());
     Assert.assertEquals("char2", ((String) row2.get("CHAR_COL")).trim());
     Assert.assertEquals(124.45, row1.get("SCORE"), 0.000001);

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConstants.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConstants.java
@@ -30,4 +30,5 @@ public final class OracleConstants {
   public static final String DEFAULT_BATCH_VALUE = "defaultBatchValue";
   public static final String DEFAULT_ROW_PREFETCH = "defaultRowPrefetch";
   public static final String SERVICE_CONNECTION_TYPE = "service";
+  public static final String CONNECTION_TYPE = "connectionType";
 }

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleDBRecord.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleDBRecord.java
@@ -23,6 +23,7 @@ import io.cdap.plugin.db.SchemaReader;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Types;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -52,7 +53,7 @@ public class OracleDBRecord extends DBRecord {
   @Override
   protected void handleField(ResultSet resultSet, StructuredRecord.Builder recordBuilder, Schema.Field field,
                              int columnIndex, int sqlType, int sqlPrecision, int sqlScale) throws SQLException {
-    if (OracleSchemaReader.ORACLE_TYPES.contains(sqlType)) {
+    if (OracleSchemaReader.ORACLE_TYPES.contains(sqlType) || sqlType == Types.NCLOB) {
       handleOracleSpecificType(resultSet, recordBuilder, field, columnIndex, sqlType);
     } else {
       setField(resultSet, recordBuilder, field, columnIndex, sqlType, sqlPrecision, sqlScale);
@@ -66,6 +67,7 @@ public class OracleDBRecord extends DBRecord {
     switch (sqlType) {
       case OracleSchemaReader.INTERVAL_YM:
       case OracleSchemaReader.INTERVAL_DS:
+      case Types.NCLOB:
         recordBuilder.set(field.getName(), resultSet.getString(columnIndex));
         break;
       case OracleSchemaReader.TIMESTAMP_LTZ:

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSink.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSink.java
@@ -58,7 +58,7 @@ public class OracleSink extends AbstractDBSink {
     @Nullable
     public Integer defaultBatchValue;
 
-    @Name("connectionType")
+    @Name(OracleConstants.CONNECTION_TYPE)
     @Description("Whether to use an SID or Service Name when connecting to the database.")
     public String connectionType;
 

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSource.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSource.java
@@ -79,7 +79,7 @@ public class OracleSource extends AbstractDBSource {
     @Nullable
     public Integer defaultRowPrefetch;
 
-    @Name("connectionType")
+    @Name(OracleConstants.CONNECTION_TYPE)
     @Description("Whether to use an SID or Service Name when connecting to the database.")
     public String connectionType;
 

--- a/oracle-plugin/src/test/java/io/cdap/plugin/oracle/OracleSinkTestRun.java
+++ b/oracle-plugin/src/test/java/io/cdap/plugin/oracle/OracleSinkTestRun.java
@@ -16,9 +16,9 @@
 
 package io.cdap.plugin.oracle;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.table.Table;
@@ -35,13 +35,9 @@ import java.sql.Connection;
 import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.Statement;
-import java.sql.Time;
 import java.sql.Timestamp;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -80,6 +76,9 @@ public class OracleSinkTestRun extends OraclePluginTestBase {
       users.add(resultSet.getString("VARCHAR_COL"));
       Assert.assertEquals(new Date(CURRENT_TS).toString(), resultSet.getDate("DATE_COL").toString());
       Assert.assertTrue(resultSet.next());
+      Assert.assertEquals("user2", resultSet.getString("CLOB_COL"));
+      Assert.assertEquals("user2", resultSet.getString("NCLOB_COL"));
+      Assert.assertEquals("user2", Bytes.toString(resultSet.getBytes("BLOB_COL"), 0, 5));
       users.add(resultSet.getString("VARCHAR_COL"));
       Assert.assertEquals(ImmutableSet.of("user1", "user2"), users);
 
@@ -109,6 +108,7 @@ public class OracleSinkTestRun extends OraclePluginTestBase {
       Schema.Field.of("INTERVAL_DAY_TO_SECOND_COL", Schema.of(Schema.Type.STRING)),
       Schema.Field.of("RAW_COL", Schema.of(Schema.Type.BYTES)),
       Schema.Field.of("CLOB_COL", Schema.of(Schema.Type.BYTES)),
+      Schema.Field.of("NCLOB_COL", Schema.of(Schema.Type.BYTES)),
       Schema.Field.of("BLOB_COL", Schema.of(Schema.Type.BYTES))
     );
     List<StructuredRecord> inputRecords = new ArrayList<>();
@@ -134,6 +134,7 @@ public class OracleSinkTestRun extends OraclePluginTestBase {
                          .set("INTERVAL_DAY_TO_SECOND_COL", "23 3:02:10")
                          .set("RAW_COL", name.getBytes())
                          .set("CLOB_COL", name.getBytes())
+                         .set("NCLOB_COL", name.getBytes())
                          .set("BLOB_COL", name.getBytes())
                          .build());
     }

--- a/oracle-plugin/src/test/java/io/cdap/plugin/oracle/OracleSourceTestRun.java
+++ b/oracle-plugin/src/test/java/io/cdap/plugin/oracle/OracleSourceTestRun.java
@@ -84,8 +84,8 @@ public class OracleSourceTestRun extends OraclePluginTestBase {
   public void testDBSource() throws Exception {
     String importQuery = "SELECT CHAR_COL, VARCHAR_COL, INT_COL, INTEGER_COL, DEC_COL, DECIMAL_COL, NUMBER_COL," +
       " NUMERIC_COL, SMALLINT_COL, REAL_COL, DATE_COL, TIMESTAMP_COL, INTERVAL_YEAR_TO_MONTH_COL, " +
-      "INTERVAL_DAY_TO_SECOND_COL, RAW_COL, TIMESTAMPTZ_COL, TIMESTAMPLTZ_COL, CLOB_COL, BLOB_COL FROM my_table " +
-      " WHERE SMALLINT_COL < 3 AND $CONDITIONS";
+      "INTERVAL_DAY_TO_SECOND_COL, RAW_COL, TIMESTAMPTZ_COL, TIMESTAMPLTZ_COL, CLOB_COL, NCLOB_COL, " +
+      "BLOB_COL FROM my_table WHERE SMALLINT_COL < 3 AND $CONDITIONS";
     String boundingQuery = "SELECT MIN(SMALLINT_COL),MAX(SMALLINT_COL) from my_table";
     String splitBy = "SMALLINT_COL";
     ETLPlugin sourceConfig = new ETLPlugin(
@@ -154,6 +154,8 @@ public class OracleSourceTestRun extends OraclePluginTestBase {
     Assert.assertEquals("user2", Bytes.toString((ByteBuffer) row2.get("RAW_COL")));
     Assert.assertEquals("user1", row1.get("CLOB_COL"));
     Assert.assertEquals("user2", row2.get("CLOB_COL"));
+    Assert.assertEquals("user1", row1.get("NCLOB_COL"));
+    Assert.assertEquals("user2", row2.get("NCLOB_COL"));
     Assert.assertEquals("user1", Bytes.toString((ByteBuffer) row1.get("BLOB_COL")));
     Assert.assertEquals("user2", Bytes.toString((ByteBuffer) row2.get("BLOB_COL")));
   }
@@ -211,6 +213,7 @@ public class OracleSourceTestRun extends OraclePluginTestBase {
     Map<String, String> baseSourceProps = ImmutableMap.<String, String>builder()
       .put(OracleConstants.DEFAULT_ROW_PREFETCH, "40")
       .put(OracleConstants.DEFAULT_BATCH_VALUE, "40")
+      .put(OracleConstants.CONNECTION_TYPE, BASE_PROPS.get(OracleConstants.CONNECTION_TYPE))
       .put(ConnectionConfig.HOST, BASE_PROPS.get(ConnectionConfig.HOST))
       .put(ConnectionConfig.PORT, BASE_PROPS.get(ConnectionConfig.PORT))
       .put(ConnectionConfig.DATABASE, BASE_PROPS.get(ConnectionConfig.DATABASE))
@@ -305,6 +308,7 @@ public class OracleSourceTestRun extends OraclePluginTestBase {
       ImmutableMap.<String, String>builder()
         .put(OracleConstants.DEFAULT_ROW_PREFETCH, "40")
         .put(OracleConstants.DEFAULT_BATCH_VALUE, "40")
+        .put(OracleConstants.CONNECTION_TYPE, BASE_PROPS.get(OracleConstants.CONNECTION_TYPE))
         .put(ConnectionConfig.HOST, BASE_PROPS.get(ConnectionConfig.HOST))
         .put(ConnectionConfig.PORT, BASE_PROPS.get(ConnectionConfig.PORT))
         .put(ConnectionConfig.DATABASE, "dumDB")

--- a/postgresql-plugin/src/test/java/io/cdap/plugin/postgres/PostgresSinkTestRun.java
+++ b/postgresql-plugin/src/test/java/io/cdap/plugin/postgres/PostgresSinkTestRun.java
@@ -105,7 +105,8 @@ public class PostgresSinkTestRun extends PostgresPluginTestBase {
       Schema.Field.of("TIME_COL", Schema.of(Schema.LogicalType.TIME_MICROS)),
       Schema.Field.of("TIMESTAMP_COL", Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)),
       Schema.Field.of("CHAR_COL", Schema.of(Schema.Type.STRING)),
-      Schema.Field.of("BYTEA_COL", Schema.of(Schema.Type.BYTES))
+      Schema.Field.of("BYTEA_COL", Schema.of(Schema.Type.BYTES)),
+      Schema.Field.of("TEXT_COL", Schema.of(Schema.Type.STRING))
     );
     List<StructuredRecord> inputRecords = new ArrayList<>();
     LocalDateTime localDateTime = new Timestamp(CURRENT_TS).toLocalDateTime();
@@ -126,6 +127,7 @@ public class PostgresSinkTestRun extends PostgresPluginTestBase {
                          .setTimestamp("TIMESTAMP_COL", localDateTime.atZone(ZoneId.ofOffset("UTC", ZoneOffset.UTC)))
                          .set("BYTEA_COL", name.getBytes())
                          .set("CHAR_COL", name)
+                         .set("TEXT_COL", name)
                          .build());
     }
     MockSource.writeInput(inputManager, inputRecords);

--- a/postgresql-plugin/src/test/java/io/cdap/plugin/postgres/PostgresSourceTestRun.java
+++ b/postgresql-plugin/src/test/java/io/cdap/plugin/postgres/PostgresSourceTestRun.java
@@ -88,7 +88,7 @@ public class PostgresSourceTestRun extends PostgresPluginTestBase {
   public void testDBSource() throws Exception {
     String importQuery = "SELECT \"ID\", \"NAME\", \"SCORE\", \"GRADUATED\", \"SMALLINT_COL\", \"BIG\", " +
       "\"NUMERIC_COL\", \"CHAR_COL\", \"DECIMAL_COL\", \"BYTEA_COL\", \"DATE_COL\", \"TIME_COL\", \"TIMESTAMP_COL\", " +
-      "\"TEXT_COL\" FROM my_table " +
+      "\"TEXT_COL\", \"DOUBLE_PREC_COL\" FROM my_table " +
       "WHERE \"ID\" < 3 AND $CONDITIONS";
     String boundingQuery = "SELECT MIN(\"ID\"),MAX(\"ID\") from my_table";
     String splitBy = "ID";
@@ -142,6 +142,9 @@ public class PostgresSourceTestRun extends PostgresPluginTestBase {
     Assert.assertEquals(124.45, (double) row1.get("NUMERIC_COL"), 0.000001);
     Assert.assertEquals(125.45, (double) row2.get("NUMERIC_COL"), 0.000001);
     Assert.assertEquals(124.45, (double) row1.get("DECIMAL_COL"), 0.000001);
+
+    Assert.assertEquals(124.45, (double) row1.get("DOUBLE_PREC_COL"), 0.000001);
+    Assert.assertEquals(125.45, (double) row2.get("DOUBLE_PREC_COL"), 0.000001);
     // Verify time columns
     java.util.Date date = new java.util.Date(CURRENT_TS);
     SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15479

In scope of this PR:

- fixed pipeline initialization in tests for Oracle DB
- fixed NCLOB support in Oracle DB
- added LOB tests to MySQL, MSSQL Postgres, DB2, Oracle, Aurora