### PR TITLE
[CDAP-18170] Change JDBC Driver Name to required for all databases

### DIFF
--- a/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBConnectorConfig.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBConnectorConfig.java
@@ -40,7 +40,6 @@ public abstract class AbstractDBConnectorConfig extends PluginConfig implements 
   @Name(ConnectionConfig.JDBC_PLUGIN_NAME)
   @Description("Name of the JDBC driver to use. This is the value of the 'jdbcPluginName' key defined in the JSON " +
     "file for the JDBC plugin.")
-  @Nullable
   @Macro
   protected String jdbcPluginName;
 

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnectorConfig.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnectorConfig.java
@@ -16,9 +16,14 @@
 
 package io.cdap.plugin.mysql;
 
+import io.cdap.cdap.api.annotation.Description;
+import io.cdap.cdap.api.annotation.Macro;
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.plugin.db.ConnectionConfig;
 import io.cdap.plugin.db.connector.AbstractDBSpecificConnectorConfig;
-
 import java.util.Properties;
+import javax.annotation.Nullable;
+
 
 /**
  * Configuration for Mysql Connector
@@ -36,9 +41,14 @@ public class MysqlConnectorConfig extends AbstractDBSpecificConnectorConfig {
     this.port = port;
     this.user = user;
     this.password = password;
-    this.jdbcPluginName = jdbcPluginName;
     this.connectionArguments = connectionArguments;
   }
+
+  @Name(ConnectionConfig.JDBC_PLUGIN_NAME)
+  @Description("Name of the JDBC driver to use. This is the value of the 'jdbcPluginName' key defined in the JSON " +
+          "file for the JDBC plugin.")
+  @Macro
+  private String jdbcPluginName;
 
   @Override
   public String getConnectionString() {
@@ -48,6 +58,11 @@ public class MysqlConnectorConfig extends AbstractDBSpecificConnectorConfig {
   @Override
   public int getDefaultPort() {
     return 3306;
+  }
+
+  @Override
+  public String getJdbcPluginName() {
+    return jdbcPluginName;
   }
 
   @Override

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnectorConfig.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnectorConfig.java
@@ -16,14 +16,9 @@
 
 package io.cdap.plugin.mysql;
 
-import io.cdap.cdap.api.annotation.Description;
-import io.cdap.cdap.api.annotation.Macro;
-import io.cdap.cdap.api.annotation.Name;
-import io.cdap.plugin.db.ConnectionConfig;
 import io.cdap.plugin.db.connector.AbstractDBSpecificConnectorConfig;
-import java.util.Properties;
-import javax.annotation.Nullable;
 
+import java.util.Properties;
 
 /**
  * Configuration for Mysql Connector
@@ -41,14 +36,9 @@ public class MysqlConnectorConfig extends AbstractDBSpecificConnectorConfig {
     this.port = port;
     this.user = user;
     this.password = password;
+    this.jdbcPluginName = jdbcPluginName;
     this.connectionArguments = connectionArguments;
   }
-
-  @Name(ConnectionConfig.JDBC_PLUGIN_NAME)
-  @Description("Name of the JDBC driver to use. This is the value of the 'jdbcPluginName' key defined in the JSON " +
-          "file for the JDBC plugin.")
-  @Macro
-  private String jdbcPluginName;
 
   @Override
   public String getConnectionString() {
@@ -58,11 +48,6 @@ public class MysqlConnectorConfig extends AbstractDBSpecificConnectorConfig {
   @Override
   public int getDefaultPort() {
     return 3306;
-  }
-
-  @Override
-  public String getJdbcPluginName() {
-    return jdbcPluginName;
   }
 
   @Override


### PR DESCRIPTION
# [CDAP-18170] Change JDBC Driver Name to required for all databases

## Description
Change JDBC Driver Name field to be required. If empty when clicking Test Connection, UI will prompt alerts and prevent the request

## Links
[CDAP-18170](https://cdap.atlassian.net/browse/CDAP-18170)

## Screenshots
<img width="1188" alt="image" src="https://user-images.githubusercontent.com/98125204/158694659-ed6b2f2c-4381-40fc-a5d2-5b7b5004fa67.png">
