### PR TITLE
CDAP-15547 Postgres db plugin enhacements: all data types support + proper test coverage

### DIFF
--- a/database-commons/src/main/java/io/cdap/plugin/db/ColumnType.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/ColumnType.java
@@ -21,16 +21,22 @@ package io.cdap.plugin.db;
  */
 public class ColumnType {
 
-  private final String name;
-  private final int type;
+  private String name;
+  private String typeName;
+  private int type;
 
-  public ColumnType(String name, int type) {
+  public ColumnType(String name, String typeName, int type) {
     this.name = name;
+    this.typeName = typeName;
     this.type = type;
   }
 
   public String getName() {
     return name;
+  }
+
+  public String getTypeName() {
+    return typeName;
   }
 
   public int getType() {

--- a/database-commons/src/main/java/io/cdap/plugin/db/DBRecord.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/DBRecord.java
@@ -157,8 +157,8 @@ public class DBRecord implements Writable, DBWritable, Configurable {
 
   protected void setFieldAccordingToSchema(ResultSet resultSet, StructuredRecord.Builder recordBuilder,
                                            Schema.Field field, int columnIndex) throws SQLException {
-
-    Schema.Type fieldType = field.getSchema().getType();
+    Schema.Type fieldType = field.getSchema().isNullable() ? field.getSchema().getNonNullable().getType()
+      : field.getSchema().getType();
 
     switch (fieldType) {
       case NULL:

--- a/postgresql-plugin/docs/Postgres-batchsink.md
+++ b/postgresql-plugin/docs/Postgres-batchsink.md
@@ -56,3 +56,47 @@ Table Name: "users"
 Username: "root"
 Password: "root"
 ```
+Data Types Mapping
+------
+All PostgreSQL specific data types mapped to string and can have multiple input formats and one 'canonical' output form.
+Please, refer to PostgreSQL data types documentation to figure out proper formats.
+
+| PostgreSQL Data Type                                | CDAP Schema Data Type | Comment                                      |
+|-----------------------------------------------------|-----------------------|----------------------------------------------|
+| bigint                                              | long                  |                                              |
+| bit(n)                                              | string                | string with '0' and '1' chars exact n length |
+| bit varying(n)                                      | string                | string with '0' and '1' chars max n length   |
+| boolean                                             | boolean               |                                              |
+| bytea                                               | bytes                 |                                              |
+| character                                           | string                |                                              |
+| character varying                                   | string                |                                              |
+| double precision                                    | double                |                                              |
+| integer                                             | int                   |                                              |
+| numeric(precision, scale)/decimal(precision, scale) | decimal               |                                              |
+| real                                                | float                 |                                              |
+| smallint                                            | int                   |                                              |
+| text                                                | string                |                                              |
+| date                                                | date                  |                                              |
+| time [ (p) ] [ without time zone ]                  | time                  |                                              |
+| time [ (p) ] with time zone                         | string                |                                              |
+| timestamp [ (p) ] [ without time zone ]             | timestamp             |                                              |
+| timestamp [ (p) ] with time zone                    | timestamp             | stored in UTC format in database             |
+| xml                                                 | string                |                                              |
+| tsquery                                             | string                |                                              |
+| tsvector                                            | string                |                                              |
+| uuid                                                | string                |                                              |
+| box                                                 | string                |                                              |
+| cidr                                                | string                |                                              |
+| circle                                              | string                |                                              |
+| inet                                                | string                |                                              |
+| interval                                            | string                |                                              |
+| json                                                | string                |                                              |
+| jsonb                                               | string                |                                              |
+| line                                                | string                |                                              |
+| lseg                                                | string                |                                              |
+| macaddr                                             | string                |                                              |
+| macaddr8                                            | string                |                                              |
+| money                                               | string                |                                              |
+| path                                                | string                |                                              |
+| point                                               | string                |                                              |
+| polygon                                             | string                |                                              |

--- a/postgresql-plugin/docs/Postgres-batchsource.md
+++ b/postgresql-plugin/docs/Postgres-batchsource.md
@@ -83,3 +83,51 @@ non-nullable varchars, output records will have this schema:
     | name           | string              |
     | email          | string              |
     | phone          | string              |
+
+Data Types Mapping
+------
+All PostgreSQL specific data types mapped to string and can have multiple input formats and one 'canonical' output form.
+Please, refer to PostgreSQL data types documentation to figure out proper formats.
+
+| PostgreSQL Data Type                                | CDAP Schema Data Type | Comment                                      |
+|-----------------------------------------------------|-----------------------|----------------------------------------------|
+| bigint                                              | long                  |                                              |
+| bigserial                                           | long                  |                                              |
+| bit(n)                                              | string                | string with '0' and '1' chars exact n length |
+| bit varying(n)                                      | string                | string with '0' and '1' chars max n length   |
+| boolean                                             | boolean               |                                              |
+| bytea                                               | bytes                 |                                              |
+| character                                           | string                |                                              |
+| character varying                                   | string                |                                              |
+| double precision                                    | double                |                                              |
+| integer                                             | int                   |                                              |
+| numeric(precision, scale)/decimal(precision, scale) | decimal               |                                              |
+| real                                                | float                 |                                              |
+| smallint                                            | int                   |                                              |
+| smallserial                                         | int                   |                                              |
+| serial                                              | int                   |                                              |
+| text                                                | string                |                                              |
+| date                                                | date                  |                                              |
+| time [ (p) ] [ without time zone ]                  | time                  |                                              |
+| time [ (p) ] with time zone                         | string                |                                              |
+| timestamp [ (p) ] [ without time zone ]             | timestamp             |                                              |
+| timestamp [ (p) ] with time zone                    | timestamp             | stored in UTC format in database             |
+| xml                                                 | string                |                                              |
+| tsquery                                             | string                |                                              |
+| tsvector                                            | string                |                                              |
+| uuid                                                | string                |                                              |
+| box                                                 | string                |                                              |
+| cidr                                                | string                |                                              |
+| circle                                              | string                |                                              |
+| inet                                                | string                |                                              |
+| interval                                            | string                |                                              |
+| json                                                | string                |                                              |
+| jsonb                                               | string                |                                              |
+| line                                                | string                |                                              |
+| lseg                                                | string                |                                              |
+| macaddr                                             | string                |                                              |
+| macaddr8                                            | string                |                                              |
+| money                                               | string                |                                              |
+| path                                                | string                |                                              |
+| point                                               | string                |                                              |
+| polygon                                             | string                |                                              |

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresDBRecord.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresDBRecord.java
@@ -22,7 +22,11 @@ import io.cdap.plugin.db.ColumnType;
 import io.cdap.plugin.db.DBRecord;
 import io.cdap.plugin.db.SchemaReader;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.List;
 
@@ -39,21 +43,57 @@ public class PostgresDBRecord extends DBRecord {
    * Used in map-reduce. Do not remove.
    */
   @SuppressWarnings("unused")
-  public PostgresDBRecord() {}
+  public PostgresDBRecord() {
+  }
 
   @Override
   protected void handleField(ResultSet resultSet, StructuredRecord.Builder recordBuilder, Schema.Field field,
                              int columnIndex, int sqlType, int sqlPrecision, int sqlScale) throws SQLException {
-    if (PostgresSchemaReader.POSTGRES_TYPES.contains(sqlType)) {
-      handleSpecificType(resultSet, recordBuilder, field, columnIndex);
+    if (isUseSchema(resultSet.getMetaData(), columnIndex)) {
+      setFieldAccordingToSchema(resultSet, recordBuilder, field, columnIndex);
     } else {
       setField(resultSet, recordBuilder, field, columnIndex, sqlType, sqlPrecision, sqlScale);
     }
   }
 
-  private void handleSpecificType(ResultSet resultSet, StructuredRecord.Builder recordBuilder, Schema.Field field,
-                                  int columnIndex) throws SQLException {
-    setFieldAccordingToSchema(resultSet, recordBuilder, field, columnIndex);
+  private static boolean isUseSchema(ResultSetMetaData metadata, int columnIndex) throws SQLException {
+    switch (metadata.getColumnTypeName(columnIndex)) {
+      case "bit":
+      case "timetz":
+      case "money":
+        return true;
+      default:
+        return PostgresSchemaReader.STRING_MAPPED_POSTGRES_TYPES.contains(metadata.getColumnType(columnIndex));
+    }
+  }
+
+  private Object createPGobject(String type, String value, ClassLoader classLoader) throws SQLException {
+    try {
+      Class pGObjectClass = classLoader.loadClass("org.postgresql.util.PGobject");
+      Method setTypeMethod = pGObjectClass.getMethod("setType", String.class);
+      Method setValueMethod = pGObjectClass.getMethod("setValue", String.class);
+      Object result = pGObjectClass.newInstance();
+      setTypeMethod.invoke(result, type);
+      setValueMethod.invoke(result, value);
+      return result;
+    } catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException |
+      InvocationTargetException e) {
+      throw new SQLException("Failed to create instance of org.postgresql.util.PGobject");
+    }
+  }
+
+  @Override
+  protected void writeToDB(PreparedStatement stmt, Schema.Field field, int fieldIndex) throws SQLException {
+    int sqlIndex = fieldIndex + 1;
+    ColumnType columnType = columnTypes.get(fieldIndex);
+    if (PostgresSchemaReader.STRING_MAPPED_POSTGRES_TYPES_NAMES.contains(columnType.getTypeName()) ||
+      PostgresSchemaReader.STRING_MAPPED_POSTGRES_TYPES.contains(columnType.getType())) {
+      stmt.setObject(sqlIndex, createPGobject(columnType.getTypeName(),
+                                              record.get(field.getName()),
+                                              stmt.getClass().getClassLoader()));
+    } else {
+      super.writeToDB(stmt, field, fieldIndex);
+    }
   }
 
   @Override

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSchemaReader.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSchemaReader.java
@@ -30,13 +30,20 @@ import java.util.Set;
  */
 public class PostgresSchemaReader extends CommonSchemaReader {
 
-  public static final Set<Integer> POSTGRES_TYPES = ImmutableSet.of(
+  public static final Set<Integer> STRING_MAPPED_POSTGRES_TYPES = ImmutableSet.of(
     Types.OTHER, Types.ARRAY, Types.SQLXML
+  );
+
+  public static final Set<String> STRING_MAPPED_POSTGRES_TYPES_NAMES = ImmutableSet.of(
+    "bit", "timetz", "money"
   );
 
   @Override
   public Schema getSchema(ResultSetMetaData metadata, int index) throws SQLException {
-    if (POSTGRES_TYPES.contains(metadata.getColumnType(index))) {
+    String typeName = metadata.getColumnTypeName(index);
+    int columnType = metadata.getColumnType(index);
+
+    if (STRING_MAPPED_POSTGRES_TYPES_NAMES.contains(typeName) || STRING_MAPPED_POSTGRES_TYPES.contains(columnType)) {
       return Schema.of(Schema.Type.STRING);
     }
 

--- a/postgresql-plugin/src/test/java/io/cdap/plugin/postgres/PostgresSinkTestRun.java
+++ b/postgresql-plugin/src/test/java/io/cdap/plugin/postgres/PostgresSinkTestRun.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.postgres;
 
+import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.cdap.cdap.api.data.format.StructuredRecord;
@@ -24,6 +25,7 @@ import io.cdap.cdap.api.dataset.table.Table;
 import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.mock.batch.MockSource;
 import io.cdap.cdap.etl.proto.v2.ETLPlugin;
+import io.cdap.cdap.test.ApplicationManager;
 import io.cdap.cdap.test.DataSetManager;
 import io.cdap.plugin.common.Constants;
 import io.cdap.plugin.db.batch.sink.AbstractDBSink;
@@ -51,6 +53,48 @@ import java.util.Set;
  * Test for ETL using databases.
  */
 public class PostgresSinkTestRun extends PostgresPluginTestBase {
+  private static final Schema SCHEMA = Schema.recordOf(
+    "dbRecord",
+    Schema.Field.of("ID", Schema.of(Schema.Type.INT)),
+    Schema.Field.of("NAME", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("SCORE", Schema.of(Schema.Type.FLOAT)),
+    Schema.Field.of("GRADUATED", Schema.of(Schema.Type.BOOLEAN)),
+    Schema.Field.of("NOT_IMPORTED", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("SMALLINT_COL", Schema.of(Schema.Type.INT)),
+    Schema.Field.of("BIG", Schema.of(Schema.Type.LONG)),
+    Schema.Field.of("NUMERIC_COL", Schema.decimalOf(PRECISION, SCALE)),
+    Schema.Field.of("DECIMAL_COL", Schema.decimalOf(PRECISION, SCALE)),
+    Schema.Field.of("DOUBLE_PREC_COL", Schema.of(Schema.Type.DOUBLE)),
+    Schema.Field.of("DATE_COL", Schema.of(Schema.LogicalType.DATE)),
+    Schema.Field.of("TIME_COL", Schema.of(Schema.LogicalType.TIME_MICROS)),
+    Schema.Field.of("TIMESTAMP_COL", Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)),
+    Schema.Field.of("TEXT_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("CHAR_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("BYTEA_COL", Schema.of(Schema.Type.BYTES)),
+    Schema.Field.of("BIT_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("VAR_BIT_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("TIMETZ_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("TIMESTAMPTZ_COL", Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)),
+    Schema.Field.of("XML_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("UUID_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("CIDR_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("CIRCLE_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("INET_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("INTERVAL_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("JSON_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("JSONB_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("LINE_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("LSEG_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("MACADDR_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("MACADDR8_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("MONEY_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("PATH_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("POINT_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("POLYGON_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("TSQUERY_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("TSVECTOR_COL", Schema.of(Schema.Type.STRING)),
+    Schema.Field.of("BOX_COL", Schema.of(Schema.Type.STRING))
+  );
 
   @Before
   public void setup() throws Exception {
@@ -82,20 +126,29 @@ public class PostgresSinkTestRun extends PostgresPluginTestBase {
   }
 
   @Test
-  public void testDBSink() throws Exception {
+  public void testDBSinkWithExplicitInputSchema() throws Exception {
+    testDBSink("testDBSinkWithExplicitInputSchema", "input-dbsinktest-explicit", true);
+  }
 
-    String inputDatasetName = "input-dbsinktest";
+  @Test
+  public void testDBSinkWithInferredInputSchema() throws Exception {
+    testDBSink("testDBSinkWithInferredInputSchema", "input-dbsinktest-inferred", false);
+  }
 
-    ETLPlugin sourceConfig = MockSource.getPlugin(inputDatasetName);
+  public void testDBSink(String appName, String inputDatasetName, boolean setInputSchema) throws Exception {
+    ETLPlugin sourceConfig = (setInputSchema)
+      ? MockSource.getPlugin(inputDatasetName, SCHEMA)
+      : MockSource.getPlugin(inputDatasetName);
+
     ETLPlugin sinkConfig = getSinkConfig();
 
-    deployETL(sourceConfig, sinkConfig, DATAPIPELINE_ARTIFACT, "testDBSink");
+    ApplicationManager appManager = deployETL(sourceConfig, sinkConfig, DATAPIPELINE_ARTIFACT, appName);
     createInputData(inputDatasetName);
-
+    runETLOnce(appManager, ImmutableMap.of("logical.start.time", String.valueOf(CURRENT_TS)));
 
     try (Connection conn = createConnection();
          Statement stmt = conn.createStatement();
-         ResultSet resultSet = stmt.executeQuery("SELECT * FROM my_table")) {
+         ResultSet resultSet = stmt.executeQuery("SELECT * FROM \"MY_DEST_TABLE\" ORDER BY \"ID\" ASC")) {
       Set<String> users = new HashSet<>();
       Assert.assertTrue(resultSet.next());
       users.add(resultSet.getString("NAME"));
@@ -103,6 +156,8 @@ public class PostgresSinkTestRun extends PostgresPluginTestBase {
       Assert.assertEquals(new Time(CURRENT_TS).toString(), resultSet.getTime("TIME_COL").toString());
       Assert.assertEquals(new Timestamp(CURRENT_TS),
                           resultSet.getTimestamp("TIMESTAMP_COL"));
+      Assert.assertEquals(new Timestamp(CURRENT_TS),
+                          resultSet.getTimestamp("TIMESTAMPTZ_COL"));
       Assert.assertTrue(resultSet.next());
       Assert.assertArrayEquals("user2".getBytes(), resultSet.getBytes("BYTEA_COL"));
       Assert.assertEquals(new BigDecimal(3.458, new MathContext(PRECISION)).setScale(SCALE),
@@ -113,39 +168,52 @@ public class PostgresSinkTestRun extends PostgresPluginTestBase {
       users.add(resultSet.getString("NAME"));
       Assert.assertEquals(ImmutableSet.of("user1", "user2"), users);
 
+      Assert.assertEquals(3.451f, resultSet.getFloat("SCORE"), 0.00001);
+      Assert.assertTrue(resultSet.getBoolean("GRADUATED"));
+      Assert.assertEquals(4, resultSet.getInt("SMALLINT_COL"));
+      Assert.assertEquals(3456987L, resultSet.getLong("BIG"));
+      Assert.assertEquals(3.459d, resultSet.getFloat("DOUBLE_PREC_COL"), 0.00001);
+      Assert.assertEquals("user2", resultSet.getString("TEXT_COL"));
+      Assert.assertEquals("char2", resultSet.getString("CHAR_COL").trim());
+      Assert.assertEquals("1010", resultSet.getString("BIT_COL"));
+      Assert.assertEquals("101", resultSet.getString("VAR_BIT_COL"));
+      Assert.assertEquals("03:02:03.456+03", resultSet.getString("TIMETZ_COL"));
+      Assert.assertEquals("<root></root>", resultSet.getString("XML_COL"));
+      Assert.assertEquals("e95861c9-1111-40ce-b42b-d6b9d1765c2c", resultSet.getString("UUID_COL"));
+      Assert.assertEquals("192.168.0.0/23", resultSet.getString("CIDR_COL"));
+      Assert.assertEquals("<(1,2),10>", resultSet.getString("CIRCLE_COL"));
+      Assert.assertEquals("192.168.1.1", resultSet.getString("INET_COL"));
+      Assert.assertEquals("1 day", resultSet.getString("INTERVAL_COL"));
+      Assert.assertEquals("{\"hello\": \"world\"}", resultSet.getString("JSON_COL"));
+      Assert.assertEquals("{\"hello\": \"world\"}", resultSet.getString("JSONB_COL"));
+      Assert.assertEquals("{1,-1,0}", resultSet.getString("LINE_COL"));
+      Assert.assertEquals("[(1,1),(2,2)]", resultSet.getString("LSEG_COL"));
+      Assert.assertEquals("08:00:2b:01:02:03", resultSet.getString("MACADDR_COL"));
+      Assert.assertEquals("08:00:2b:01:02:03:04:05", resultSet.getString("MACADDR8_COL"));
+      Assert.assertEquals("$1,234.12", resultSet.getString("MONEY_COL"));
+      Assert.assertEquals("[(1,1),(2,2),(3,3)]", resultSet.getString("PATH_COL"));
+      Assert.assertEquals("(1,1)", resultSet.getString("POINT_COL"));
+      Assert.assertEquals("((1,1),(2,2),(0,5))", resultSet.getString("POLYGON_COL"));
+      Assert.assertEquals("'fat' & ( 'rat' | 'cat' )", resultSet.getString("TSQUERY_COL"));
+      Assert.assertEquals("'a' 'cat' 'fat'", resultSet.getString("TSVECTOR_COL"));
+      Assert.assertEquals("(2,2),(1,1)", resultSet.getString("BOX_COL"));
     }
   }
 
   private void createInputData(String inputDatasetName) throws Exception {
     // add some data to the input table
     DataSetManager<Table> inputManager = getDataset(inputDatasetName);
-    Schema schema = Schema.recordOf(
-      "dbRecord",
-      Schema.Field.of("ID", Schema.of(Schema.Type.INT)),
-      Schema.Field.of("NAME", Schema.of(Schema.Type.STRING)),
-      Schema.Field.of("SCORE", Schema.of(Schema.Type.FLOAT)),
-      Schema.Field.of("GRADUATED", Schema.of(Schema.Type.BOOLEAN)),
-      Schema.Field.of("SMALLINT_COL", Schema.of(Schema.Type.INT)),
-      Schema.Field.of("BIG", Schema.of(Schema.Type.LONG)),
-      Schema.Field.of("NUMERIC_COL", Schema.decimalOf(PRECISION, SCALE)),
-      Schema.Field.of("DECIMAL_COL", Schema.decimalOf(PRECISION, SCALE)),
-      Schema.Field.of("DOUBLE_PREC_COL", Schema.of(Schema.Type.DOUBLE)),
-      Schema.Field.of("DATE_COL", Schema.of(Schema.LogicalType.DATE)),
-      Schema.Field.of("TIME_COL", Schema.of(Schema.LogicalType.TIME_MICROS)),
-      Schema.Field.of("TIMESTAMP_COL", Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)),
-      Schema.Field.of("CHAR_COL", Schema.of(Schema.Type.STRING)),
-      Schema.Field.of("BYTEA_COL", Schema.of(Schema.Type.BYTES)),
-      Schema.Field.of("TEXT_COL", Schema.of(Schema.Type.STRING))
-    );
+
     List<StructuredRecord> inputRecords = new ArrayList<>();
     LocalDateTime localDateTime = new Timestamp(CURRENT_TS).toLocalDateTime();
     for (int i = 1; i <= 2; i++) {
       String name = "user" + i;
-      inputRecords.add(StructuredRecord.builder(schema)
+      inputRecords.add(StructuredRecord.builder(SCHEMA)
                          .set("ID", i)
                          .set("NAME", name)
                          .set("SCORE", 3.451f)
                          .set("GRADUATED", (i % 2 == 0))
+                         .set("NOT_IMPORTED", "random" + i)
                          .set("SMALLINT_COL", i + 2)
                          .set("BIG", 3456987L)
                          .setDecimal("NUMERIC_COL", new BigDecimal(3.458d, new MathContext(PRECISION)).setScale(SCALE))
@@ -154,9 +222,32 @@ public class PostgresSinkTestRun extends PostgresPluginTestBase {
                          .setDate("DATE_COL", localDateTime.toLocalDate())
                          .setTime("TIME_COL", localDateTime.toLocalTime())
                          .setTimestamp("TIMESTAMP_COL", localDateTime.atZone(ZoneId.ofOffset("UTC", ZoneOffset.UTC)))
-                         .set("BYTEA_COL", name.getBytes())
-                         .set("CHAR_COL", name)
                          .set("TEXT_COL", name)
+                         .set("CHAR_COL", "char" + i)
+                         .set("BYTEA_COL", name.getBytes(Charsets.UTF_8))
+                         .set("BIT_COL", "1010")
+                         .set("VAR_BIT_COL", "101")
+                         .set("TIMETZ_COL", "03:02:03.456+03")
+                         .setTimestamp("TIMESTAMPTZ_COL", localDateTime.atZone(ZoneId.ofOffset("UTC", ZoneOffset.UTC)))
+                         .set("XML_COL", "<root></root>")
+                         .set("UUID_COL", "e95861c9-1111-40ce-b42b-d6b9d1765c2c")
+                         .set("CIDR_COL", "192.168.0.0/23")
+                         .set("CIRCLE_COL", "<(1.0,2.0),10.0>")
+                         .set("INET_COL", "192.168.1.1")
+                         .set("INTERVAL_COL", "1 day")
+                         .set("JSON_COL", "{\"hello\": \"world\"}")
+                         .set("JSONB_COL", "{\"hello\": \"world\"}")
+                         .set("LINE_COL", "((1.0, 1.0),(2.0, 2.0))")
+                         .set("LSEG_COL", "[(1,1),(2,2)]")
+                         .set("MACADDR_COL", "08:00:2b:01:02:03")
+                         .set("MACADDR8_COL", "08:00:2b:01:02:03:04:05")
+                         .set("MONEY_COL", "1234.12")
+                         .set("PATH_COL", "[(1.0, 1.0),(2.0, 2.0), (3.0, 3.0)]")
+                         .set("POINT_COL" , "(1.0, 1.0)")
+                         .set("POLYGON_COL", "((1.0, 1.0),(2.0, 2.0), (0.0, 5.0))")
+                         .set("TSQUERY_COL", "'fat' & ( 'rat' | 'cat' )")
+                         .set("TSVECTOR_COL", "'a' 'cat' 'fat'")
+                         .set("BOX_COL", "(2,2),(1,1)")
                          .build());
     }
     MockSource.writeInput(inputManager, inputRecords);

--- a/postgresql-plugin/src/test/java/io/cdap/plugin/postgres/PostgresSourceTestRun.java
+++ b/postgresql-plugin/src/test/java/io/cdap/plugin/postgres/PostgresSourceTestRun.java
@@ -88,9 +88,49 @@ public class PostgresSourceTestRun extends PostgresPluginTestBase {
   @Test
   @SuppressWarnings("ConstantConditions")
   public void testDBSource() throws Exception {
-    String importQuery = "SELECT \"ID\", \"NAME\", \"SCORE\", \"GRADUATED\", \"SMALLINT_COL\", \"BIG\", " +
-      "\"NUMERIC_COL\", \"CHAR_COL\", \"DECIMAL_COL\", \"BYTEA_COL\", \"DATE_COL\", \"TIME_COL\", \"TIMESTAMP_COL\", " +
-      "\"TEXT_COL\", \"DOUBLE_PREC_COL\" FROM my_table " +
+    String importQuery = "SELECT " +
+      "\"ID\", " +
+      "\"NAME\", " +
+      "\"SCORE\", " +
+      "\"GRADUATED\", " +
+      "\"SMALLINT_COL\", " +
+      "\"BIG\", " +
+      "\"NUMERIC_COL\", " +
+      "\"CHAR_COL\", " +
+      "\"DECIMAL_COL\", " +
+      "\"BYTEA_COL\", " +
+      "\"DATE_COL\", " +
+      "\"TIME_COL\", " +
+      "\"TIMESTAMP_COL\", " +
+      "\"TEXT_COL\", " +
+      "\"DOUBLE_PREC_COL\", " +
+      "\"BIG_SERIAL_COL\", " +
+      "\"SMALL_SERIAL_COL\", " +
+      "\"SERIAL_COL\", " +
+      "\"BIT_COL\", " +
+      "\"VAR_BIT_COL\", " +
+      "\"TIMETZ_COL\", " +
+      "\"TIMESTAMPTZ_COL\", " +
+      "\"XML_COL\", " +
+      "\"UUID_COL\", " +
+      "\"CIDR_COL\", " +
+      "\"CIRCLE_COL\", " +
+      "\"INET_COL\", " +
+      "\"INTERVAL_COL\", " +
+      "\"JSON_COL\", " +
+      "\"JSONB_COL\", " +
+      "\"LINE_COL\", " +
+      "\"LSEG_COL\", " +
+      "\"MACADDR_COL\", " +
+      "\"MACADDR8_COL\", " +
+      "\"MONEY_COL\", " +
+      "\"PATH_COL\", " +
+      "\"POINT_COL\", " +
+      "\"POLYGON_COL\", " +
+      "\"TSQUERY_COL\", " +
+      "\"TSVECTOR_COL\", " +
+      "\"BOX_COL\" " +
+      "FROM my_table " +
       "WHERE \"ID\" < 3 AND $CONDITIONS";
     String boundingQuery = "SELECT MIN(\"ID\"),MAX(\"ID\") from my_table";
     String splitBy = "ID";
@@ -124,6 +164,14 @@ public class PostgresSourceTestRun extends PostgresPluginTestBase {
 
     // Verify data
     Assert.assertEquals("user1", row1.get("NAME"));
+    Assert.assertEquals(1L, (long) row1.get("BIG_SERIAL_COL"));
+    Assert.assertEquals(1, (int) row1.get("SERIAL_COL"));
+    Assert.assertEquals(1, (int) row1.get("SMALL_SERIAL_COL"));
+    Assert.assertEquals(2L, (long) row2.get("BIG_SERIAL_COL"));
+    Assert.assertEquals(2, (int) row2.get("SERIAL_COL"));
+    Assert.assertEquals(2, (int) row2.get("SMALL_SERIAL_COL"));
+    Assert.assertEquals("1010", row1.get("BIT_COL"));
+    Assert.assertEquals("101", row1.get("VAR_BIT_COL"));
     Assert.assertEquals("user2", row2.get("NAME"));
     Assert.assertEquals("user1", row1.get("TEXT_COL"));
     Assert.assertEquals("user2", row2.get("TEXT_COL"));
@@ -160,10 +208,34 @@ public class PostgresSourceTestRun extends PostgresPluginTestBase {
     Assert.assertEquals(expectedDate, row1.getDate("DATE_COL"));
     Assert.assertEquals(expectedTime, row1.getTime("TIME_COL"));
     Assert.assertEquals(expectedTs, row1.getTimestamp("TIMESTAMP_COL", ZoneId.ofOffset("UTC", ZoneOffset.UTC)));
-
+    Assert.assertEquals("03:02:03.456+03", row1.get("TIMETZ_COL"));
+    Assert.assertEquals(
+      OFFSET_TIME.atZoneSameInstant(ZoneId.ofOffset("UTC", ZoneOffset.UTC)),
+      row1.getTimestamp("TIMESTAMPTZ_COL", ZoneId.ofOffset("UTC", ZoneOffset.UTC))
+    );
     // verify binary columns
     Assert.assertEquals("user1", Bytes.toString(((ByteBuffer) row1.get("BYTEA_COL")).array(), 0, 5));
     Assert.assertEquals("user2", Bytes.toString(((ByteBuffer) row2.get("BYTEA_COL")).array(), 0, 5));
+    // verity string-mapped pg specific types
+    Assert.assertEquals("<root></root>", row2.get("XML_COL"));
+    Assert.assertEquals("e95861c9-1111-40ce-b42b-d6b9d1765c2c", row2.get("UUID_COL"));
+    Assert.assertEquals("192.168.0.0/23", row2.get("CIDR_COL"));
+    Assert.assertEquals("<(1,2),10>", row2.get("CIRCLE_COL"));
+    Assert.assertEquals("192.168.1.1", row2.get("INET_COL"));
+    Assert.assertEquals("1 day", row2.get("INTERVAL_COL"));
+    Assert.assertEquals("{\"hello\": \"world\"}", row2.get("JSON_COL"));
+    Assert.assertEquals("{\"hello\": \"world\"}", row2.get("JSONB_COL"));
+    Assert.assertEquals("{1,-1,0}", row2.get("LINE_COL"));
+    Assert.assertEquals("[(1,1),(2,2)]", row2.get("LSEG_COL"));
+    Assert.assertEquals("08:00:2b:01:02:03", row2.get("MACADDR_COL"));
+    Assert.assertEquals("08:00:2b:01:02:03:04:05", row2.get("MACADDR8_COL"));
+    Assert.assertEquals("$1,234.12", row2.get("MONEY_COL"));
+    Assert.assertEquals("[(1,1),(2,2),(3,3)]", row2.get("PATH_COL"));
+    Assert.assertEquals("(1,1)", row2.get("POINT_COL"));
+    Assert.assertEquals("((1,1),(2,2),(0,5))", row2.get("POLYGON_COL"));
+    Assert.assertEquals("'fat' & ( 'rat' | 'cat' )", row2.get("TSQUERY_COL"));
+    Assert.assertEquals("'a' 'cat' 'fat'", row2.get("TSVECTOR_COL"));
+    Assert.assertEquals("(2,2),(1,1)", row2.get("BOX_COL"));
   }
 
   @Test
@@ -300,7 +372,7 @@ public class PostgresSourceTestRun extends PostgresPluginTestBase {
     ApplicationId appId = NamespaceId.DEFAULT.app("dbSourceNonExistingTest");
     assertRuntimeFailure(appId, etlConfig, DATAPIPELINE_ARTIFACT,
                          "ETL Application with DB Source should have failed because of a " +
-      "non-existent source table.", 1);
+                           "non-existent source table.", 1);
 
     // Bad connection
     ETLPlugin sourceBadConnConfig = new ETLPlugin(
@@ -327,6 +399,6 @@ public class PostgresSourceTestRun extends PostgresPluginTestBase {
       .build();
     assertRuntimeFailure(appId, etlConfig, DATAPIPELINE_ARTIFACT,
                          "ETL Application with DB Source should have failed because of a " +
-      "non-existent source database.", 2);
+                           "non-existent source database.", 2);
   }
 }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15547
WIKI: https://wiki.cask.co/display/CE/PostgreSQL+database+plugin

**In scope of this PR:**

* Added tests for Source plugin for next types:
```
bigint, bigserial, bit(n), bit varying(n), boolean, bytea, character, character varying, double precision, integer, numeric(precision, scale)/decimal(precision, scale), real, smallint, smallserial, serial, text, date, time [ (p) ] [ without time zone ], time [ (p) ] with time zone, timestamp [ (p) ] [ without time zone ], timestamp [ (p) ] with time zone, xml, tsquery, tsvector, uuid, box, cidr, circle, inet, interval, json, jsonb, line, lseg, macaddr, macaddr8, money, path, point, polygon
```
* Added tests for Sink plugin for next types:
```
bigint, bit(n), bit varying(n), boolean, bytea, character, character varying, double precision, integer, numeric(precision, scale)/decimal(precision, scale), real, smallint, text, date, time [ (p) ] [ without time zone ], time [ (p) ] with time zone, timestamp [ (p) ] [ without time zone ], timestamp [ (p) ] with time zone, xml, tsquery, tsvector, uuid, box, cidr, circle, inet, interval, json, jsonb, line, lseg, macaddr, macaddr8, money, path, point, polygon```
```
* Added support of the following types:
```
bit, bit varying, box, cidr, circle, inet, interval, json, jsonb, line, lseg, macaddr, macaddr8, money, path, point, polygon, tsquery, tsvector, uuid, xml
```
* Mappings added to the reference documentation

All PostgreSQL specific types mapped to string and most of them have multiple input formats and one output format. This was reflected in reference documentation.