### PR TITLE
Create calendar with UTC as timezone.

### DIFF
--- a/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
+++ b/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
@@ -66,7 +66,7 @@ public final class DBUtils {
   // This causes old dates from database such as 0001-01-01 01:00:00 mapped to 0000-12-30
   // Get the pure gregorian calendar so that all dates are treated as gregorian format.
   private static Calendar createPureGregorianCalender() {
-    GregorianCalendar gc = new GregorianCalendar();
+    GregorianCalendar gc = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
     gc.setGregorianChange(new Date(Long.MIN_VALUE));
     return gc;
   }


### PR DESCRIPTION
Since timestamps in database are timezone independent, use `UTC` to retrieve them without relying on machine timezone. 