### PR TITLE
remove snapshot

### DIFF
--- a/aurora-mysql-plugin/pom.xml
+++ b/aurora-mysql-plugin/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <artifactId>database-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.1</version>
   </parent>
 
   <name>Aurora DB MySQL plugin</name>
   <artifactId>aurora-mysql-plugin</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.1</version>
   <modelVersion>4.0.0</modelVersion>
 
   <dependencies>

--- a/aurora-postgresql-plugin/pom.xml
+++ b/aurora-postgresql-plugin/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <artifactId>database-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.1</version>
   </parent>
 
   <name>Aurora DB PostgreSQL plugin</name>
   <artifactId>aurora-postgresql-plugin</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.1</version>
   <modelVersion>4.0.0</modelVersion>
 
   <dependencies>

--- a/cloudsql-mysql-plugin/pom.xml
+++ b/cloudsql-mysql-plugin/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <artifactId>database-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.1</version>
   </parent>
 
   <name>CloudSQL MySQL plugin</name>
   <artifactId>cloudsql-mysql-plugin</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.1</version>
   <modelVersion>4.0.0</modelVersion>
   
   <dependencies>

--- a/cloudsql-postgresql-plugin/pom.xml
+++ b/cloudsql-postgresql-plugin/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <artifactId>database-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.1</version>
   </parent>
 
   <name>CloudSQL PostgreSQL plugin</name>
   <artifactId>cloudsql-postgresql-plugin</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.1</version>
   <modelVersion>4.0.0</modelVersion>
 
   <dependencies>
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>io.cdap.plugin</groupId>
       <artifactId>postgresql-plugin</artifactId>
-      <version>1.4.0-SNAPSHOT</version>
+      <version>1.4.1</version>
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>

--- a/database-commons/pom.xml
+++ b/database-commons/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.1</version>
   </parent>
 
   <name>Database Commons</name>

--- a/db2-plugin/pom.xml
+++ b/db2-plugin/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <artifactId>database-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.1</version>
   </parent>
 
   <name>IBM DB2 plugin</name>
   <artifactId>db2-plugin</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.1</version>
   <modelVersion>4.0.0</modelVersion>
 
   <dependencies>

--- a/generic-database-plugin/pom.xml
+++ b/generic-database-plugin/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <artifactId>database-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.1</version>
   </parent>
 
   <name>Generic database plugin</name>
   <artifactId>generic-database-plugin</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.1</version>
   <modelVersion>4.0.0</modelVersion>
 
   <dependencies>

--- a/memsql-plugin/pom.xml
+++ b/memsql-plugin/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <artifactId>database-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.1</version>
   </parent>
 
   <name>Memsql plugin</name>
   <artifactId>memsql-plugin</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.1</version>
   <modelVersion>4.0.0</modelVersion>
 
   <dependencies>

--- a/mssql-plugin/pom.xml
+++ b/mssql-plugin/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <artifactId>database-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.1</version>
   </parent>
 
   <name>Microsoft SQL Server plugin</name>
   <artifactId>mssql-plugin</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.1</version>
   <modelVersion>4.0.0</modelVersion>
 
   <dependencies>

--- a/mysql-plugin/pom.xml
+++ b/mysql-plugin/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <artifactId>database-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.1</version>
   </parent>
 
   <name>Mysql plugin</name>
   <artifactId>mysql-plugin</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.1</version>
   <modelVersion>4.0.0</modelVersion>
 
   <dependencies>

--- a/netezza-plugin/pom.xml
+++ b/netezza-plugin/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <artifactId>database-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.1</version>
   </parent>
 
   <name>Netezza plugin</name>
   <artifactId>netezza-plugin</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.1</version>
   <modelVersion>4.0.0</modelVersion>
 
   <dependencies>

--- a/oracle-plugin/pom.xml
+++ b/oracle-plugin/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <artifactId>database-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.1</version>
   </parent>
 
   <name>Oracle plugin</name>
   <artifactId>oracle-plugin</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.1</version>
   <modelVersion>4.0.0</modelVersion>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>database-plugins</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.1</version>
   <packaging>pom</packaging>
   <name>Database Plugins</name>
   <description>Collection of database plugins</description>

--- a/postgresql-plugin/pom.xml
+++ b/postgresql-plugin/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <artifactId>database-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.1</version>
   </parent>
 
   <name>PostgreSQL plugin</name>
   <artifactId>postgresql-plugin</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.1</version>
   <modelVersion>4.0.0</modelVersion>
 
   <dependencies>

--- a/saphana-plugin/pom.xml
+++ b/saphana-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.1</version>
   </parent>
 
   <name>SAP HANA plugin</name>


### PR DESCRIPTION
The cloud sql plugins were released as version 1.4.0 from develop. But the branching wasn't set up correctly. So this bumps the version to 1.4.1.