### PR TITLE
Use timestamp in gregorian calendar format.

### DIFF
--- a/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
+++ b/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
@@ -37,9 +37,13 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Objects;
+import java.util.TimeZone;
 import javax.annotation.Nullable;
 import javax.management.InstanceNotFoundException;
 import javax.management.IntrospectionException;
@@ -54,6 +58,18 @@ import javax.management.ReflectionException;
  */
 public final class DBUtils {
   private static final Logger LOG = LoggerFactory.getLogger(DBUtils.class);
+
+  private static final Calendar PURE_GREGORIAN_CALENDAR = createPureGregorianCalender();
+
+  // Java by default uses October 15, 1582 as a Gregorian cut over date.
+  // Any timestamp created with time less than this cut over date is treated as Julian date.
+  // This causes old dates from database such as 0001-01-01 01:00:00 mapped to 0000-12-30
+  // Get the pure gregorian calendar so that all dates are treated as gregorian format.
+  private static Calendar createPureGregorianCalender() {
+    GregorianCalendar gc = new GregorianCalendar();
+    gc.setGregorianChange(new Date(Long.MIN_VALUE));
+    return gc;
+  }
 
   /**
    * Performs any Database related cleanup
@@ -116,7 +132,7 @@ public final class DBUtils {
         case Types.TIME:
           return resultSet.getTime(columnIndex);
         case Types.TIMESTAMP:
-          return resultSet.getTimestamp(columnIndex);
+          return resultSet.getTimestamp(columnIndex, PURE_GREGORIAN_CALENDAR);
         case Types.ROWID:
           return resultSet.getString(columnIndex);
         case Types.BLOB:

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnectorConfig.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnectorConfig.java
@@ -58,7 +58,7 @@ public class OracleConnectorConfig extends AbstractDBSpecificConnectorConfig {
     } else if (OracleConstants.SERVICE_CONNECTION_TYPE.equals(getConnectionType())) {
       return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SERVICE_NAME_FORMAT, host, getPort(), database);
     } else {
-      return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SID_FORMAT, host, getPort(),database);
+      return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SID_FORMAT, host, getPort(), database);
     }
   }
 

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConstants.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConstants.java
@@ -34,5 +34,5 @@ public final class OracleConstants {
   public static final String CONNECTION_TYPE = "connectionType";
   public static final String ROLE = "role";
   public static final String NAME_DATABASE = "database";
-  public static final String TNS_CONNECTION_TYPE= "TNS";
+  public static final String TNS_CONNECTION_TYPE = "TNS";
 }


### PR DESCRIPTION
Java by default uses `October 15, 1582` as a Gregorian cutover date. (See details here - https://docs.oracle.com/javase/7/docs/api/java/util/GregorianCalendar.html) Any timestamp created with time less than this cutover date is treated as Julian date. 

As a result when in database we have timestamp values less than gregorian cutover date as `0001-01-01 01:00:00` (inserted with sample query as `insert into hr.ts6 values (5, to_timestamp('0001-01-01 01.00.00.000000 AM','YYYY-MM-DD HH.MI.SS.FF6 AM'));`), when creating java.sql.Timestamp object, java thinks this is julian date for which corresponding gregorian date is `0000-12-30` which is what we see in CDAP for actual date `0001-01-01 01:00:00` in database.

This PR explicitly sets the gregorian date cutover to min value i.e. all timestamps will be treated as gregorian timestamps. With this change we get same value in cdap as that in db without any conversion.

If anyone is using julian dates for some reason in db, workaround for them would be convert them into gregorian before using in cdap. Most db provides sql functions for such conversion.