### PR TITLE
Refactor getTableQuery() in DB connectors to use getTableName()

### DIFF
--- a/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLConnector.java
+++ b/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLConnector.java
@@ -72,13 +72,8 @@ public class CloudSQLMySQLConnector extends AbstractDBSpecificConnector<DBRecord
   }
 
   @Override
-  protected String getTableQuery(String database, String schema, String table) {
-    return String.format("SELECT * FROM `%s`.`%s`", database, table);
-  }
-
-  @Override
-  protected String getTableQuery(String database, String schema, String table, int limit) {
-    return String.format("SELECT * FROM `%s`.`%s` LIMIT %d", database, table, limit);
+  protected String getTableName(String database, String schema, String table) {
+    return String.format("`%s`.`%s`", database, table);
   }
 
   @Override

--- a/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLConnector.java
+++ b/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLConnector.java
@@ -84,13 +84,8 @@ public class CloudSQLPostgreSQLConnector extends AbstractDBSpecificConnector<Pos
   }
 
   @Override
-  protected String getTableQuery(String database, String schema, String table) {
-    return String.format("SELECT * FROM \"%s\".\"%s\"", schema, table);
-  }
-
-  @Override
-  protected String getTableQuery(String database, String schema, String table, int limit) {
-    return String.format("SELECT * FROM \"%s\".\"%s\" LIMIT %d", schema, table, limit);
+  protected String getTableName(String database, String schema, String table) {
+    return String.format("\"%s\".\"%s\"", schema, table);
   }
 
   @Override

--- a/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnector.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnector.java
@@ -117,16 +117,19 @@ public abstract class AbstractDBSpecificConnector<T extends DBWritable> extends 
     return config.getConnectionString();
   }
 
+  protected String getTableName(String database, String schema, String table) {
+    return schema == null ? String.format("\"%s\".\"%s\"", database, table)
+      : String.format("\"%s\".\"%s\".\"%s\"", database, schema, table);
+  }
+
   protected String getTableQuery(String database, String schema, String table) {
-    return schema == null ? String.format("SELECT * FROM \"%s\".\"%s\"", database, table)
-      : String.format("SELECT * FROM \"%s\".\"%s\".\"%s\"", database, schema, table);
+    String tableName = getTableName(database, schema, table);
+    return String.format("SELECT * FROM %s", tableName);
   }
 
   protected String getTableQuery(String database, String schema, String table, int limit) {
-    return schema == null ?
-      String.format("SELECT * FROM \"%s\".\"%s\" LIMIT %d", database, table, limit) :
-      String.format(
-        "SELECT * FROM \"%s\".\"%s\".\"%s\" LIMIT %d", database, schema, table, limit);
+    String tableName = getTableName(database, schema, table);
+    return String.format("SELECT * FROM %s LIMIT %d", tableName, limit);
   }
 
   protected Schema loadTableSchema(Connection connection, String query) throws SQLException {

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerConnector.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerConnector.java
@@ -112,8 +112,9 @@ public class SqlServerConnector extends AbstractDBSpecificConnector<SqlServerSou
 
   @Override
   protected String getTableQuery(String database, String schema, String table, int limit) {
+    String tableName = getTableName(database, schema, table);
     return String.format(
-      "SELECT TOP(%d) * FROM \"%s\".\"%s\".\"%s\"", limit, database, schema, table);
+      "SELECT TOP(%d) * FROM %s", limit, tableName);
   }
 
   @Override

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
@@ -87,13 +87,8 @@ public class MysqlConnector extends AbstractDBSpecificConnector<DBRecord> {
   }
 
   @Override
-  protected String getTableQuery(String database, String schema, String table) {
-    return String.format("SELECT * FROM `%s`.`%s`", database, table);
-  }
-
-  @Override
-  protected String getTableQuery(String database, String schema, String table, int limit) {
-    return String.format("SELECT * FROM `%s`.`%s` LIMIT %d", database, table, limit);
+  protected String getTableName(String database, String schema, String table) {
+    return String.format("`%s`.`%s`", database, table);
   }
 
   @Override

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
@@ -134,13 +134,14 @@ public class OracleConnector extends AbstractDBSpecificConnector<OracleSourceDBR
   }
 
   @Override
-  protected String getTableQuery(String database, String schema, String table) {
-    return String.format("SELECT * from \"%s\".\"%s\"", schema, table);
+  protected String getTableName(String database, String schema, String table) {
+    return String.format("\"%s\".\"%s\"", schema, table);
   }
 
   @Override
   protected String getTableQuery(String database, String schema, String table, int limit) {
-    return String.format("SELECT * FROM \"%s\".\"%s\" WHERE ROWNUM <= %d", schema, table, limit);
+    String tableName = getTableName(database, schema, table);
+    return String.format("SELECT * FROM %s WHERE ROWNUM <= %d", tableName, limit);
   }
 
   @Override

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresConnector.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresConnector.java
@@ -112,13 +112,8 @@ public class PostgresConnector extends AbstractDBSpecificConnector<PostgresDBRec
   }
 
   @Override
-  protected String getTableQuery(String database, String schema, String table) {
-    return String.format("SELECT * FROM \"%s\".\"%s\"", schema, table);
-  }
-
-  @Override
-  protected String getTableQuery(String database, String schema, String table, int limit) {
-    return String.format("SELECT * FROM \"%s\".\"%s\" LIMIT %d", schema, table, limit);
+  protected String getTableName(String database, String schema, String table) {
+    return String.format("\"%s\".\"%s\"", schema, table);
   }
 
 }


### PR DESCRIPTION
# Refactor getTableQuery() in DB connectors to use getTableName()

## Description
Fixed `getTableQuery()` function in all database connectors within this repository to refer to an added `getTableName()` function instead of using the previous hardcoded table name within each connector's `getTableQuery()` SQL query. The way in which this was refactored should be backwards compatible (so shouldn't affect the behavior of any other functions/classes that rely on `getTableQuery()` or extend any of the connectors changed).

*This PR has been merged into PR #285*

## PR Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [x] General Improvement
- [ ] Cherry Pick

## Links
Jira: none