### PR TITLE
CDAP-15518 Investigate pipeline failure on demo environment: input schema validation

### DIFF
--- a/aurora-mysql-plugin/src/test/java/io/cdap/plugin/aurora/mysql/AuroraMysqlSinkTestRun.java
+++ b/aurora-mysql-plugin/src/test/java/io/cdap/plugin/aurora/mysql/AuroraMysqlSinkTestRun.java
@@ -31,6 +31,7 @@ import io.cdap.plugin.auroradb.mysql.AuroraMysqlConstants;
 import io.cdap.plugin.common.Constants;
 import io.cdap.plugin.db.batch.sink.AbstractDBSink;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.math.BigDecimal;
@@ -54,20 +55,41 @@ import java.util.Set;
  */
 public class AuroraMysqlSinkTestRun extends AuroraMysqlPluginTestBase {
 
+  @Before
+  public void setup() throws Exception {
+    try (Connection connection = createConnection();
+         Statement stmt = connection.createStatement()) {
+      stmt.execute("TRUNCATE TABLE MY_DEST_TABLE");
+    }
+  }
+
+  @Test
+  public void testDBSinkWithInvalidFieldType() throws Exception {
+    testDBInvalidFieldType("ID", Schema.Type.STRING, getSinkConfig(), DATAPIPELINE_ARTIFACT);
+  }
+
+  @Test
+  public void testDBSinkWithInvalidFieldLogicalType() throws Exception {
+    testDBInvalidFieldLogicalType("TIMESTAMP_COL", Schema.Type.LONG, getSinkConfig(), DATAPIPELINE_ARTIFACT);
+  }
+
+  @Test
+  public void testDBSinkWithDBSchemaAndInvalidData() throws Exception {
+    String stringColumnName = "NAME";
+    startPipelineAndWriteInvalidData(stringColumnName, getSinkConfig(), DATAPIPELINE_ARTIFACT);
+    try (Connection conn = createConnection();
+         Statement stmt = conn.createStatement();
+         ResultSet resultSet = stmt.executeQuery("SELECT * FROM MY_DEST_TABLE")) {
+      testInvalidDataWrite(resultSet, stringColumnName);
+    }
+  }
+
   @Test
   public void testDBSink() throws Exception {
     String inputDatasetName = "input-dbsinktest";
 
     ETLPlugin sourceConfig = MockSource.getPlugin(inputDatasetName);
-    ETLPlugin sinkConfig = new ETLPlugin(
-      AuroraMysqlConstants.PLUGIN_NAME,
-      BatchSink.PLUGIN_TYPE,
-      ImmutableMap.<String, String>builder()
-        .putAll(BASE_PROPS)
-        .put(AbstractDBSink.DBSinkConfig.TABLE_NAME, "MY_DEST_TABLE")
-        .put(Constants.Reference.REFERENCE_NAME, "DBTest")
-        .build(),
-      null);
+    ETLPlugin sinkConfig = getSinkConfig();
 
     deployETL(sourceConfig, sinkConfig, DATAPIPELINE_ARTIFACT, "testDBSink");
     createInputData(inputDatasetName);
@@ -158,5 +180,17 @@ public class AuroraMysqlSinkTestRun extends AuroraMysqlPluginTestBase {
                          .build());
     }
     MockSource.writeInput(inputManager, inputRecords);
+  }
+
+  private ETLPlugin getSinkConfig() {
+    return new ETLPlugin(
+      AuroraMysqlConstants.PLUGIN_NAME,
+      BatchSink.PLUGIN_TYPE,
+      ImmutableMap.<String, String>builder()
+        .putAll(BASE_PROPS)
+        .put(AbstractDBSink.DBSinkConfig.TABLE_NAME, "MY_DEST_TABLE")
+        .put(Constants.Reference.REFERENCE_NAME, "DBTest")
+        .build(),
+      null);
   }
 }

--- a/aurora-postgresql-plugin/src/test/java/io/cdap/plugin/auroradb/postgres/AuroraPostgresSinkTestRun.java
+++ b/aurora-postgresql-plugin/src/test/java/io/cdap/plugin/auroradb/postgres/AuroraPostgresSinkTestRun.java
@@ -28,6 +28,7 @@ import io.cdap.cdap.test.DataSetManager;
 import io.cdap.plugin.common.Constants;
 import io.cdap.plugin.db.batch.sink.AbstractDBSink;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.math.BigDecimal;
@@ -51,21 +52,41 @@ import java.util.Set;
  */
 public class AuroraPostgresSinkTestRun extends AuroraPostgresPluginTestBase {
 
+  @Before
+  public void setup() throws Exception {
+    try (Connection connection = createConnection();
+         Statement stmt = connection.createStatement()) {
+      stmt.execute("TRUNCATE TABLE \"MY_DEST_TABLE\"");
+    }
+  }
+
+  @Test
+  public void testDBSinkWithInvalidFieldType() throws Exception {
+    testDBInvalidFieldType("ID", Schema.Type.STRING, getSinkConfig(), DATAPIPELINE_ARTIFACT);
+  }
+
+  @Test
+  public void testDBSinkWithInvalidFieldLogicalType() throws Exception {
+    testDBInvalidFieldLogicalType("TIMESTAMP_COL", Schema.Type.LONG, getSinkConfig(), DATAPIPELINE_ARTIFACT);
+  }
+
+  @Test
+  public void testDBSinkWithDBSchemaAndInvalidData() throws Exception {
+    String stringColumnName = "NAME";
+    startPipelineAndWriteInvalidData(stringColumnName, getSinkConfig(), DATAPIPELINE_ARTIFACT);
+    try (Connection conn = createConnection();
+         Statement stmt = conn.createStatement();
+         ResultSet resultSet = stmt.executeQuery("SELECT * FROM \"MY_DEST_TABLE\"")) {
+      testInvalidDataWrite(resultSet, stringColumnName);
+    }
+  }
+
   @Test
   public void testDBSink() throws Exception {
     String inputDatasetName = "input-dbsinktest";
 
     ETLPlugin sourceConfig = MockSource.getPlugin(inputDatasetName);
-    ETLPlugin sinkConfig = new ETLPlugin(
-      AuroraPostgresConstants.PLUGIN_NAME,
-      BatchSink.PLUGIN_TYPE,
-      ImmutableMap.<String, String>builder()
-        .putAll(BASE_PROPS)
-        .put(AbstractDBSink.DBSinkConfig.TABLE_NAME, "MY_DEST_TABLE")
-        .put(Constants.Reference.REFERENCE_NAME, "DBTest")
-        .build(),
-      null);
-
+    ETLPlugin sinkConfig = getSinkConfig();
     deployETL(sourceConfig, sinkConfig, DATAPIPELINE_ARTIFACT, "testDBSink");
     createInputData(inputDatasetName);
 
@@ -135,5 +156,18 @@ public class AuroraPostgresSinkTestRun extends AuroraPostgresPluginTestBase {
                          .build());
     }
     MockSource.writeInput(inputManager, inputRecords);
+  }
+
+  private ETLPlugin getSinkConfig() {
+    return new ETLPlugin(
+      AuroraPostgresConstants.PLUGIN_NAME,
+      BatchSink.PLUGIN_TYPE,
+      ImmutableMap.<String, String>builder()
+        .putAll(BASE_PROPS)
+        .put(AbstractDBSink.DBSinkConfig.TABLE_NAME, "MY_DEST_TABLE")
+        .put(Constants.Reference.REFERENCE_NAME, "DBTest")
+        .build(),
+      null);
+
   }
 }

--- a/database-commons/src/main/java/io/cdap/plugin/db/batch/sink/ETLDBOutputFormat.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/batch/sink/ETLDBOutputFormat.java
@@ -110,9 +110,15 @@ public class ETLDBOutputFormat<K extends DBWritable, V> extends DBOutputFormat<K
         }
 
         @Override
-        public void write(K key, V value) throws IOException {
-          super.write(key, value);
+        public void write(K key, V value) {
           emptyData = false;
+          //We need to make correct logging to avoid losing information about error
+          try {
+            key.write(getStatement());
+            getStatement().addBatch();
+          } catch (SQLException e) {
+            LOG.warn("Failed to write value to database", e);
+          }
         }
       };
     } catch (Exception ex) {


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15518

**In scope of this PR:**

* Added input schema validation in sink plugin during pipeline configuration
* Added check of logical types during schema validation
An attempt to write data type LONG instead of data type LONG with logical type TIMESTAMP_MICROS cased pipeline fail in MSSQL sink plugin on demo environment
* Added tests for schema validation in MySQL, MSSQL, Postgresql, Oracle, DB2, Netezza sink plugins for such cases:
   * incorrect data type
   * incorrect data logical type
* Added tests for invalid data write attempt in MySQL, MSSQL, Postgresql, Oracle, DB2, Netezza sink plugins
* Fixed connection close in DB2 sink plugin after attempt to write invalid data
