### PR TITLE
Cherry pick TNS support for Oracle DB and Gregorian calendar fix to release branch.

### DIFF
--- a/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
+++ b/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
@@ -37,9 +37,13 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Objects;
+import java.util.TimeZone;
 import javax.annotation.Nullable;
 import javax.management.InstanceNotFoundException;
 import javax.management.IntrospectionException;
@@ -54,6 +58,18 @@ import javax.management.ReflectionException;
  */
 public final class DBUtils {
   private static final Logger LOG = LoggerFactory.getLogger(DBUtils.class);
+
+  private static final Calendar PURE_GREGORIAN_CALENDAR = createPureGregorianCalender();
+
+  // Java by default uses October 15, 1582 as a Gregorian cut over date.
+  // Any timestamp created with time less than this cut over date is treated as Julian date.
+  // This causes old dates from database such as 0001-01-01 01:00:00 mapped to 0000-12-30
+  // Get the pure gregorian calendar so that all dates are treated as gregorian format.
+  private static Calendar createPureGregorianCalender() {
+    GregorianCalendar gc = new GregorianCalendar();
+    gc.setGregorianChange(new Date(Long.MIN_VALUE));
+    return gc;
+  }
 
   /**
    * Performs any Database related cleanup
@@ -116,7 +132,7 @@ public final class DBUtils {
         case Types.TIME:
           return resultSet.getTime(columnIndex);
         case Types.TIMESTAMP:
-          return resultSet.getTimestamp(columnIndex);
+          return resultSet.getTimestamp(columnIndex, PURE_GREGORIAN_CALENDAR);
         case Types.ROWID:
           return resultSet.getString(columnIndex);
         case Types.BLOB:

--- a/oracle-plugin/docs/Oracle-action.md
+++ b/oracle-plugin/docs/Oracle-action.md
@@ -22,9 +22,12 @@ Properties
 
 **Port:** Port that Oracle is running on.
 
-**SID/Service Name:** Oracle connection point (Database name or Service name).
+**SID/Service Name/TNS Connect Descriptor:** Oracle connection point (Database name, Service name, or a TNS Connect Descriptor). When using TNS, place
+the full TNS Connect Descriptor in the text field. For example:
+(DESCRIPTION =(ADDRESS = (PROTOCOL = TCP)(HOST = 123.123.123.123)(PORT = 1521))(CONNECT_DATA =(SERVER = DEDICATED)
+(SERVICE_NAME = XE)))
 
-**Connection Type** Whether to use an SID or Service Name when connecting to the database.
+**Connection Type** Whether to use an SID, Service Name, or TNS Connect Descriptor when connecting to the database.
 
 **Username:** User identity for connecting to the specified database.
 

--- a/oracle-plugin/docs/Oracle-batchsink.md
+++ b/oracle-plugin/docs/Oracle-batchsink.md
@@ -23,9 +23,12 @@ Properties
 
 **Port:** Port that Oracle is running on.
 
-**SID/Service Name:** Oracle connection point (Database name or Service name).
+**SID/Service Name/TNS Connect Descriptor:** Oracle connection point (Database name, Service name, or a TNS Connect Descriptor). When using TNS, place
+the full TNS Connect Descriptor in the text field. For example:
+(DESCRIPTION =(ADDRESS = (PROTOCOL = TCP)(HOST = 123.123.123.123)(PORT = 1521))(CONNECT_DATA =(SERVER = DEDICATED)
+(SERVICE_NAME = XE)))
 
-**Connection Type** Whether to use an SID or Service Name when connecting to the database.
+**Connection Type** Whether to use an SID, Service Name, or TNS Connect Descriptor when connecting to the database.
 
 **Table Name:** Name of the table to export to.
 

--- a/oracle-plugin/docs/Oracle-batchsource.md
+++ b/oracle-plugin/docs/Oracle-batchsource.md
@@ -24,11 +24,15 @@ Properties
 
 **Port:** Port that Oracle is running on.
 
-**SID/Service Name:** Oracle connection point (Database name or Service name).
+**SID/Service Name/TNS Connect Descriptor:** Oracle connection point (Database name, Service name, or a TNS Connect Descriptor). When using TNS, place
+the full TNS Connect Descriptor in the text field. For example:
+(DESCRIPTION =(ADDRESS = (PROTOCOL = TCP)(HOST = 123.123.123.123)(PORT = 1521))(CONNECT_DATA =(SERVER = DEDICATED)
+(SERVICE_NAME = XE)))
+
+**Connection Type** Whether to use an SID, Service Name, or TNS Connect Descriptor when connecting to the database.
 
 **Role** Login role of the user when connecting to the database.
 
-**Connection Type** Whether to use an SID or Service Name when connecting to the database.
 
 **Import Query:** The SELECT query to use to import data from the specified table.
 You can specify an arbitrary number of columns to import, or import all columns using \*. The Query should

--- a/oracle-plugin/docs/Oracle-connector.md
+++ b/oracle-plugin/docs/Oracle-connector.md
@@ -22,9 +22,12 @@ authentication. Optional for databases that do not require authentication.
 
 **Password:** Password to use to connect to the specified database.
 
-**Connection Type:** Whether to use an SID or Service Name when connecting to the database.
+**SID/Service Name/TNS Connect Descriptor:** Oracle connection point (Database name, Service name, or a TNS Connect Descriptor). When using TNS, place
+the full TNS Connect Descriptor in the text field. For example:
+(DESCRIPTION =(ADDRESS = (PROTOCOL = TCP)(HOST = 123.123.123.123)(PORT = 1521))(CONNECT_DATA =(SERVER = DEDICATED)
+(SERVICE_NAME = XE)))
 
-**SID/Service Name:** Oracle connection point (Database name or Service name).
+**Connection Type** Whether to use an SID, Service Name, or TNS Connect Descriptor when connecting to the database.
 
 **Role:** Login role of the user when connecting to the database.
 

--- a/oracle-plugin/docs/Oracle-postaction.md
+++ b/oracle-plugin/docs/Oracle-postaction.md
@@ -30,9 +30,12 @@ If set to 'failure', the action will only be executed if the pipeline run failed
 
 **Port:** Port that Oracle is running on.
 
-**SID/Service Name:** Oracle connection point (Database name or Service name).
+**SID/Service Name/TNS Connect Descriptor:** Oracle connection point (Database name, Service name, or a TNS Connect Descriptor). When using TNS, place
+the full TNS Connect Descriptor in the text field. For example:
+(DESCRIPTION =(ADDRESS = (PROTOCOL = TCP)(HOST = 123.123.123.123)(PORT = 1521))(CONNECT_DATA =(SERVER = DEDICATED)
+(SERVICE_NAME = XE)))
 
-**Connection Type** Whether to use an SID or Service Name when connecting to the database.
+**Connection Type** Whether to use an SID, Service Name, or TNS Connect Descriptor when connecting to the database.
 
 **Username:** User identity for connecting to the specified database.
 

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleAction.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleAction.java
@@ -57,13 +57,14 @@ public class OracleAction extends AbstractDBAction {
 
     @Override
     public String getConnectionString() {
-      if (OracleConstants.SERVICE_CONNECTION_TYPE.equals(this.connectionType)) {
-        return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SERVICE_NAME_FORMAT,
-                             host, port, database);
+      if (OracleConstants.TNS_CONNECTION_TYPE.equals(this.connectionType)) {
+        return String.format(OracleConstants.ORACLE_CONNECTION_STRING_TNS_FORMAT, database);
+      } else if (OracleConstants.SERVICE_CONNECTION_TYPE.equals(this.connectionType)) {
+        return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SERVICE_NAME_FORMAT, host, port, database);
+      } else {
+        return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SID_FORMAT, host, port, database);
       }
-      return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SID_FORMAT, host, port, database);
     }
-
 
     @Override
     protected Map<String, String> getDBSpecificArguments() {

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
@@ -115,12 +115,15 @@ public class OracleConnector extends AbstractDBSpecificConnector<OracleSourceDBR
     if (database == null) {
       return config.getConnectionString();
     }
-    if (OracleConstants.SERVICE_CONNECTION_TYPE.equals(config)) {
+    if (OracleConstants.TNS_CONNECTION_TYPE.equals(config.getConnectionType())) {
+      return String.format(OracleConstants.ORACLE_CONNECTION_STRING_TNS_FORMAT, database);
+    } else if (OracleConstants.SERVICE_CONNECTION_TYPE.equals(config.getConnectionType())) {
       return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SERVICE_NAME_FORMAT, config.getHost(),
-                           config.getPort(), database);
+              config.getPort(), database);
+    } else {
+      return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SID_FORMAT,
+              config.getHost(), config.getPort(), database);
     }
-    return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SID_FORMAT,
-                         config.getHost(), config.getPort(), database);
   }
 
   @Override

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnectorConfig.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnectorConfig.java
@@ -58,7 +58,7 @@ public class OracleConnectorConfig extends AbstractDBSpecificConnectorConfig {
     } else if (OracleConstants.SERVICE_CONNECTION_TYPE.equals(getConnectionType())) {
       return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SERVICE_NAME_FORMAT, host, getPort(), database);
     } else {
-      return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SID_FORMAT, host, getPort(),database);
+      return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SID_FORMAT, host, getPort(), database);
     }
   }
 

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnectorConfig.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnectorConfig.java
@@ -53,10 +53,13 @@ public class OracleConnectorConfig extends AbstractDBSpecificConnectorConfig {
 
   @Override
   public String getConnectionString() {
-    if (OracleConstants.SERVICE_CONNECTION_TYPE.equals(connectionType)) {
+    if (OracleConstants.TNS_CONNECTION_TYPE.equals(getConnectionType())) {
+      return String.format(OracleConstants.ORACLE_CONNECTION_STRING_TNS_FORMAT, database);
+    } else if (OracleConstants.SERVICE_CONNECTION_TYPE.equals(getConnectionType())) {
       return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SERVICE_NAME_FORMAT, host, getPort(), database);
+    } else {
+      return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SID_FORMAT, host, getPort(),database);
     }
-    return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SID_FORMAT, host, getPort(), database);
   }
 
   @Name(OracleConstants.CONNECTION_TYPE)
@@ -105,5 +108,4 @@ public class OracleConnectorConfig extends AbstractDBSpecificConnectorConfig {
     return ROLE_NORMAL.equals(getRole()) ? null :
       TransactionIsolationLevel.Level.TRANSACTION_READ_COMMITTED.name();
   }
-
 }

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConstants.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConstants.java
@@ -34,5 +34,5 @@ public final class OracleConstants {
   public static final String CONNECTION_TYPE = "connectionType";
   public static final String ROLE = "role";
   public static final String NAME_DATABASE = "database";
-  public static final String TNS_CONNECTION_TYPE= "TNS";
+  public static final String TNS_CONNECTION_TYPE = "TNS";
 }

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConstants.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConstants.java
@@ -27,10 +27,12 @@ public final class OracleConstants {
   public static final String PLUGIN_NAME = "Oracle";
   public static final String ORACLE_CONNECTION_STRING_SID_FORMAT = "jdbc:oracle:thin:@%s:%s:%s";
   public static final String ORACLE_CONNECTION_STRING_SERVICE_NAME_FORMAT = "jdbc:oracle:thin:@//%s:%s/%s";
+  public static final String ORACLE_CONNECTION_STRING_TNS_FORMAT = "jdbc:oracle:thin:@%s";
   public static final String DEFAULT_BATCH_VALUE = "defaultBatchValue";
   public static final String DEFAULT_ROW_PREFETCH = "defaultRowPrefetch";
   public static final String SERVICE_CONNECTION_TYPE = "service";
   public static final String CONNECTION_TYPE = "connectionType";
   public static final String ROLE = "role";
   public static final String NAME_DATABASE = "database";
+  public static final String TNS_CONNECTION_TYPE= "TNS";
 }

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OraclePostAction.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OraclePostAction.java
@@ -57,11 +57,13 @@ public class OraclePostAction extends AbstractQueryAction {
 
     @Override
     public String getConnectionString() {
-      if (OracleConstants.SERVICE_CONNECTION_TYPE.equals(this.connectionType)) {
-        return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SERVICE_NAME_FORMAT,
-                             host, port, database);
+      if (OracleConstants.TNS_CONNECTION_TYPE.equals(this.connectionType)) {
+        return String.format(OracleConstants.ORACLE_CONNECTION_STRING_TNS_FORMAT, database);
+      } else if (OracleConstants.SERVICE_CONNECTION_TYPE.equals(this.connectionType)) {
+        return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SERVICE_NAME_FORMAT, host, port, database);
+      } else {
+        return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SID_FORMAT, host, port, database);
       }
-      return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SID_FORMAT, host, port, database);
     }
 
     @Override

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSink.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSink.java
@@ -76,11 +76,14 @@ public class OracleSink extends AbstractDBSink {
 
     @Override
     public String getConnectionString() {
-      if (OracleConstants.SERVICE_CONNECTION_TYPE.equals(this.connectionType)) {
-        return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SERVICE_NAME_FORMAT,
-                             host, port, database);
+      if (OracleConstants.TNS_CONNECTION_TYPE.equals(this.connectionType)) {
+        return String.format(OracleConstants.ORACLE_CONNECTION_STRING_TNS_FORMAT, database);
+
+      } else if (OracleConstants.SERVICE_CONNECTION_TYPE.equals(this.connectionType)) {
+        return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SERVICE_NAME_FORMAT, host, port, database);
+      } else {
+        return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SID_FORMAT, host, port, database);
       }
-      return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SID_FORMAT, host, port, database);
     }
 
     @Override

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSource.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSource.java
@@ -95,12 +95,15 @@ public class OracleSource extends AbstractDBSource<OracleSource.OracleSourceConf
 
     @Override
     public String getConnectionString() {
-      if (OracleConstants.SERVICE_CONNECTION_TYPE.equals(connection.getConnectionType())) {
+      if (OracleConstants.TNS_CONNECTION_TYPE.equals(connection.getConnectionType())) {
+        return String.format(OracleConstants.ORACLE_CONNECTION_STRING_TNS_FORMAT, connection.getDatabase());
+      } else if (OracleConstants.SERVICE_CONNECTION_TYPE.equals(connection.getConnectionType())) {
         return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SERVICE_NAME_FORMAT, connection.getHost(),
-                             connection.getPort(), connection.getDatabase());
+                connection.getPort(), connection.getDatabase());
+      } else {
+        return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SID_FORMAT,
+                connection.getHost(), connection.getPort(), connection.getDatabase());
       }
-      return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SID_FORMAT,
-                           connection.getHost(), connection.getPort(), connection.getDatabase());
     }
 
     @Override

--- a/oracle-plugin/widgets/Oracle-action.json
+++ b/oracle-plugin/widgets/Oracle-action.json
@@ -46,13 +46,18 @@
               {
                 "id": "service",
                 "label": "Service Name"
+              },
+              {
+                "id": "TNS",
+                "label": "TNS Connect Descriptor"
               }
             ]
           }
         },
         {
           "widget-type": "textbox",
-          "label": "SID/Service Name",
+          "label": "SID/Service Name/TNS Connect Descriptor",
+          "description": "Oracle connection point (Database name, Service name, or TNS Connect Descriptor)",
           "name": "database"
         },
         {

--- a/oracle-plugin/widgets/Oracle-batchsink.json
+++ b/oracle-plugin/widgets/Oracle-batchsink.json
@@ -54,13 +54,18 @@
               {
                 "id": "service",
                 "label": "Service Name"
+              },
+              {
+                "id": "TNS",
+                "label": "TNS Connect Descriptor"
               }
             ]
           }
         },
         {
           "widget-type": "textbox",
-          "label": "SID/Service Name",
+          "label": "SID/Service Name/TNS Connect Descriptor",
+          "description": "Oracle connection point (Database name, Service name, or TNS Connect Descriptor)",
           "name": "database"
         },
         {

--- a/oracle-plugin/widgets/Oracle-batchsource.json
+++ b/oracle-plugin/widgets/Oracle-batchsource.json
@@ -94,14 +94,18 @@
               {
                 "id": "service",
                 "label": "Service Name"
+              },
+              {
+                "id": "TNS",
+                "label": "TNS Connect Descriptor"
               }
             ]
           }
         },
         {
           "widget-type": "textbox",
-          "label": "SID/Service Name",
-          "description": "Oracle connection point (Database name or Service name)",
+          "label": "SID/Service Name/TNS Connect Descriptor",
+          "description": "Oracle connection point (Database name, Service name, or TNS Connect Descriptor)",
           "name": "database"
         },
         {

--- a/oracle-plugin/widgets/Oracle-connector.json
+++ b/oracle-plugin/widgets/Oracle-connector.json
@@ -46,13 +46,18 @@
               {
                 "id": "service",
                 "label": "Service Name"
+              },
+              {
+                "id": "TNS",
+                "label": "TNS Connect Descriptor"
               }
             ]
           }
         },
         {
           "widget-type": "textbox",
-          "label": "SID/Service Name",
+          "label": "SID/Service Name/TNS Connect Descriptor",
+          "description": "Oracle connection point (Database name, Service name, or TNS Connect Descriptor)",
           "name": "database"
         }
       ]

--- a/oracle-plugin/widgets/Oracle-postaction.json
+++ b/oracle-plugin/widgets/Oracle-postaction.json
@@ -58,13 +58,18 @@
               {
                 "id": "service",
                 "label": "Service Name"
+              },
+              {
+                "id": "TNS",
+                "label": "TNS Connect Descriptor"
               }
             ]
           }
         },
         {
           "widget-type": "textbox",
-          "label": "SID/Service Name",
+          "label": "SID/Service Name/TNS Connect Descriptor",
+          "description": "Oracle connection point (Database name, Service name, or TNS Connect Descriptor)",
           "name": "database"
         },
         {


### PR DESCRIPTION
This PR cherry-picks two changes in their own separate commits:
1. First commit (support for TNS name) is cherrypicking change from PR #212 which was originally meant for release/1.6 branch but was accidentally merged into branch with the name `release-1.6.2`

2. Second commit (support for pure gregorian calendar) is cherrypicking change from PR #224 to release/1.6 branch.