### PR TITLE
set Double values to structured record for NUMERIC type when oracle return a double value

### DIFF
--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSourceDBRecord.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSourceDBRecord.java
@@ -212,7 +212,7 @@ public class OracleSourceDBRecord extends DBRecord {
         // This is the only way to differentiate FLOAT/REAL columns from other numeric columns, that based on NUMBER.
         // Since FLOAT is a subtype of the NUMBER data type, 'getColumnType' and 'getColumnTypeName' can not be used.
         if (Double.class.getTypeName().equals(resultSet.getMetaData().getColumnClassName(columnIndex))) {
-          recordBuilder.setDecimal(field.getName(), BigDecimal.valueOf(resultSet.getDouble(columnIndex)));
+          recordBuilder.set(field.getName(), resultSet.getDouble(columnIndex));
         } else {
           // For a Number type without specified precision and scale, precision will be 0 and scale will be -127
           if (precision == 0) {


### PR DESCRIPTION
the value set should match the schema read here :
https://github.com/data-integrations/database-plugins/blob/345c77fced9a472312f7423f01d9b05451ec12d7/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSourceSchemaReader.java#L83