### PR TITLE
CDAP-15519 Reference doc updates

### DIFF
--- a/mssql-plugin/docs/SqlServer-batchsink.md
+++ b/mssql-plugin/docs/SqlServer-batchsink.md
@@ -88,7 +88,8 @@ Data Types Mapping
     | DATE             | date                   |                                                                |
     | DATETIME         | timestamp              |                                                                |
     | DATETIME2        | timestamp              |                                                                |
-    | DATETIMEOFFSET   | string                 |                                                                |
+    | DATETIMEOFFSET   | string                 |  DATETIMEOFFSET string literal in the following format:        |
+    |                  |                        |  "2019-06-24 16:19:15.8010000 +03:00"                          |
     | DECIMAL          | decimal                |                                                                |
     | FLOAT            | double                 |                                                                |
     | IMAGE            | bytes                  |                                                                |
@@ -126,6 +127,7 @@ Data Types Mapping
     |                  |                        | such as "POINT(3 40 5 6)".                                     |
     | GEOGRAPHY        | string                 | Values of this type can be set from Well Known Text strings,   |
     |                  |                        | such as "POINT(3 40 5 6)".                                     |
+    | TIMESTAMP        |                        | TIMESTAMP data type is not supported for the sink              |
 
 
 Example

--- a/mysql-plugin/docs/Mysql-batchsink.md
+++ b/mysql-plugin/docs/Mysql-batchsink.md
@@ -58,6 +58,42 @@ connections.
 **SQL_MODE:** Override the default SQL_MODE session variable used by the server.
 
 
+Data Types Mapping
+----------
+
+    | MySQL Data Type                | CDAP Schema Data Type | Comment                                            |
+    | ------------------------------ | --------------------- | -------------------------------------------------- |
+    | BIT                            | boolean               |                                                    |
+    | TINYINT                        | int                   |                                                    |
+    | BOOL, BOOLEAN                  | boolean               |                                                    |
+    | SMALLINT                       | int                   |                                                    |
+    | MEDIUMINT                      | double                |                                                    |
+    | INT,INTEGER                    | int                   |                                                    |
+    | BIGINT                         | long                  |                                                    |
+    | FLOAT                          | float                 |                                                    |
+    | DOUBLE                         | double                |                                                    |
+    | DECIMAL                        | decimal               |                                                    |
+    | DATE                           | date                  |                                                    |
+    | DATETIME                       | timestamp             |                                                    |
+    | TIMESTAMP                      | timestamp             |                                                    |
+    | TIME                           | time                  |                                                    |
+    | YEAR                           | date                  |                                                    |
+    | CHAR                           | string                |                                                    |
+    | VARCHAR                        | string                |                                                    |
+    | BINARY                         | bytes                 |                                                    |
+    | VARBINARY                      | bytes                 |                                                    |
+    | TINYBLOB                       | bytes                 |                                                    |
+    | TINYTEXT                       | string                |                                                    |
+    | BLOB                           | bytes                 |                                                    |
+    | TEXT                           | string                |                                                    |
+    | MEDIUMBLOB                     | bytes                 |                                                    |
+    | MEDIUMTEXT                     | string                |                                                    |
+    | LONGBLOB                       | bytes                 |                                                    |
+    | LONGTEXT                       | string                |                                                    |
+    | ENUM                           | string                |                                                    |
+    | SET                            | string                |                                                    |
+
+
 Example
 -------
 Suppose you want to write output records to "users" table of MySQL database named "prod" that is running on "localhost", 

--- a/mysql-plugin/docs/Mysql-batchsource.md
+++ b/mysql-plugin/docs/Mysql-batchsource.md
@@ -74,6 +74,42 @@ connections.
 **SQL_MODE:** Override the default SQL_MODE session variable used by the server.
 
 
+Data Types Mapping
+----------
+
+    | MySQL Data Type                | CDAP Schema Data Type | Comment                                            |
+    | ------------------------------ | --------------------- | -------------------------------------------------- |
+    | BIT                            | boolean               |                                                    |
+    | TINYINT                        | int                   |                                                    |
+    | BOOL, BOOLEAN                  | boolean               |                                                    |
+    | SMALLINT                       | int                   |                                                    |
+    | MEDIUMINT                      | double                |                                                    |
+    | INT,INTEGER                    | int                   |                                                    |
+    | BIGINT                         | long                  |                                                    |
+    | FLOAT                          | float                 |                                                    |
+    | DOUBLE                         | double                |                                                    |
+    | DECIMAL                        | decimal               |                                                    |
+    | DATE                           | date                  |                                                    |
+    | DATETIME                       | timestamp             |                                                    |
+    | TIMESTAMP                      | timestamp             |                                                    |
+    | TIME                           | time                  |                                                    |
+    | YEAR                           | date                  |                                                    |
+    | CHAR                           | string                |                                                    |
+    | VARCHAR                        | string                |                                                    |
+    | BINARY                         | bytes                 |                                                    |
+    | VARBINARY                      | bytes                 |                                                    |
+    | TINYBLOB                       | bytes                 |                                                    |
+    | TINYTEXT                       | string                |                                                    |
+    | BLOB                           | bytes                 |                                                    |
+    | TEXT                           | string                |                                                    |
+    | MEDIUMBLOB                     | bytes                 |                                                    |
+    | MEDIUMTEXT                     | string                |                                                    |
+    | LONGBLOB                       | bytes                 |                                                    |
+    | LONGTEXT                       | string                |                                                    |
+    | ENUM                           | string                |                                                    |
+    | SET                            | string                |                                                    |
+
+
 Example
 ------
 Suppose you want to read data from MySQL database named "prod" that is running on "localhost" port 3306,
@@ -96,9 +132,9 @@ Password: "root"
 For example, if the 'id' column is a primary key of type int and the other columns are
 non-nullable varchars, output records will have this schema:
 
-| field name     | type                |
-| -------------- | ------------------- |
-| id             | int                 |
-| name           | string              |
-| email          | string              |
-| phone          | string              |
+    | field name     | type                |
+    | -------------- | ------------------- |
+    | id             | int                 |
+    | name           | string              |
+    | email          | string              |
+    | phone          | string              |

--- a/netezza-plugin/docs/Netezza-batchsink.md
+++ b/netezza-plugin/docs/Netezza-batchsink.md
@@ -36,6 +36,36 @@ Properties
 **Connection Arguments:** A list of arbitrary string key/value pairs as connection arguments. These arguments
 will be passed to the JDBC driver as connection arguments for JDBC drivers that may need additional configurations.
 
+
+Data Types Mapping
+----------
+
+    | Netezza Data Type              | CDAP Schema Data Type | Comment                                            |
+    | ------------------------------ | --------------------- | -------------------------------------------------- |
+    | BOOLEAN                        | boolean               |                                                    |
+    | BYTEINT                        | int                   |                                                    |
+    | CHAR                           | string                |                                                    |
+    | DATE                           | date                  |                                                    |
+    | NUMERIC, DECIMAL               | decimal               |                                                    |
+    | FLOAT(1-6)                     | float                 | Floating point number with precision of 6 or less  |
+    | FLOAT(7-15)                    | double                | Floating point number with precision of 7 - 15     |
+    | REAL                           | float                 | Equivalent to FLOAT(6)                             |
+    | DOUBLE PRECISION               | double                |                                                    |
+    | INTEGER                        | int                   |                                                    |
+    | SMALLINT                       | int                   |                                                    |
+    | BIGINT                         | long                  |                                                    |
+    | NCHAR                          | string                |                                                    |
+    | NVARCHAR                       | string                |                                                    |
+    | TIME                           | time                  |                                                    |
+    | TIMETZ, TIME WITH TIME ZONE    | string                | Time with time zone string literal in the          |
+    |                                |                       | following format: "13:24:16+03"                    |
+    | TIMESTAMP                      | timestampt            |                                                    |
+    | VARCHAR                        | string                |                                                    |
+    | INTERVAL                       | string                |                                                    |
+    | VARBINARY                      | bytes                 |                                                    |
+    | ST_GEOMETRY                    | bytes                 |                                                    |
+
+
 Example
 -------
 Suppose you want to write output records to "users" table of Netezza database named "prod" that is running on "localhost", 

--- a/netezza-plugin/docs/Netezza-batchsource.md
+++ b/netezza-plugin/docs/Netezza-batchsource.md
@@ -51,6 +51,37 @@ back from the query. However, it must match the schema that comes back from the 
 except it can mark fields as nullable and can contain a subset of the fields.
 
 
+Data Types Mapping
+----------
+
+    | Netezza Data Type              | CDAP Schema Data Type | Comment                                            |
+    | ------------------------------ | --------------------- | -------------------------------------------------- |
+    | BOOLEAN                        | boolean               |                                                    |
+    | BYTEINT                        | int                   |                                                    |
+    | CHAR                           | string                |                                                    |
+    | DATE                           | date                  |                                                    |
+    | NUMERIC, DECIMAL               | decimal               |                                                    |
+    | FLOAT(1-6)                     | float                 | Floating point number with precision of 6 or less  |
+    | FLOAT(7-15)                    | double                | Floating point number with precision of 7 - 15     |
+    | REAL                           | float                 | Equivalent to FLOAT(6)                             |
+    | DOUBLE PRECISION               | double                |                                                    |
+    | INTEGER                        | int                   |                                                    |
+    | SMALLINT                       | int                   |                                                    |
+    | BIGINT                         | long                  |                                                    |
+    | NCHAR                          | string                |                                                    |
+    | NVARCHAR                       | string                |                                                    |
+    | TIME                           | time                  |                                                    |
+    | TIMETZ, TIME WITH TIME ZONE    | string                |                                                    |
+    |                                |                       |                                                    |
+    | TIMESTAMP                      | timestampt            |                                                    |
+    | VARCHAR                        | string                |                                                    |
+    | INTERVAL                       | string                |                                                    |
+    | VARBINARY                      | bytes                 |                                                    |
+    | ST_GEOMETRY                    | bytes                 |                                                    |
+
+
+
+
 Example
 ------
 Suppose you want to read data from Netezza database named "prod" that is running on "localhost" port 5480,
@@ -73,9 +104,9 @@ Password: "testpwsd"
 For example, if the 'id' column is a primary key of type int and the other columns are
 non-nullable varchars, output records will have this schema:
 
-| field name     | type                |
-| -------------- | ------------------- |
-| id             | int                 |
-| name           | string              |
-| email          | string              |
-| phone          | string              |
+    | field name     | type                |
+    | -------------- | ------------------- |
+    | id             | int                 |
+    | name           | string              |
+    | email          | string              |
+    | phone          | string              |

--- a/postgresql-plugin/docs/Postgres-batchsource.md
+++ b/postgresql-plugin/docs/Postgres-batchsource.md
@@ -77,9 +77,9 @@ Password: "postgres"
 For example, if the 'id' column is a primary key of type int and the other columns are
 non-nullable varchars, output records will have this schema:
 
-| field name     | type                |
-| -------------- | ------------------- |
-| id             | int                 |
-| name           | string              |
-| email          | string              |
-| phone          | string              |
+    | field name     | type                |
+    | -------------- | ------------------- |
+    | id             | int                 |
+    | name           | string              |
+    | email          | string              |
+    | phone          | string              |


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15519

In the scope of this PR:
* Missing mappings added to the reference docs for MySQL and Netezza plugins
* Added example of a valid `DATETIMEOFFSET` string value for MS SQL plugin