### PR TITLE
PLUGIN-986

### DIFF
--- a/database-commons/src/main/java/io/cdap/plugin/db/batch/sink/AbstractDBSink.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/batch/sink/AbstractDBSink.java
@@ -305,9 +305,10 @@ public abstract class AbstractDBSink extends ReferenceBatchSink<StructuredRecord
           return;
         }
       }
-
-      try (PreparedStatement pStmt = connection.prepareStatement("SELECT * FROM " + dbSinkConfig.getEscapedTableName()
-                                                                   + " WHERE 1 = 0");
+      setColumnsInfo(inputSchema.getFields());
+      try (PreparedStatement pStmt = connection.prepareStatement(String.format("SELECT %s FROM %s WHERE 1 = 0",
+                                                                               dbColumns,
+                                                                               dbSinkConfig.getEscapedTableName()));
            ResultSet rs = pStmt.executeQuery()) {
         getFieldsValidator().validateFields(inputSchema, rs, collector);
       }
@@ -315,8 +316,9 @@ public abstract class AbstractDBSink extends ReferenceBatchSink<StructuredRecord
       LOG.error("Exception while trying to validate schema of database table {} for connection {}.",
                 tableName, connectionString, e);
       collector.addFailure(
-        String.format("Exception while trying to validate schema of database table '%s' for connection '%s'.",
-                      tableName, connectionString), null).withStacktrace(e.getStackTrace());
+        String.format("Exception while trying to validate schema of database table '%s' for connection '%s' with %s",
+                      tableName, connectionString, e.getMessage()),
+        null).withStacktrace(e.getStackTrace());
     }
   }
 


### PR DESCRIPTION
[PLUGIN-986](https://cdap.atlassian.net/browse/PLUGIN-986)

Postgress automatically converts unquoted column names to lowercase in the query which creates problem when the table itself contains columns in CamelCase or UpperCase. To deal with this, we pass the column names in quotes to the query. So, if a table contains column names in lowercase then inputSchema should also have column names in lowercase otherwise plugin validation will fail.

After fix:-
![image](https://user-images.githubusercontent.com/88528384/143080970-e244623b-d127-4019-a2ef-5985349b494d.png)
