### PR TITLE
fix(PLUGIN-1281): fix the authenticationType typo

### DIFF
--- a/mssql-plugin/widgets/SqlServer-action.json
+++ b/mssql-plugin/widgets/SqlServer-action.json
@@ -48,7 +48,7 @@
       "properties": [
         {
           "label": "Authentication Type",
-          "name": "authentication",
+          "name": "authenticationType",
           "widget-type": "radio-group",
           "widget-attributes": {
             "layout": "inline",


### PR DESCRIPTION
The "authentication" label in "Credentials" missed the Type postfix, which made the UI infer a generic unresolved `authenticationType` property

Before:
![image](https://user-images.githubusercontent.com/20428112/171474222-3829bb78-f88e-46c0-b2bc-deeebda4574a.png)

After:
![image](https://user-images.githubusercontent.com/20428112/171474242-589c8dbd-69d3-4408-9dc6-20b4bd49d011.png)
