### PR TITLE
use db specific way instead of generic way to get table schema for db  specific plugin (#190)

### DIFF
--- a/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLConnector.java
+++ b/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLConnector.java
@@ -72,13 +72,13 @@ public class CloudSQLMySQLConnector extends AbstractDBSpecificConnector<DBRecord
   }
 
   @Override
-  protected String getTableQuery(DBConnectorPath path) {
-    return String.format("SELECT * FROM `%s`.`%s`", path.getDatabase(), path.getTable());
+  protected String getTableQuery(String database, String schema, String table) {
+    return String.format("SELECT * FROM `%s`.`%s`", database, table);
   }
 
   @Override
-  protected String getTableQuery(DBConnectorPath path, int limit) {
-    return String.format("SELECT * FROM `%s`.`%s` LIMIT %d", path.getDatabase(), path.getTable(), limit);
+  protected String getTableQuery(String database, String schema, String table, int limit) {
+    return String.format("SELECT * FROM `%s`.`%s` LIMIT %d", database, table, limit);
   }
 
   @Override
@@ -95,7 +95,9 @@ public class CloudSQLMySQLConnector extends AbstractDBSpecificConnector<DBRecord
       return;
     }
 
-    properties.put(CloudSQLMySQLSource.CloudSQLMySQLSourceConfig.IMPORT_QUERY, getTableQuery(path));
+    properties.put(CloudSQLMySQLSource.CloudSQLMySQLSourceConfig.IMPORT_QUERY, getTableQuery(path.getDatabase(),
+                                                                                             path.getSchema(),
+                                                                                             path.getTable()));
     properties.put(CloudSQLMySQLSource.CloudSQLMySQLSourceConfig.NUM_SPLITS, "1");
     properties.put(ConnectionConfig.DATABASE, path.getDatabase());
     properties.put(Constants.Reference.REFERENCE_NAME, ReferenceNames.cleanseReferenceName(table));

--- a/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLConnector.java
+++ b/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLConnector.java
@@ -78,13 +78,13 @@ public class CloudSQLPostgreSQLConnector extends AbstractDBSpecificConnector<Pos
   }
 
   @Override
-  protected String getTableQuery(DBConnectorPath path) {
-    return String.format("SELECT * FROM \"%s\".\"%s\"", path.getSchema(), path.getTable());
+  protected String getTableQuery(String database, String schema, String table) {
+    return String.format("SELECT * FROM \"%s\".\"%s\"", schema, table);
   }
 
   @Override
-  protected String getTableQuery(DBConnectorPath path, int limit) {
-    return String.format("SELECT * FROM \"%s\".\"%s\" LIMIT %d", path.getSchema(), path.getTable(), limit);
+  protected String getTableQuery(String database, String schema, String table, int limit) {
+    return String.format("SELECT * FROM \"%s\".\"%s\" LIMIT %d", schema, table, limit);
   }
 
   @Override
@@ -101,7 +101,8 @@ public class CloudSQLPostgreSQLConnector extends AbstractDBSpecificConnector<Pos
       return;
     }
 
-    properties.put(CloudSQLPostgreSQLSource.CloudSQLPostgreSQLSourceConfig.IMPORT_QUERY, getTableQuery(path));
+    properties.put(CloudSQLPostgreSQLSource.CloudSQLPostgreSQLSourceConfig.IMPORT_QUERY,
+                   getTableQuery(path.getDatabase(), path.getSchema(), path.getTable()));
     properties.put(CloudSQLPostgreSQLSource.CloudSQLPostgreSQLSourceConfig.NUM_SPLITS, "1");
     properties.put(ConnectionConfig.DATABASE, path.getDatabase());
     properties.put(Constants.Reference.REFERENCE_NAME, ReferenceNames.cleanseReferenceName(table));

--- a/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnector.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnector.java
@@ -87,7 +87,7 @@ public abstract class AbstractDBSpecificConnector<T extends DBWritable> extends 
       DBConfiguration.configureDB(connectionConfigAccessor.getConfiguration(), driverClass.getName(),
                      getConnectionString(path.getDatabase()), config.getUser(), config.getPassword());
     }
-    String tableQuery = getTableQuery(path, request.getLimit());
+    String tableQuery = getTableQuery(path.getDatabase(), path.getSchema(), path.getTable(), request.getLimit());
     DataDrivenETLDBInputFormat.setInput(connectionConfigAccessor.getConfiguration(), getDBRecordType(),
                                         tableQuery, null, false);
     connectionConfigAccessor.setConnectionArguments(Maps.fromProperties(config.getConnectionArgumentsProperties()));
@@ -115,16 +115,16 @@ public abstract class AbstractDBSpecificConnector<T extends DBWritable> extends 
     return config.getConnectionString();
   }
 
-  protected String getTableQuery(DBConnectorPath path) {
-    return path.getSchema() == null ? String.format("SELECT * FROM \"%s\".\"%s\"", path.getDatabase(), path.getTable())
-      : String.format("SELECT * FROM \"%s\".\"%s\".\"%s\"", path.getDatabase(), path.getSchema(), path.getTable());
+  protected String getTableQuery(String database, String schema, String table) {
+    return schema == null ? String.format("SELECT * FROM \"%s\".\"%s\"", database, table)
+      : String.format("SELECT * FROM \"%s\".\"%s\".\"%s\"", database, schema, table);
   }
 
-  protected String getTableQuery(DBConnectorPath path, int limit) {
-    return path.getSchema() == null ?
-      String.format("SELECT * FROM \"%s\".\"%s\" LIMIT %d", path.getDatabase(), path.getTable(), limit) :
+  protected String getTableQuery(String database, String schema, String table, int limit) {
+    return schema == null ?
+      String.format("SELECT * FROM \"%s\".\"%s\" LIMIT %d", database, table, limit) :
       String.format(
-        "SELECT * FROM \"%s\".\"%s\".\"%s\" LIMIT %d", path.getDatabase(), path.getSchema(), path.getTable(), limit);
+        "SELECT * FROM \"%s\".\"%s\".\"%s\" LIMIT %d", database, schema, table, limit);
   }
 
   protected Schema loadTableSchema(Connection connection, String query) throws SQLException {
@@ -142,5 +142,12 @@ public abstract class AbstractDBSpecificConnector<T extends DBWritable> extends 
     properties.put(ConnectionConfig.USER, rawProperties.get(ConnectionConfig.USER));
     properties.put(ConnectionConfig.PASSWORD, rawProperties.get(ConnectionConfig.PASSWORD));
     properties.put(ConnectionConfig.CONNECTION_ARGUMENTS, rawProperties.get(ConnectionConfig.CONNECTION_ARGUMENTS));
+  }
+
+  @Override
+  protected Schema getTableSchema(Connection connection, String database,
+                                  String schema, String table) throws SQLException {
+
+    return loadTableSchema(getConnection(),  getTableQuery(database, schema, table));
   }
 }

--- a/database-commons/src/test/java/io/cdap/plugin/db/connector/DBSpecificConnectorBaseTest.java
+++ b/database-commons/src/test/java/io/cdap/plugin/db/connector/DBSpecificConnectorBaseTest.java
@@ -265,9 +265,7 @@ public abstract class DBSpecificConnectorBaseTest {
     Map<String, String> properties = pluginSpec.getProperties();
     Assert.assertNull(properties.get(NAME_USE_CONNECTION));
     Assert.assertNull(properties.get(NAME_CONNECTION));
-    Assert.assertEquals(connector.getTableQuery(connector.getDBConnectorPath(schema == null ? database + "/" + table :
-                                                                               database + "/" + schema + "/" + table)),
-                        properties.get(IMPORT_QUERY));
+    Assert.assertEquals(connector.getTableQuery(database, schema, table), properties.get(IMPORT_QUERY));
     properties.put("1", properties.get(NUM_SPLITS));
   }
 

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerConnector.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerConnector.java
@@ -78,7 +78,9 @@ public class SqlServerConnector extends AbstractDBSpecificConnector<SqlServerSou
       return;
     }
 
-    properties.put(SqlServerSource.SqlServerSourceConfig.IMPORT_QUERY, getTableQuery(path));
+    properties.put(SqlServerSource.SqlServerSourceConfig.IMPORT_QUERY, getTableQuery(path.getDatabase(),
+                                                                                     path.getSchema(),
+                                                                                     path.getTable()));
     properties.put(SqlServerSource.SqlServerSourceConfig.NUM_SPLITS, "1");
     properties.put(SqlServerSource.SqlServerSourceConfig.DATABASE, path.getDatabase());
     properties.put(Constants.Reference.REFERENCE_NAME, ReferenceNames.cleanseReferenceName(table));
@@ -96,9 +98,9 @@ public class SqlServerConnector extends AbstractDBSpecificConnector<SqlServerSou
   }
 
   @Override
-  protected String getTableQuery(DBConnectorPath path, int limit) {
+  protected String getTableQuery(String database, String schema, String table, int limit) {
     return String.format(
-      "SELECT TOP(%d) * FROM \"%s\".\"%s\".\"%s\"", limit, path.getDatabase(), path.getSchema(), path.getTable());
+      "SELECT TOP(%d) * FROM \"%s\".\"%s\".\"%s\"", limit, database, schema, table);
   }
 
   @Override

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
@@ -77,7 +77,8 @@ public class MysqlConnector extends AbstractDBSpecificConnector<DBRecord> {
       return;
     }
 
-    properties.put(MysqlSource.MysqlSourceConfig.IMPORT_QUERY, getTableQuery(path));
+    properties.put(MysqlSource.MysqlSourceConfig.IMPORT_QUERY, getTableQuery(path.getDatabase(), path.getSchema(),
+                                                                             path.getTable()));
     properties.put(MysqlSource.MysqlSourceConfig.NUM_SPLITS, "1");
     properties.put(MysqlSource.MysqlSourceConfig.DATABASE, path.getDatabase());
     properties.put(Constants.Reference.REFERENCE_NAME, ReferenceNames.cleanseReferenceName(table));
@@ -85,13 +86,13 @@ public class MysqlConnector extends AbstractDBSpecificConnector<DBRecord> {
   }
 
   @Override
-  protected String getTableQuery(DBConnectorPath path) {
-    return String.format("SELECT * FROM `%s`.`%s`", path.getDatabase(), path.getTable());
+  protected String getTableQuery(String database, String schema, String table) {
+    return String.format("SELECT * FROM `%s`.`%s`", database, table);
   }
 
   @Override
-  protected String getTableQuery(DBConnectorPath path, int limit) {
-    return String.format("SELECT * FROM `%s`.`%s` LIMIT %d", path.getDatabase(), path.getTable(), limit);
+  protected String getTableQuery(String database, String schema, String table, int limit) {
+    return String.format("SELECT * FROM `%s`.`%s` LIMIT %d", database, table, limit);
   }
 
   @Override

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
@@ -83,7 +83,8 @@ public class OracleConnector extends AbstractDBSpecificConnector<OracleSourceDBR
       return;
     }
 
-    properties.put(OracleSource.OracleSourceConfig.IMPORT_QUERY, getTableQuery(path));
+    properties.put(OracleSource.OracleSourceConfig.IMPORT_QUERY, getTableQuery(path.getDatabase(), path.getSchema(),
+                                                                               path.getTable()));
     properties.put(OracleSource.OracleSourceConfig.NUM_SPLITS, "1");
     properties.put(Constants.Reference.REFERENCE_NAME, ReferenceNames.cleanseReferenceName(table));
     properties.put(OracleSink.OracleSinkConfig.TABLE_NAME, table);
@@ -127,13 +128,13 @@ public class OracleConnector extends AbstractDBSpecificConnector<OracleSourceDBR
   }
 
   @Override
-  protected String getTableQuery(DBConnectorPath path) {
-    return String.format("SELECT * from \"%s\".\"%s\"", path.getSchema(), path.getTable());
+  protected String getTableQuery(String database, String schema, String table) {
+    return String.format("SELECT * from \"%s\".\"%s\"", schema, table);
   }
 
   @Override
-  protected String getTableQuery(DBConnectorPath path, int limit) {
-    return String.format("SELECT * FROM \"%s\".\"%s\" WHERE ROWNUM <= %d", path.getSchema(), path.getTable(), limit);
+  protected String getTableQuery(String database, String schema, String table, int limit) {
+    return String.format("SELECT * FROM \"%s\".\"%s\" WHERE ROWNUM <= %d", schema, table, limit);
   }
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -366,8 +366,8 @@
           <version>1.1.0</version>
           <configuration>
             <cdapArtifacts>
-              <parent>system:cdap-data-pipeline[6.5.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
-              <parent>system:cdap-data-streams[6.5.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+              <parent>system:cdap-data-pipeline[6.5.0,7.0.0-SNAPSHOT)</parent>
+              <parent>system:cdap-data-streams[6.5.0,7.0.0-SNAPSHOT)</parent>
             </cdapArtifacts>
           </configuration>
           <executions>

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresConnector.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresConnector.java
@@ -84,7 +84,8 @@ public class PostgresConnector extends AbstractDBSpecificConnector<PostgresDBRec
       return;
     }
 
-    properties.put(PostgresSource.PostgresSourceConfig.IMPORT_QUERY, getTableQuery(path));
+    properties.put(PostgresSource.PostgresSourceConfig.IMPORT_QUERY, getTableQuery(path.getDatabase(),
+                                                                                   path.getSchema(), path.getTable()));
     properties.put(PostgresSource.PostgresSourceConfig.NUM_SPLITS, "1");
     properties.put(Constants.Reference.REFERENCE_NAME, ReferenceNames.cleanseReferenceName(table));
     properties.put(PostgresSink.PostgresSinkConfig.TABLE_NAME, table);
@@ -108,13 +109,14 @@ public class PostgresConnector extends AbstractDBSpecificConnector<PostgresDBRec
     return record.getRecord();
   }
 
-  protected String getTableQuery(DBConnectorPath path) {
-    return String.format("SELECT * FROM \"%s\".\"%s\"", path.getSchema(), path.getTable());
+  @Override
+  protected String getTableQuery(String database, String schema, String table) {
+    return String.format("SELECT * FROM \"%s\".\"%s\"", schema, table);
   }
 
   @Override
-  protected String getTableQuery(DBConnectorPath path, int limit) {
-    return String.format("SELECT * FROM \"%s\".\"%s\" LIMIT %d", path.getSchema(), path.getTable(), limit);
+  protected String getTableQuery(String database, String schema, String table, int limit) {
+    return String.format("SELECT * FROM \"%s\".\"%s\" LIMIT %d", schema, table, limit);
   }
 
 }


### PR DESCRIPTION


use db specific way instead of generic way to get table schema for db specific plugin