### PR TITLE
CDAP-15549 MS SQL db plugin enhancements: all data types support and proper test coverage

### DIFF
--- a/database-commons/src/main/java/io/cdap/plugin/db/CommonSchemaReader.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/CommonSchemaReader.java
@@ -37,6 +37,9 @@ public class CommonSchemaReader implements SchemaReader {
     ResultSetMetaData metadata = resultSet.getMetaData();
     // ResultSetMetadata columns are numbered starting with 1
     for (int i = 1; i <= metadata.getColumnCount(); i++) {
+      if (shouldIgnoreColumn(metadata, i)) {
+        continue;
+      }
       String columnName = metadata.getColumnName(i);
       Schema columnSchema = getSchema(metadata, i);
       if (ResultSetMetaData.columnNullable == metadata.isNullable(i)) {
@@ -119,5 +122,10 @@ public class CommonSchemaReader implements SchemaReader {
     }
 
     return Schema.of(type);
+  }
+
+  @Override
+  public boolean shouldIgnoreColumn(ResultSetMetaData metadata, int index) throws SQLException {
+    return false;
   }
 }

--- a/database-commons/src/main/java/io/cdap/plugin/db/DBRecord.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/DBRecord.java
@@ -264,7 +264,7 @@ public class DBRecord implements Writable, DBWritable, Configurable {
     }
   }
 
-  private void writeToDB(PreparedStatement stmt, Schema.Field field, int fieldIndex) throws SQLException {
+  protected void writeToDB(PreparedStatement stmt, Schema.Field field, int fieldIndex) throws SQLException {
     String fieldName = field.getName();
     Schema fieldSchema = getNonNullableSchema(field);
     Schema.Type fieldType = fieldSchema.getType();
@@ -330,7 +330,8 @@ public class DBRecord implements Writable, DBWritable, Configurable {
     }
   }
 
-  private void writeBytes(PreparedStatement stmt, int fieldIndex, int sqlIndex, Object fieldValue) throws SQLException {
+  protected void writeBytes(PreparedStatement stmt, int fieldIndex, int sqlIndex, Object fieldValue)
+    throws SQLException {
     byte[] byteValue = fieldValue instanceof ByteBuffer ? Bytes.toBytes((ByteBuffer) fieldValue) : (byte[]) fieldValue;
     int parameterType = columnTypes[fieldIndex];
     if (Types.BLOB == parameterType) {

--- a/database-commons/src/main/java/io/cdap/plugin/db/SchemaReader.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/SchemaReader.java
@@ -22,7 +22,6 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.List;
-import javax.annotation.Nullable;
 
 /**
  * Main Interface to read db specific types.
@@ -49,4 +48,20 @@ public interface SchemaReader {
    * @throws SQLException
    */
   Schema getSchema(ResultSetMetaData metadata, int index) throws SQLException;
+
+  /**
+   * Given a sql metadata indicates if sql column must be ignored and not included in the output schema. Thus we can
+   * support different data types for Sink and Source plugins.
+   * <p/>
+   * For example, in MS SQL 'TIMESTAMP' is the synonym for the 'ROWVERSION' data type, values of which are
+   * automatically generated and can not be inserted or updated. Therefore 'TIMESTAMP' can not be supported by Sink
+   * plugin. 'TIMESTAMP' reported as non-nullable column by JDBC connector, so inferred schema will be also
+   * non-nullable for this field, requiring to set a value. By ignoring this column we will avoid schema validation
+   * failure.
+   * @param metadata resultSet metadata
+   * @param index sql column index
+   * @return 'true' if sql column must not included in the output schema, 'false' otherwise
+   * @throws SQLException
+   */
+  boolean shouldIgnoreColumn(ResultSetMetaData metadata, int index) throws SQLException;
 }

--- a/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
+++ b/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
@@ -34,7 +34,6 @@ import java.lang.management.ManagementFactory;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
-import java.math.MathContext;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Driver;
@@ -258,8 +257,7 @@ public final class DBUtils {
           return ((Number) original).intValue();
         case Types.NUMERIC:
         case Types.DECIMAL:
-          BigDecimal decimal = (BigDecimal) original;
-          return new BigDecimal(decimal.unscaledValue(), scale, new MathContext(precision));
+          return (BigDecimal) original;
         case Types.DATE:
           return resultSet.getDate(columnIndex);
         case Types.TIME:

--- a/database-commons/src/test/java/io/cdap/plugin/db/CustomAssertions.java
+++ b/database-commons/src/test/java/io/cdap/plugin/db/CustomAssertions.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.db;
+
+import org.junit.Assert;
+
+/**
+ * Test util methods for custom assertions.
+ */
+public final class CustomAssertions {
+
+  /**
+   * The maximum delta between expected and actual floating point number for which both numbers are still considered
+   * equal.
+   */
+  public static final double DELTA = 0.000001;
+
+  private CustomAssertions() {
+    throw new AssertionError("Should not instantiate static utility class.");
+  }
+
+  /**
+   * Reuses {@link Assert#assertEquals(Object, Object)}. Added to prevent 'Ambiguous method call' issue.
+   * Asserts that two objects are equal. If they are not, an {@link AssertionError} without a message is thrown.
+   * If expected and actual are null, they are considered equal.
+   *
+   * @param expected expected value
+   * @param actual   the value to check against expected
+   */
+  public static void assertObjectEquals(Object expected, Object actual) {
+    Assert.assertEquals(expected, actual);
+  }
+
+  /**
+   * Reuses {@link Assert#assertEquals(double, double, double)} with default {@link CustomAssertions#DELTA}.
+   * Added to prevent repetitive casts to 'double' and specifying delta. Asserts that two doubles are equal to within
+   * the delta. If they are not, an AssertionError is thrown with the given message.
+   *
+   * @param expected expected value
+   * @param actual   the value to check against expected
+   */
+  public static void assertNumericEquals(double expected, double actual) {
+    Assert.assertEquals(expected, actual, 0.01);
+  }
+
+  /**
+   * Reuses {@link Assert#assertEquals(double, double, double)} with default {@link CustomAssertions#DELTA}.
+   * Added to prevent repetitive casts to 'float' and specifying delta. Asserts that two doubles are equal to within
+   * the delta. If they are not, an AssertionError is thrown with the given message.
+   *
+   * @param expected expected value
+   * @param actual   the value to check against expected
+   */
+  public static void assertNumericEquals(float expected, float actual) {
+    Assert.assertEquals(expected, actual, 0.01);
+  }
+}

--- a/mssql-plugin/docs/SqlServer-batchsink.md
+++ b/mssql-plugin/docs/SqlServer-batchsink.md
@@ -75,6 +75,58 @@ https://docs.microsoft.com/en-us/sql/relational-databases/system-compatibility-v
 **Connection Arguments:** A list of arbitrary string key/value pairs as connection arguments. These arguments
 will be passed to the JDBC driver as connection arguments for JDBC drivers that may need additional configurations.
 
+Data Types Mapping
+----------
+
+
+    | MS SQL Data Type | CDAP Schema Data Type  | Comment                                                        |
+    | ---------------- | ---------------------- | -------------------------------------------------------------- |
+    | BIGINT           | long                   |                                                                |
+    | BINARY           | bytes                  |                                                                |
+    | BIT              | boolean                |                                                                |
+    | CHAR             | string                 |                                                                |
+    | DATE             | date                   |                                                                |
+    | DATETIME         | timestamp              |                                                                |
+    | DATETIME2        | timestamp              |                                                                |
+    | DATETIMEOFFSET   | string                 |                                                                |
+    | DECIMAL          | decimal                |                                                                |
+    | FLOAT            | double                 |                                                                |
+    | IMAGE            | bytes                  |                                                                |
+    | INT              | int                    |                                                                |
+    | MONEY            | decimal                |                                                                |
+    | NCHAR            | string                 |                                                                |
+    | NTEXT            | string                 |                                                                |
+    | NUMERIC          | decimal                |                                                                |
+    | NVARCHAR         | string                 |                                                                |
+    | NVARCHAR(MAX)    | string                 |                                                                |
+    | REAL             | float                  |                                                                |
+    | SMALLDATETIME    | timestamp              |                                                                |
+    | SMALLINT         | int                    |                                                                |
+    | SMALLMONEY       | decimal                |                                                                |
+    | TEXT             | string                 |                                                                |
+    | TIME             | time                   | TIME data type has the accuracy of 100 nanoseconds which is    |
+    |                  |                        | not currently supported. Values of this type will be rounded   |
+    |                  |                        | to microsecond.                                                |
+    | TINYINT          | int                    |                                                                |
+    | UDT              | bytes                  | UDT types are mapped according to the type they are an alias   |
+    |                  |                        | of. For example, is there is an 'SSN' type that was created as |
+    |                  |                        | 'CREATE TYPE SSN FROM varchar(11);', that type would get       |
+    |                  |                        | mapped to a CDAP string. Common Language Runtime UDTs are      |
+    |                  |                        | mapped to CDAP bytes.                                          |
+    | UNIQUEIDENTIFIER | string                 |                                                                |
+    | VARBINARY        | bytes                  |                                                                |
+    | VARBINARY(MAX)   | bytes                  |                                                                |
+    | VARCHAR          | string                 |                                                                |
+    | VARCHAR(MAX)     | string                 |                                                                |
+    | XML              | string                 |                                                                |
+    | SQLVARIANT       | string                 |                                                                |
+    | GEOMETRY         | bytes                  |                                                                |
+    | GEOGRAPHY        | bytes                  |                                                                |
+    | GEOMETRY         | string                 | Values of this type can be set from Well Known Text strings,   |
+    |                  |                        | such as "POINT(3 40 5 6)".                                     |
+    | GEOGRAPHY        | string                 | Values of this type can be set from Well Known Text strings,   |
+    |                  |                        | such as "POINT(3 40 5 6)".                                     |
+
 
 Example
 -------

--- a/mssql-plugin/docs/SqlServer-batchsource.md
+++ b/mssql-plugin/docs/SqlServer-batchsource.md
@@ -90,6 +90,54 @@ back from the query. However, it must match the schema that comes back from the 
 except it can mark fields as nullable and can contain a subset of the fields.
 
 
+Data Types Mapping
+----------
+
+    | MS SQL Data Type | CDAP Schema Data Type  | Comment                                                        |
+    | ---------------- | ---------------------- | -------------------------------------------------------------- |
+    | BIGINT           | long                   |                                                                |
+    | BINARY           | bytes                  |                                                                |
+    | BIT              | boolean                |                                                                |
+    | CHAR             | string                 |                                                                |
+    | DATE             | date                   |                                                                |
+    | DATETIME         | timestamp              |                                                                |
+    | DATETIME2        | timestamp              |                                                                |
+    | DATETIMEOFFSET   | string                 |                                                                |
+    | DECIMAL          | decimal                |                                                                |
+    | FLOAT            | double                 |                                                                |
+    | IMAGE            | bytes                  |                                                                |
+    | INT              | int                    |                                                                |
+    | MONEY            | decimal                |                                                                |
+    | NCHAR            | string                 |                                                                |
+    | NTEXT            | string                 |                                                                |
+    | NUMERIC          | decimal                |                                                                |
+    | NVARCHAR         | string                 |                                                                |
+    | NVARCHAR(MAX)    | string                 |                                                                |
+    | REAL             | float                  |                                                                |
+    | SMALLDATETIME    | timestamp              |                                                                |
+    | SMALLINT         | int                    |                                                                |
+    | SMALLMONEY       | decimal                |                                                                |
+    | TEXT             | string                 |                                                                |
+    | TIME             | time                   | TIME data type has the accuracy of 100 nanoseconds which is    |
+    |                  |                        | not currently supported. Values of this type will be rounded   |
+    |                  |                        | to microsecond.                                                |
+    | TINYINT          | int                    |                                                                |
+    | UDT              | bytes                  | UDT types are mapped according to the type they are an alias   |
+    |                  |                        | of. For example, is there is an 'SSN' type that was created as |
+    |                  |                        | 'CREATE TYPE SSN FROM varchar(11);', that type would get       |
+    |                  |                        | mapped to a CDAP string. Common Language Runtime UDTs are      |
+    |                  |                        | mapped to CDAP bytes.                                          |
+    | UNIQUEIDENTIFIER | string                 |                                                                |
+    | VARBINARY        | bytes                  |                                                                |
+    | VARBINARY(MAX)   | bytes                  |                                                                |
+    | VARCHAR          | string                 |                                                                |
+    | VARCHAR(MAX)     | string                 |                                                                |
+    | XML              | string                 |                                                                |
+    | SQLVARIANT       | string                 |                                                                |
+    | GEOMETRY         | bytes                  |                                                                |
+    | GEOGRAPHY        | bytes                  |                                                                |
+
+
 Example
 ------
 Suppose you want to read data from SQL Server database named "prod" that is running on "localhost" port 1433,
@@ -112,9 +160,9 @@ Password: "Test11"
 For example, if the 'id' column is a primary key of type int and the other columns are
 non-nullable varchars, output records will have this schema:
 
-| field name     | type                |
-| -------------- | ------------------- |
-| id             | int                 |
-| name           | string              |
-| email          | string              |
-| phone          | string              |
+    | field name     | type                |
+    | -------------- | ------------------- |
+    | id             | int                 |
+    | name           | string              |
+    | email          | string              |
+    | phone          | string              |

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerSinkDBRecord.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerSinkDBRecord.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.mssql;
+
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.plugin.db.SchemaReader;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * SQL Server Sink implementation {@link org.apache.hadoop.mapreduce.lib.db.DBWritable} and
+ * {@link org.apache.hadoop.io.Writable}.
+ */
+public class SqlServerSinkDBRecord extends SqlServerSourceDBRecord {
+
+  public SqlServerSinkDBRecord(StructuredRecord record, int[] columnTypes) {
+    super(record, columnTypes);
+  }
+
+  @Override
+  protected void writeToDB(PreparedStatement stmt, Schema.Field field, int fieldIndex) throws SQLException {
+    String fieldName = field.getName();
+    Object fieldValue = record.get(fieldName);
+    int sqlType = columnTypes[fieldIndex];
+    int sqlIndex = fieldIndex + 1;
+    switch (sqlType) {
+      case SqlServerSourceSchemaReader.GEOGRAPHY_TYPE:
+      case SqlServerSourceSchemaReader.GEOMETRY_TYPE:
+        if (fieldValue == null) {
+          // Handle setting GEOGRAPHY and GEOMETRY 'null' values. Using 'stmt.setNull(sqlIndex, GEOMETRY_TYPE)' leads
+          // to com.microsoft.sqlserver.jdbc.SQLServerException: The conversion from OBJECT to GEOMETRY is unsupported
+          stmt.setString(sqlIndex, "Null");
+        } else if (fieldValue instanceof String) {
+          // Handle setting GEOGRAPHY and GEOMETRY values from Well Known Text.
+          // For example, "POINT(3 40 5 6)"
+          stmt.setString(sqlIndex, (String) fieldValue);
+        } else {
+          super.writeBytes(stmt, fieldIndex, sqlIndex, fieldValue);
+        }
+        break;
+      case Types.TIME:
+        // Handle setting SQL Server 'TIME' data type as string to avoid accuracy loss. 'TIME' data type has the
+        // accuracy of 100 nanoseconds(1 millisecond in Informatica) but 'java.sql.Time' will round value to second.
+        if (fieldValue != null) {
+          stmt.setString(sqlIndex, record.getTime(fieldName).toString());
+        } else {
+          super.writeToDB(stmt, field, fieldIndex);
+        }
+        break;
+      default:
+        super.writeToDB(stmt, field, fieldIndex);
+    }
+  }
+
+  @Override
+  protected SchemaReader getSchemaReader() {
+    return new SqlServerSinkSchemaReader();
+  }
+}

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerSinkSchemaReader.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerSinkSchemaReader.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.mssql;
+
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+
+/**
+ * SQL Server Sink schema reader.
+ */
+public class SqlServerSinkSchemaReader extends SqlServerSourceSchemaReader {
+
+  @Override
+  public boolean shouldIgnoreColumn(ResultSetMetaData metadata, int index) throws SQLException {
+    // Ignore 'TIMESTAMP' column in the output schema since values of this type are generated automatically and can
+    // not be set nor updated
+    return TIMESTAMP_TYPE_NAME.equalsIgnoreCase(metadata.getColumnTypeName(index));
+  }
+}

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerSource.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerSource.java
@@ -21,8 +21,10 @@ import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.etl.api.batch.BatchSource;
+import io.cdap.plugin.db.SchemaReader;
 import io.cdap.plugin.db.batch.config.DBSpecificSourceConfig;
 import io.cdap.plugin.db.batch.source.AbstractDBSource;
+import org.apache.hadoop.mapreduce.lib.db.DBWritable;
 
 import java.util.Collections;
 import java.util.List;
@@ -49,6 +51,16 @@ public class SqlServerSource extends AbstractDBSource {
   protected String createConnectionString() {
     return String.format(SqlServerConstants.SQL_SERVER_CONNECTION_STRING_FORMAT,
                          sqlServerSourceConfig.host, sqlServerSourceConfig.port, sqlServerSourceConfig.database);
+  }
+
+  @Override
+  protected SchemaReader getSchemaReader() {
+    return new SqlServerSourceSchemaReader();
+  }
+
+  @Override
+  protected Class<? extends DBWritable> getDBRecordType() {
+    return SqlServerSourceDBRecord.class;
   }
 
   /**

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerSourceDBRecord.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerSourceDBRecord.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.mssql;
+
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.plugin.db.DBRecord;
+import io.cdap.plugin.db.SchemaReader;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * SQL Server Source implementation {@link org.apache.hadoop.mapreduce.lib.db.DBWritable} and
+ * {@link org.apache.hadoop.io.Writable}.
+ */
+public class SqlServerSourceDBRecord extends DBRecord {
+
+  public SqlServerSourceDBRecord(StructuredRecord record, int[] columnTypes) {
+    super(record, columnTypes);
+  }
+
+  public SqlServerSourceDBRecord() {
+    // Required by Hadoop DBRecordReader to create an instance
+  }
+
+  @Override
+  protected void handleField(ResultSet resultSet, StructuredRecord.Builder recordBuilder, Schema.Field field,
+                             int columnIndex, int sqlType, int sqlPrecision, int sqlScale) throws SQLException {
+    switch (sqlType) {
+      case Types.TIME:
+        // Handle reading SQL Server 'TIME' data type to avoid accuracy loss.
+        // 'TIME' data type has the accuracy of 100 nanoseconds(1 millisecond in Informatica)
+        // but reading via 'getTime' and 'getObject' will round value to second.
+        recordBuilder.setTime(field.getName(), resultSet.getTimestamp(columnIndex).toLocalDateTime().toLocalTime());
+        break;
+      case SqlServerSourceSchemaReader.DATETIME_OFFSET_TYPE:
+        recordBuilder.set(field.getName(), resultSet.getString(columnIndex));
+        break;
+      default:
+        setField(resultSet, recordBuilder, field, columnIndex, sqlType, sqlPrecision, sqlScale);
+    }
+  }
+
+  @Override
+  protected SchemaReader getSchemaReader() {
+    return new SqlServerSourceSchemaReader();
+  }
+}

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerSourceSchemaReader.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerSourceSchemaReader.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.mssql;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.plugin.db.CommonSchemaReader;
+
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+
+/**
+ * SQL Server Source schema reader.
+ */
+public class SqlServerSourceSchemaReader extends CommonSchemaReader {
+
+  public static final String TIMESTAMP_TYPE_NAME = "TIMESTAMP";
+  public static final int DATETIME_OFFSET_TYPE = -155;
+  public static final int GEOMETRY_TYPE = -157;
+  public static final int GEOGRAPHY_TYPE = -158;
+
+  @Override
+  public Schema getSchema(ResultSetMetaData metadata, int index) throws SQLException {
+    int columnSqlType = metadata.getColumnType(index);
+    if (DATETIME_OFFSET_TYPE == columnSqlType) {
+      return Schema.of(Schema.Type.STRING);
+    }
+    if (GEOMETRY_TYPE == columnSqlType || GEOGRAPHY_TYPE == columnSqlType) {
+      return Schema.of(Schema.Type.BYTES);
+    }
+    return super.getSchema(metadata, index);
+  }
+}

--- a/mssql-plugin/src/test/java/io/cdap/plugin/mssql/SqlServerSinkTestRun.java
+++ b/mssql-plugin/src/test/java/io/cdap/plugin/mssql/SqlServerSinkTestRun.java
@@ -18,7 +18,6 @@ package io.cdap.plugin.mssql;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
@@ -26,8 +25,10 @@ import io.cdap.cdap.api.dataset.table.Table;
 import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.mock.batch.MockSource;
 import io.cdap.cdap.etl.proto.v2.ETLPlugin;
+import io.cdap.cdap.test.ApplicationManager;
 import io.cdap.cdap.test.DataSetManager;
 import io.cdap.plugin.common.Constants;
+import io.cdap.plugin.db.CustomAssertions;
 import io.cdap.plugin.db.batch.sink.AbstractDBSink;
 import org.junit.Assert;
 import org.junit.Before;
@@ -36,23 +37,62 @@ import org.junit.Test;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.sql.Connection;
-import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.Statement;
-import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Test for ETL using databases.
  */
 public class SqlServerSinkTestRun extends SqlServerPluginTestBase {
+
+  private static final Schema SCHEMA = Schema.recordOf(
+    "dbRecord",
+    Schema.Field.of("ID", Schema.of(Schema.Type.INT)),
+    Schema.Field.of("NAME", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("TINY", Schema.of(Schema.Type.INT)),
+    Schema.Field.of("SMALL", Schema.of(Schema.Type.INT)),
+    Schema.Field.of("BIG", Schema.of(Schema.Type.LONG)),
+    Schema.Field.of("FLOAT_COL", Schema.of(Schema.Type.DOUBLE)),
+    Schema.Field.of("REAL_COL", Schema.of(Schema.Type.FLOAT)),
+    Schema.Field.of("NUMERIC_COL", Schema.decimalOf(PRECISION, SCALE)),
+    Schema.Field.of("DECIMAL_COL", Schema.decimalOf(PRECISION, SCALE)),
+    Schema.Field.of("BIT_COL", Schema.of(Schema.Type.BOOLEAN)),
+    Schema.Field.of("DATE_COL", Schema.of(Schema.LogicalType.DATE)),
+    Schema.Field.of("TIME_COL", Schema.of(Schema.LogicalType.TIME_MICROS)),
+    Schema.Field.of("DATETIME_COL", Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)),
+    Schema.Field.of("DATETIME2_COL", Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)),
+    Schema.Field.of("DATETIMEOFFSET_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("SMALLDATETIME_COL", Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)),
+    Schema.Field.of("BINARY_COL", Schema.of(Schema.Type.BYTES)),
+    Schema.Field.of("VARBINARY_COL", Schema.of(Schema.Type.BYTES)),
+    Schema.Field.of("VARBINARY_MAX_COL", Schema.of(Schema.Type.BYTES)),
+    Schema.Field.of("IMAGE_COL", Schema.of(Schema.Type.BYTES)),
+    Schema.Field.of("MONEY_COL", Schema.decimalOf(MONEY_PRECISION, MONEY_SCALE)),
+    Schema.Field.of("SMALLMONEY_COL", Schema.decimalOf(SMALL_MONEY_PRECISION, SMALL_MONEY_SCALE)),
+    Schema.Field.of("NCHAR_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("CHAR_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("NTEXT_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("NVARCHAR_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("NVARCHAR_MAX_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("VARCHAR_MAX_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("TEXT_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("UNIQUEIDENTIFIER_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("XML_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("SQL_VARIANT_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("GEOMETRY_COL", Schema.of(Schema.Type.BYTES)),
+    Schema.Field.of("GEOGRAPHY_COL", Schema.of(Schema.Type.BYTES)),
+    Schema.Field.of("GEOMETRY_WKT_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("GEOGRAPHY_WKT_COL", Schema.of(Schema.Type.STRING)),
+    // UDT will be mapped as basic type if it's an alias of this type
+    // In this case UDT_COL is alias of 'varchar(11)'
+    Schema.Field.of("UDT_COL", Schema.of(Schema.Type.STRING)),
+    // BIG_UDT_COL is alias of 'bigint'
+    Schema.Field.of("BIG_UDT_COL", Schema.of(Schema.Type.LONG))
+  );
 
   @Before
   public void setup() throws Exception {
@@ -84,82 +124,145 @@ public class SqlServerSinkTestRun extends SqlServerPluginTestBase {
   }
 
   @Test
-  public void testDBSink() throws Exception {
-    String inputDatasetName = "input-dbsinktest";
+  public void testDBSinkWithExplicitInputSchema() throws Exception {
+    testDBSink("testDBSinkWithExplicitInputSchema", "input-dbsinktest-explicit", SCHEMA);
+  }
 
-    ETLPlugin sourceConfig = MockSource.getPlugin(inputDatasetName);
-    ETLPlugin sinkConfig = getSinkConfig();
+  @Test
+  public void testDBSinkWithInferredSchema() throws Exception {
+    testDBSink("testDBSinkWithInferredInputSchema", "input-dbsinktest-inferred", null);
+  }
 
-    deployETL(sourceConfig, sinkConfig, DATAPIPELINE_ARTIFACT, "testDBSink");
-    createInputData(inputDatasetName);
+  private void testDBSink(String appName, String inputDatasetName, Schema schema) throws Exception {
+    ETLPlugin sourceConfig = (schema != null)
+      ? MockSource.getPlugin(inputDatasetName, schema)
+      : MockSource.getPlugin(inputDatasetName);
 
+    ApplicationManager appManager = deployETL(sourceConfig, getSinkConfig(), DATAPIPELINE_ARTIFACT, appName);
+    List<StructuredRecord> inputRecords = createInputData();
+    // add some data to the input table
+    DataSetManager<Table> inputManager = getDataset(inputDatasetName);
+    MockSource.writeInput(inputManager, inputRecords);
+    runETLOnce(appManager, ImmutableMap.of("logical.start.time", String.valueOf(CURRENT_TS)));
 
     try (Connection conn = createConnection();
          Statement stmt = conn.createStatement();
-         ResultSet resultSet = stmt.executeQuery("SELECT * FROM my_table")) {
-      Set<String> users = new HashSet<>();
-      Assert.assertTrue(resultSet.next());
-      users.add(resultSet.getString("NAME"));
-      Assert.assertEquals(new Date(CURRENT_TS).toString(), resultSet.getDate("DATE_COL").toString());
-      Assert.assertEquals(new Time(CURRENT_TS).toString(), resultSet.getTime("TIME_COL").toString());
-      Assert.assertEquals(new Timestamp(CURRENT_TS),
-                          resultSet.getTimestamp("DATETIME_COL"));
-      Assert.assertTrue(resultSet.next());
-      Assert.assertEquals("user2", Bytes.toString(resultSet.getBytes("BINARY_COL"), 0, 5));
-      Assert.assertEquals(new BigDecimal(3.458, new MathContext(PRECISION)).setScale(SCALE),
-                          resultSet.getBigDecimal("NUMERIC_COL"));
-      Assert.assertEquals(new BigDecimal(3.459, new MathContext(PRECISION)).setScale(SCALE),
-                          resultSet.getBigDecimal("DECIMAL_COL").doubleValue());
-      users.add(resultSet.getString("NAME"));
-      Assert.assertEquals(ImmutableSet.of("user1", "user2"), users);
+         ResultSet actual = stmt.executeQuery("SELECT * FROM MY_DEST_TABLE ORDER BY ID")) {
 
+      for (StructuredRecord expected: inputRecords) {
+        Assert.assertTrue(actual.next());
+        CustomAssertions.assertObjectEquals(expected.get("ID"), actual.getInt("ID"));
+        CustomAssertions.assertObjectEquals(expected.get("TINY"), actual.getInt("TINY"));
+        CustomAssertions.assertObjectEquals(expected.get("SMALL"), actual.getInt("SMALL"));
+        CustomAssertions.assertObjectEquals(expected.getDate("DATE_COL"), actual.getDate("DATE_COL").toLocalDate());
+
+        CustomAssertions.assertObjectEquals(expected.getTime("TIME_COL"),
+                           actual.getTimestamp("TIME_COL").toLocalDateTime().toLocalTime());
+        CustomAssertions.assertObjectEquals(expected.getTimestamp("DATETIME2_COL"),
+                           actual.getTimestamp("DATETIME2_COL").toLocalDateTime().atZone(UTC));
+        CustomAssertions.assertObjectEquals(expected.get("DATETIMEOFFSET_COL"), actual.getString("DATETIMEOFFSET_COL"));
+
+        // 'datetime' values are rounded to increments of .000, .003, or .007 seconds
+        CustomAssertions.assertObjectEquals(expected.getTimestamp("DATETIME_COL").toInstant().toEpochMilli() / 100,
+                           actual.getTimestamp("DATETIME_COL").toInstant().toEpochMilli() / 100);
+
+        // 'smalldate' does not store seconds and minutes can be rounded. Compare with 10 min accuracy
+        CustomAssertions.assertObjectEquals(expected.getTimestamp("SMALLDATETIME_COL").toEpochSecond() / 600,
+                           actual.getTimestamp("SMALLDATETIME_COL").toInstant().getEpochSecond() / 600);
+
+        CustomAssertions.assertObjectEquals(expected.getDecimal("MONEY_COL"), actual.getBigDecimal("MONEY_COL"));
+        CustomAssertions.assertObjectEquals(expected.getDecimal("SMALLMONEY_COL"),
+                                            actual.getBigDecimal("SMALLMONEY_COL"));
+        CustomAssertions.assertObjectEquals(expected.getDecimal("NUMERIC_COL"), actual.getBigDecimal("NUMERIC_COL"));
+        CustomAssertions.assertObjectEquals(expected.getDecimal("DECIMAL_COL"), actual.getBigDecimal("DECIMAL_COL"));
+
+        // SQL Server 'float' is 'float(53)' by default, uses 8 bytes
+        CustomAssertions.assertNumericEquals(expected.get("FLOAT_COL"), actual.getDouble("FLOAT_COL"));
+        CustomAssertions.assertNumericEquals(expected.<Float>get("REAL_COL"), actual.getFloat("REAL_COL"));
+
+        // trim since 'NTEXT' is fixed-length datatype and result string will contain multiple whitespace chars
+        // at the end
+        CustomAssertions.assertObjectEquals(expected.get("NTEXT_COL"), actual.getString("NTEXT_COL").trim());
+
+        // trim since 'NCHAR' is fixed-length datatype and result string will contain multiple whitespace chars
+        // at the end
+        CustomAssertions.assertObjectEquals(expected.get("NCHAR_COL"), actual.getString("NCHAR_COL").trim());
+        CustomAssertions.assertObjectEquals(expected.get("CHAR_COL"), actual.getString("CHAR_COL").trim());
+
+        CustomAssertions.assertObjectEquals(expected.get("NAME"), actual.getString("NAME"));
+        CustomAssertions.assertObjectEquals(expected.get("NVARCHAR_COL"), actual.getString("NVARCHAR_COL"));
+        CustomAssertions.assertObjectEquals(expected.get("TEXT_COL"), actual.getString("TEXT_COL"));
+        CustomAssertions.assertObjectEquals(expected.get("SQL_VARIANT_COL"), actual.getString("SQL_VARIANT_COL"));
+        CustomAssertions.assertObjectEquals(expected.get("XML_COL"), actual.getString("XML_COL"));
+        CustomAssertions.assertObjectEquals(expected.get("NVARCHAR_MAX_COL"), actual.getString("NVARCHAR_MAX_COL"));
+        CustomAssertions.assertObjectEquals(expected.get("VARCHAR_MAX_COL"), actual.getString("VARCHAR_MAX_COL"));
+        CustomAssertions.assertObjectEquals(expected.get("UNIQUEIDENTIFIER_COL"),
+                                            actual.getString("UNIQUEIDENTIFIER_COL"));
+
+        Assert.assertArrayEquals(expected.get("BINARY_COL"), actual.getBytes("BINARY_COL"));
+        Assert.assertArrayEquals(expected.get("VARBINARY_COL"), actual.getBytes("VARBINARY_COL"));
+        Assert.assertArrayEquals(expected.get("VARBINARY_MAX_COL"), actual.getBytes("VARBINARY_MAX_COL"));
+        Assert.assertArrayEquals(expected.get("IMAGE_COL"), actual.getBytes("IMAGE_COL"));
+        Assert.assertArrayEquals(expected.get("GEOMETRY_COL"), actual.getBytes("GEOMETRY_COL"));
+        Assert.assertArrayEquals(expected.get("GEOGRAPHY_COL"), actual.getBytes("GEOGRAPHY_COL"));
+
+        CustomAssertions.assertObjectEquals(expected.get("UDT_COL"), actual.getString("UDT_COL"));
+        CustomAssertions.assertObjectEquals(expected.get("BIG_UDT_COL"), actual.getLong("BIG_UDT_COL"));
+      }
     }
   }
 
-  private void createInputData(String inputDatasetName) throws Exception {
-    // add some data to the input table
-    DataSetManager<Table> inputManager = getDataset(inputDatasetName);
-    Schema schema = Schema.recordOf(
-      "dbRecord",
-      Schema.Field.of("ID", Schema.of(Schema.Type.INT)),
-      Schema.Field.of("NAME", Schema.of(Schema.Type.STRING)),
-      Schema.Field.of("GRADUATED", Schema.of(Schema.Type.BOOLEAN)),
-      Schema.Field.of("TINY", Schema.of(Schema.Type.INT)),
-      Schema.Field.of("SMALL", Schema.of(Schema.Type.INT)),
-      Schema.Field.of("BIG", Schema.of(Schema.Type.LONG)),
-      Schema.Field.of("FLOAT_COL", Schema.of(Schema.Type.FLOAT)),
-      Schema.Field.of("REAL_COL", Schema.of(Schema.Type.FLOAT)),
-      Schema.Field.of("NUMERIC_COL", Schema.decimalOf(PRECISION, SCALE)),
-      Schema.Field.of("DECIMAL_COL", Schema.decimalOf(PRECISION, SCALE)),
-      Schema.Field.of("BIT_COL", Schema.of(Schema.Type.BOOLEAN)),
-      Schema.Field.of("DATE_COL", Schema.of(Schema.LogicalType.DATE)),
-      Schema.Field.of("TIME_COL", Schema.of(Schema.LogicalType.TIME_MICROS)),
-      Schema.Field.of("DATETIME_COL", Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)),
-      Schema.Field.of("BINARY_COL", Schema.of(Schema.Type.BYTES))
-    );
+  private List<StructuredRecord> createInputData() throws Exception {
     List<StructuredRecord> inputRecords = new ArrayList<>();
     LocalDateTime localDateTime = new Timestamp(CURRENT_TS).toLocalDateTime();
     for (int i = 1; i <= 2; i++) {
       String name = "user" + i;
-      inputRecords.add(StructuredRecord.builder(schema)
-                         .set("ID", i)
-                         .set("NAME", name)
-                         .set("GRADUATED", (i % 2 == 0))
-                         .set("TINY", i + 1)
-                         .set("SMALL", i + 2)
-                         .set("BIG", 3456987L)
-                         .set("FLOAT_COL", 3.456f)
-                         .set("REAL_COL", 3.457f)
-                         .setDecimal("NUMERIC_COL", new BigDecimal(3.458d, new MathContext(PRECISION)).setScale(SCALE))
-                         .setDecimal("DECIMAL_COL", new BigDecimal(3.459d, new MathContext(PRECISION)).setScale(SCALE))
-                         .set("BIT_COL", (i % 2 == 1))
-                         .setDate("DATE_COL", localDateTime.toLocalDate())
-                         .setTime("TIME_COL", localDateTime.toLocalTime())
-                         .setTimestamp("DATETIME_COL", localDateTime.atZone(ZoneId.ofOffset("UTC", ZoneOffset.UTC)))
-                         .set("BINARY_COL", name.getBytes(Charsets.UTF_8))
-                         .build());
+      StructuredRecord.Builder builder = StructuredRecord.builder(SCHEMA)
+        .set("ID", i)
+        .set("NAME", name)
+        .set("TINY", i + 1)
+        .set("SMALL", i + 2)
+        .set("BIG", 3456987L)
+        .set("FLOAT_COL", Double.MAX_VALUE)
+        .set("REAL_COL", 3.457f)
+        .setDecimal("NUMERIC_COL", new BigDecimal(3.458d, new MathContext(PRECISION)).setScale(SCALE))
+        .setDecimal("DECIMAL_COL", new BigDecimal(3.459d, new MathContext(PRECISION)).setScale(SCALE))
+        .set("BIT_COL", (i % 2 == 1))
+        .setDate("DATE_COL", localDateTime.toLocalDate())
+        .setTime("TIME_COL", TIME_MICROS)
+        .setTimestamp("DATETIME_COL", localDateTime.atZone(UTC))
+        .setTimestamp("DATETIME2_COL", localDateTime.atZone(UTC))
+        .set("DATETIMEOFFSET_COL", "2019-06-24 16:19:15.8010000 +03:00")
+        .setTimestamp("SMALLDATETIME_COL", localDateTime.atZone(UTC))
+        .set("BINARY_COL", name.getBytes(Charsets.UTF_8))
+        .set("VARBINARY_COL", name.getBytes(Charsets.UTF_8))
+        .set("VARBINARY_MAX_COL", name.getBytes(Charsets.UTF_8))
+        .set("IMAGE_COL", name.getBytes(Charsets.UTF_8))
+        .setDecimal("MONEY_COL", new BigDecimal(123.45, new MathContext(MONEY_PRECISION))
+          .setScale(MONEY_SCALE, BigDecimal.ROUND_HALF_UP)
+          .add(new BigDecimal(i)))
+        .setDecimal("SMALLMONEY_COL", new BigDecimal(123.45, new MathContext(SMALL_MONEY_PRECISION))
+          .setScale(SMALL_MONEY_SCALE, BigDecimal.ROUND_HALF_UP)
+          .add(new BigDecimal(i)))
+        .set("NCHAR_COL", name)
+        .set("CHAR_COL", name)
+        .set("NTEXT_COL", name)
+        .set("NVARCHAR_COL", name)
+        .set("NVARCHAR_MAX_COL", name)
+        .set("VARCHAR_MAX_COL", name)
+        .set("TEXT_COL", name)
+        .set("UNIQUEIDENTIFIER_COL", "0E984725-C51C-4BF4-9960-E1C80E27ABA" + i)
+        .set("XML_COL", "<root><child/></root>")
+        .set("SQL_VARIANT_COL", name)
+        .set("GEOMETRY_COL", Bytes.getBytes(GEOMETRY_VALUES.get(i)))
+        .set("GEOGRAPHY_COL", Bytes.getBytes(GEOGRAPHY_VALUES.get(i)))
+        .set("GEOMETRY_WKT_COL", "POINT(3 40 5 6)")
+        .set("GEOGRAPHY_WKT_COL", "POINT(3 40 5 6)")
+        .set("UDT_COL", "12345678910")
+        .set("BIG_UDT_COL", 15417543010L);
+      inputRecords.add(builder.build());
     }
-    MockSource.writeInput(inputManager, inputRecords);
+    return inputRecords;
   }
 
   private ETLPlugin getSinkConfig() {

--- a/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlPluginTestBase.java
+++ b/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlPluginTestBase.java
@@ -151,7 +151,7 @@ public class MysqlPluginTestBase extends DatabasePluginTestBase {
                      "MEDIUMTEXT_COL MEDIUMTEXT," +
                      "LONGTEXT_COL LONGTEXT," +
                      "CHAR_COL CHAR(100)," +
-                     "BINARY_COL BINARY(100)," +
+                     "BINARY_COL BINARY(5)," +
                      "VARBINARY_COL VARBINARY(20)," +
                      "TINYBLOB_COL TINYBLOB, " +
                      "BLOB_COL BLOB(100), " +

--- a/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlSinkTestRun.java
+++ b/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlSinkTestRun.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.etl.proto.v2.ETLPlugin;
 import io.cdap.cdap.test.ApplicationManager;
 import io.cdap.cdap.test.DataSetManager;
 import io.cdap.plugin.common.Constants;
+import io.cdap.plugin.db.CustomAssertions;
 import io.cdap.plugin.db.batch.sink.AbstractDBSink;
 import org.junit.Assert;
 import org.junit.Before;
@@ -40,8 +41,8 @@ import java.sql.Statement;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+
 
 /**
  * Test for ETL using databases.
@@ -145,35 +146,35 @@ public class MysqlSinkTestRun extends MysqlPluginTestBase {
         Assert.assertTrue(actual.next());
 
         // Verify data
-        assertObjectEquals(expected.get("ID"), actual.getInt("ID"));
-        assertObjectEquals(expected.get("NAME"), actual.getString("NAME"));
-        assertObjectEquals(expected.get("TEXT_COL"), actual.getString("TEXT_COL"));
-        assertObjectEquals(expected.get("TINYTEXT_COL"), actual.getString("TINYTEXT_COL"));
-        assertObjectEquals(expected.get("MEDIUMTEXT_COL"), actual.getString("MEDIUMTEXT_COL"));
-        assertObjectEquals(expected.get("LONGTEXT_COL"), actual.getString("LONGTEXT_COL"));
-        assertObjectEquals(expected.get("CHAR_COL"), actual.getString("CHAR_COL").trim());
-        assertObjectEquals(expected.get("GRADUATED"), actual.getBoolean("GRADUATED"));
+        CustomAssertions.assertObjectEquals(expected.get("ID"), actual.getInt("ID"));
+        CustomAssertions.assertObjectEquals(expected.get("NAME"), actual.getString("NAME"));
+        CustomAssertions.assertObjectEquals(expected.get("TEXT_COL"), actual.getString("TEXT_COL"));
+        CustomAssertions.assertObjectEquals(expected.get("TINYTEXT_COL"), actual.getString("TINYTEXT_COL"));
+        CustomAssertions.assertObjectEquals(expected.get("MEDIUMTEXT_COL"), actual.getString("MEDIUMTEXT_COL"));
+        CustomAssertions.assertObjectEquals(expected.get("LONGTEXT_COL"), actual.getString("LONGTEXT_COL"));
+        CustomAssertions.assertObjectEquals(expected.get("CHAR_COL"), actual.getString("CHAR_COL").trim());
+        CustomAssertions.assertObjectEquals(expected.get("GRADUATED"), actual.getBoolean("GRADUATED"));
         Assert.assertNull(actual.getString("NOT_IMPORTED"));
-        assertObjectEquals(expected.get("ENUM_COL"), actual.getString("ENUM_COL"));
-        assertObjectEquals(expected.get("SET_COL"), actual.getString("SET_COL"));
-        assertObjectEquals(expected.get("TINY"), actual.getInt("TINY"));
-        assertObjectEquals(expected.get("SMALL"), actual.getInt("SMALL"));
-        assertObjectEquals(expected.get("BIG"), actual.getLong("BIG"));
-        assertObjectEquals(expected.get("MEDIUMINT_COL"), actual.getInt("MEDIUMINT_COL"));
-        assertNumericEquals(expected.get("SCORE"), actual.getDouble("SCORE"));
-        assertNumericEquals(expected.get("FLOAT_COL"), actual.getFloat("FLOAT_COL"));
-        assertNumericEquals(expected.get("REAL_COL"), actual.getDouble("REAL_COL"));
-        assertObjectEquals(expected.getDecimal("NUMERIC_COL"), actual.getBigDecimal("NUMERIC_COL"));
-        assertObjectEquals(expected.getDecimal("DECIMAL_COL"), actual.getBigDecimal("DECIMAL_COL"));
-        assertObjectEquals(expected.get("BIT_COL"), actual.getBoolean("BIT_COL"));
+        CustomAssertions.assertObjectEquals(expected.get("ENUM_COL"), actual.getString("ENUM_COL"));
+        CustomAssertions.assertObjectEquals(expected.get("SET_COL"), actual.getString("SET_COL"));
+        CustomAssertions.assertObjectEquals(expected.get("TINY"), actual.getInt("TINY"));
+        CustomAssertions.assertObjectEquals(expected.get("SMALL"), actual.getInt("SMALL"));
+        CustomAssertions.assertObjectEquals(expected.get("BIG"), actual.getLong("BIG"));
+        CustomAssertions.assertObjectEquals(expected.get("MEDIUMINT_COL"), actual.getInt("MEDIUMINT_COL"));
+        CustomAssertions.assertNumericEquals(expected.get("SCORE"), actual.getDouble("SCORE"));
+        CustomAssertions.assertNumericEquals(expected.get("FLOAT_COL"), actual.getFloat("FLOAT_COL"));
+        CustomAssertions.assertNumericEquals(expected.get("REAL_COL"), actual.getDouble("REAL_COL"));
+        CustomAssertions.assertObjectEquals(expected.getDecimal("NUMERIC_COL"), actual.getBigDecimal("NUMERIC_COL"));
+        CustomAssertions.assertObjectEquals(expected.getDecimal("DECIMAL_COL"), actual.getBigDecimal("DECIMAL_COL"));
+        CustomAssertions.assertObjectEquals(expected.get("BIT_COL"), actual.getBoolean("BIT_COL"));
 
         // Verify binary columns
-        assertBytesEquals(expected.get("BINARY_COL"), actual.getBytes("BINARY_COL"));
-        assertBytesEquals(expected.get("VARBINARY_COL"), actual.getBytes("VARBINARY_COL"));
-        assertBytesEquals(expected.get("BLOB_COL"), actual.getBytes("BLOB_COL"));
-        assertBytesEquals(expected.get("MEDIUMBLOB_COL"), actual.getBytes("MEDIUMBLOB_COL"));
-        assertBytesEquals(expected.get("TINYBLOB_COL"), actual.getBytes("TINYBLOB_COL"));
-        assertBytesEquals(expected.get("LONGBLOB_COL"), actual.getBytes("LONGBLOB_COL"));
+        Assert.assertArrayEquals(expected.get("BINARY_COL"), actual.getBytes("BINARY_COL"));
+        Assert.assertArrayEquals(expected.get("VARBINARY_COL"), actual.getBytes("VARBINARY_COL"));
+        Assert.assertArrayEquals(expected.get("BLOB_COL"), actual.getBytes("BLOB_COL"));
+        Assert.assertArrayEquals(expected.get("MEDIUMBLOB_COL"), actual.getBytes("MEDIUMBLOB_COL"));
+        Assert.assertArrayEquals(expected.get("TINYBLOB_COL"), actual.getBytes("TINYBLOB_COL"));
+        Assert.assertArrayEquals(expected.get("LONGBLOB_COL"), actual.getBytes("LONGBLOB_COL"));
 
         // Verify time columns
         Assert.assertEquals(expected.getDate("DATE_COL"), actual.getDate("DATE_COL").toLocalDate());
@@ -188,35 +189,6 @@ public class MysqlSinkTestRun extends MysqlPluginTestBase {
                             actual.getTimestamp("TIMESTAMP_COL").toInstant().atZone(UTC_ZONE));
       }
     }
-  }
-
-  /**
-   * Added to prevent 'Ambiguous method call' issue
-   */
-  private void assertObjectEquals(Object expected, Object actual) {
-    Assert.assertEquals(expected, actual);
-  }
-
-  /**
-   * Added to trim arrays of bytes since it's common that actual arrays are larger.
-   */
-  private void assertBytesEquals(byte[] expected, byte[] actual) {
-    Assert.assertTrue(actual.length >= expected.length);
-    Assert.assertArrayEquals(expected, Arrays.copyOf(actual, expected.length));
-  }
-
-  /**
-   * Added to prevent repetitive casts to 'double' and specifying delta.
-   */
-  private void assertNumericEquals(double expected, double actual) {
-    Assert.assertEquals(expected, actual, 0.000001);
-  }
-
-  /**
-   * Added to prevent repetitive casts to 'float' and specifying delta.
-   */
-  private void assertNumericEquals(float expected, float actual) {
-    Assert.assertEquals(expected, actual, 0.000001);
   }
 
   private List<StructuredRecord> createInputData() throws Exception {

--- a/netezza-plugin/src/test/java/io/cdap/plugin/netezza/NetezzaPluginTestBase.java
+++ b/netezza-plugin/src/test/java/io/cdap/plugin/netezza/NetezzaPluginTestBase.java
@@ -186,8 +186,10 @@ public class NetezzaPluginTestBase extends DatabasePluginTestBase {
         pStmt.setFloat(6, 123.45f + i);
         pStmt.setDouble(7, 123.45 + i);
         pStmt.setDouble(8, 123.45 + i);
-        pStmt.setBigDecimal(9, new BigDecimal(123.45, MathContext.DECIMAL64).add(new BigDecimal(i, MathContext.DECIMAL64)));
-        pStmt.setBigDecimal(10, new BigDecimal(123.45, MathContext.DECIMAL64).add(new BigDecimal(i, MathContext.DECIMAL64)));
+        pStmt.setBigDecimal(9, new BigDecimal(123.45, MathContext.DECIMAL64)
+          .add(new BigDecimal(i, MathContext.DECIMAL64)));
+        pStmt.setBigDecimal(10, new BigDecimal(123.45, MathContext.DECIMAL64)
+          .add(new BigDecimal(i, MathContext.DECIMAL64)));
         pStmt.setString(11, name);
         pStmt.setString(12, name);
         pStmt.setString(13, name);


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15549
WIKI: https://wiki.cask.co/display/CE/Microsoft+SQL+Server+database+plugin

**In scope of this PR:**

* Added tests for Source plugin for next types: 
```
DATETIME, DATETIMEOFFSET, IMAGE, MONEY, NCHAR, NTEXT, NVARCHAR, NVARCHAR(MAX), SMALLDATETIME, SMALLMONEY, TIMESTAMP, UDT, UNIQUEIDENTIFIER, VARBINARY(MAX), VARCHAR(MAX), XML, SQL_VARIANT, GEOMETRY, GEOGRAPHY
```

* Added tests for Sink plugin for the next types: 
```
BIGINT, BIT, CHAR, DATETIME, DATETIMEOFFSET, DECIMAL, FLOAT, IMAGE, INT, MONEY, NCHAR, NTEXT, NUMERIC, NVARCHAR, NVARCHAR(MAX), REAL, SMALLDATETIME, SMALLINT, SMALLMONEY, TEXT, TINYINT, UDT, UNIQUEIDENTIFIER, VARBINARY, VARBINARY(MAX), VARCHAR(MAX), XML, SQL_VARIANT, GEOMETRY, GEOGRAPHY
```

* Added support of `DATETIMEOFFSET` data type, currently mapped to the `Type.STRING`

* Added support of `TIMESTAMP` type for Source plugin

`TIMESTAMP` is the synonym for the `ROWVERSION` data type, values of which are automatically generated. Thus `TIMESTAMP` can not be supported by Sink plugin.

* Added support of the `GEOMETRY` and `GEOGRAPHY` types, mapped to the `Type.BYTES`

Values of these types can be [set from Well Known Text](https://docs.microsoft.com/en-us/sql/t-sql/spatial-geometry/stgeomfromtext-geometry-data-type?view=sql-server-2017). Added support for Well Known Text in Sink plugin.

* Mappings added to the reference documentation

**Open questions:**

* `DATETIMEOFFSET` mapping

`DATETIMEOFFSET` data type, currently mapped to the `Type.STRING` in order to avoid modification of the original time zone. 
This can be changed as soon as the following scenario, [described by](https://wiki.cask.co/display/CE/Oracle+database+plugin?focusedCommentId=17990518#comment-17990518) @CuriousVini  is supported:
>  ... one approach is to store timezone information as an optional string along with epoch timestamp in platform. When reading from StrucutredRecord, getTimestamp(fieldName) method can read timestamp with provided timezone (Default timezone can be UTC). 

* `TIME` data type accuracy

MS SQL Server `TIME` data type currently mapped to the `LogicalType.TIME_MICROS`.
`TIME` data type [has the accuracy of 100 nanoseconds](https://docs.microsoft.com/en-us/sql/t-sql/data-types/time-transact-sql?view=sql-server-2017) which can not be supported using 'TIME_MICROS' logical type. This, current implementation will loose 0.1-microsecond accuracy. 

We can avoid this by mapping to the `Schema.Type.STRING`, but seems that this is not the best solution.