### PR TITLE
[CDAP-19417] Fix classloading conflicts for DB Plugins

### DIFF
--- a/aurora-mysql-plugin/pom.xml
+++ b/aurora-mysql-plugin/pom.xml
@@ -90,6 +90,35 @@
         <groupId>io.cdap</groupId>
         <artifactId>cdap-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>5.1.2</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <_exportcontents>
+              io.cdap.plugin.auroradb.mysql.*;
+              io.cdap.plugin.db.batch.source.*;
+              io.cdap.plugin.db.batch.sink.*;
+              org.apache.commons.lang;
+              org.apache.commons.logging.*;
+              org.codehaus.jackson.*
+            </_exportcontents>
+            <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+            <Embed-Transitive>true</Embed-Transitive>
+            <Embed-Directory>lib</Embed-Directory>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/aurora-postgresql-plugin/pom.xml
+++ b/aurora-postgresql-plugin/pom.xml
@@ -90,6 +90,35 @@
         <groupId>io.cdap</groupId>
         <artifactId>cdap-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>5.1.2</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <_exportcontents>
+              io.cdap.plugin.auroradb.postgres.*;
+              io.cdap.plugin.db.batch.source.*;
+              io.cdap.plugin.db.batch.sink.*;
+              org.apache.commons.lang;
+              org.apache.commons.logging.*;
+              org.codehaus.jackson.*
+            </_exportcontents>
+            <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+            <Embed-Transitive>true</Embed-Transitive>
+            <Embed-Directory>lib</Embed-Directory>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/cloudsql-mysql-plugin/pom.xml
+++ b/cloudsql-mysql-plugin/pom.xml
@@ -115,6 +115,35 @@
         <groupId>io.cdap</groupId>
         <artifactId>cdap-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>5.1.2</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <_exportcontents>
+              io.cdap.plugin.cloudsql.mysql.*;
+              io.cdap.plugin.db.batch.source.*;
+              io.cdap.plugin.db.batch.sink.*;
+              org.apache.commons.lang;
+              org.apache.commons.logging.*;
+              org.codehaus.jackson.*
+            </_exportcontents>
+            <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+            <Embed-Transitive>true</Embed-Transitive>
+            <Embed-Directory>lib</Embed-Directory>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/cloudsql-postgresql-plugin/pom.xml
+++ b/cloudsql-postgresql-plugin/pom.xml
@@ -125,6 +125,35 @@
         <groupId>io.cdap</groupId>
         <artifactId>cdap-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>5.1.2</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <_exportcontents>
+              io.cdap.plugin.cloudsql.postgres.*;
+              io.cdap.plugin.db.batch.source.*;
+              io.cdap.plugin.db.batch.sink.*;
+              org.apache.commons.lang;
+              org.apache.commons.logging.*;
+              org.codehaus.jackson.*
+            </_exportcontents>
+            <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+            <Embed-Transitive>true</Embed-Transitive>
+            <Embed-Directory>lib</Embed-Directory>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/db2-plugin/pom.xml
+++ b/db2-plugin/pom.xml
@@ -90,6 +90,35 @@
         <groupId>io.cdap</groupId>
         <artifactId>cdap-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>5.1.2</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <_exportcontents>
+              io.cdap.plugin.db2.*
+              io.cdap.plugin.db.batch.source.*;
+              io.cdap.plugin.db.batch.sink.*;
+              org.apache.commons.lang;
+              org.apache.commons.logging.*;
+              org.codehaus.jackson.*
+            </_exportcontents>
+            <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+            <Embed-Transitive>true</Embed-Transitive>
+            <Embed-Directory>lib</Embed-Directory>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generic-database-plugin/pom.xml
+++ b/generic-database-plugin/pom.xml
@@ -89,6 +89,32 @@
         <groupId>io.cdap</groupId>
         <artifactId>cdap-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>5.1.2</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <_exportcontents>
+              io.cdap.plugin.jdbc.*;
+              io.cdap.plugin.db.batch.source.*;
+              io.cdap.plugin.db.batch.sink.*;
+            </_exportcontents>
+            <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+            <Embed-Transitive>true</Embed-Transitive>
+            <Embed-Directory>lib</Embed-Directory>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/generic-db-argument-setter/pom.xml
+++ b/generic-db-argument-setter/pom.xml
@@ -89,6 +89,35 @@
         <groupId>io.cdap</groupId>
         <artifactId>cdap-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>5.1.2</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <_exportcontents>
+              io.cdap.plugin.jdbc.*;
+              io.cdap.plugin.db.batch.source.*;
+              io.cdap.plugin.db.batch.sink.*;
+              org.apache.commons.lang;
+              org.apache.commons.logging.*;
+              org.codehaus.jackson.*
+            </_exportcontents>
+            <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+            <Embed-Transitive>true</Embed-Transitive>
+            <Embed-Directory>lib</Embed-Directory>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/mariadb-plugin/pom.xml
+++ b/mariadb-plugin/pom.xml
@@ -90,6 +90,35 @@
                 <groupId>io.cdap</groupId>
                 <artifactId>cdap-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>5.1.2</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <_exportcontents>
+                            io.cdap.plugin.mariadb.*;
+                            io.cdap.plugin.db.batch.source.*;
+                            io.cdap.plugin.db.batch.sink.*;
+                            org.apache.commons.lang;
+                            org.apache.commons.logging.*;
+                            org.codehaus.jackson.*
+                        </_exportcontents>
+                        <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+                        <Embed-Transitive>true</Embed-Transitive>
+                        <Embed-Directory>lib</Embed-Directory>
+                    </instructions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>bundle</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/memsql-plugin/pom.xml
+++ b/memsql-plugin/pom.xml
@@ -90,16 +90,31 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+        <version>5.1.2</version>
+        <extensions>true</extensions>
         <configuration>
           <instructions>
             <_exportcontents>
-              io.cdap.plugin.*
+              io.cdap.plugin.memsql.*;
+              io.cdap.plugin.db.batch.source.*;
+              io.cdap.plugin.db.batch.sink.*;
+              org.apache.commons.lang;
+              org.apache.commons.logging.*;
+              org.codehaus.jackson.*
             </_exportcontents>
             <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>
             <Embed-Directory>lib</Embed-Directory>
           </instructions>
         </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>io.cdap</groupId>

--- a/mssql-plugin/pom.xml
+++ b/mssql-plugin/pom.xml
@@ -100,20 +100,28 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+        <version>5.1.2</version>
+        <extensions>true</extensions>
         <configuration>
           <instructions>
             <_exportcontents>
-              io.cdap.plugin.*;
-              org.apache.commons.lang;
-              org.apache.commons.logging.*;
-              org.codehaus.jackson.*;
-              com.microsoft.aad.*
+              io.cdap.plugin.mssql.*;
+              io.cdap.plugin.db.batch.source.*;
+              io.cdap.plugin.db.batch.sink.*;
             </_exportcontents>
             <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>
             <Embed-Directory>lib</Embed-Directory>
           </instructions>
         </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>io.cdap</groupId>

--- a/mysql-plugin/pom.xml
+++ b/mysql-plugin/pom.xml
@@ -92,6 +92,32 @@
     <testSourceDirectory>${testSourceLocation}</testSourceDirectory>
     <plugins>
       <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>5.1.2</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <_exportcontents>
+              io.cdap.plugin.mysql.*;
+              io.cdap.plugin.db.batch.source.*;
+              io.cdap.plugin.db.batch.sink.*;
+            </_exportcontents>
+            <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+            <Embed-Transitive>true</Embed-Transitive>
+            <Embed-Directory>lib</Embed-Directory>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>io.cdap</groupId>
         <artifactId>cdap-maven-plugin</artifactId>
       </plugin>

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
@@ -45,7 +45,7 @@ import java.util.Map;
 @Name(MysqlConnector.NAME)
 @Description("Connection to access data in Mysql databases using JDBC.")
 @Category("Database")
-public class MysqlConnector extends AbstractDBSpecificConnector<DBRecord> {
+public class MysqlConnector extends AbstractDBSpecificConnector<MysqlDBRecord> {
   public static final String NAME = "MySQL";
   private final MysqlConnectorConfig config;
 
@@ -61,7 +61,7 @@ public class MysqlConnector extends AbstractDBSpecificConnector<DBRecord> {
 
   @Override
   protected Class<? extends DBWritable> getDBRecordType() {
-    return DBRecord.class;
+    return MysqlDBRecord.class;
   }
 
   protected void setConnectorSpec(ConnectorSpecRequest request, DBConnectorPath path,
@@ -97,7 +97,7 @@ public class MysqlConnector extends AbstractDBSpecificConnector<DBRecord> {
   }
 
   @Override
-  public StructuredRecord transform(LongWritable longWritable, DBRecord record) {
-    return record.getRecord();
+  public StructuredRecord transform(LongWritable longWritable, MysqlDBRecord mysqlDBRecord) {
+    return mysqlDBRecord.getRecord();
   }
 }

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlDBRecord.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlDBRecord.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.mysql;
+
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.plugin.db.ColumnType;
+import io.cdap.plugin.db.DBRecord;
+
+import java.util.List;
+
+/**
+ * Writable class for MySQL Source/Sink.
+ */
+public class MysqlDBRecord extends DBRecord {
+
+  public MysqlDBRecord(StructuredRecord record, List<ColumnType> columnTypes) {
+    super(record, columnTypes);
+  }
+
+  /**
+   * Used in map-reduce. Do not remove.
+   */
+  @SuppressWarnings("unused")
+  public MysqlDBRecord() {
+    // Required by Hadoop DBRecordReader to create an instance
+  }
+}

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlSink.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlSink.java
@@ -23,11 +23,13 @@ import io.cdap.cdap.api.annotation.Metadata;
 import io.cdap.cdap.api.annotation.MetadataProperty;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.connector.Connector;
 import io.cdap.plugin.common.ConfigUtil;
 import io.cdap.plugin.db.ConnectionConfig;
+import io.cdap.plugin.db.DBRecord;
 import io.cdap.plugin.db.batch.config.AbstractDBSpecificSinkConfig;
 import io.cdap.plugin.db.batch.sink.AbstractDBSink;
 
@@ -50,6 +52,11 @@ public class MysqlSink extends AbstractDBSink<MysqlSink.MysqlSinkConfig> {
   public MysqlSink(MysqlSinkConfig mysqlSinkConfig) {
     super(mysqlSinkConfig);
     this.mysqlSinkConfig = mysqlSinkConfig;
+  }
+
+  @Override
+  protected DBRecord getDBRecord(StructuredRecord output) {
+    return new MysqlDBRecord(output, columnTypes);
   }
 
   /**

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlSource.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlSource.java
@@ -29,6 +29,7 @@ import io.cdap.cdap.etl.api.connector.Connector;
 import io.cdap.plugin.common.ConfigUtil;
 import io.cdap.plugin.db.batch.config.AbstractDBSpecificSourceConfig;
 import io.cdap.plugin.db.batch.source.AbstractDBSource;
+import org.apache.hadoop.mapreduce.lib.db.DBWritable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -55,6 +56,11 @@ public class MysqlSource extends AbstractDBSource<MysqlSource.MysqlSourceConfig>
   @Override
   protected String createConnectionString() {
     return mysqlSourceConfig.getConnectionString();
+  }
+
+  @Override
+  protected Class<? extends DBWritable> getDBRecordType() {
+    return MysqlDBRecord.class;
   }
 
   /**

--- a/netezza-plugin/pom.xml
+++ b/netezza-plugin/pom.xml
@@ -84,6 +84,35 @@
         <groupId>io.cdap</groupId>
         <artifactId>cdap-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>5.1.2</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <_exportcontents>
+              io.cdap.plugin.netezza.*;
+              io.cdap.plugin.db.batch.source.*;
+              io.cdap.plugin.db.batch.sink.*;
+              org.apache.commons.lang;
+              org.apache.commons.logging.*;
+              org.codehaus.jackson.*
+            </_exportcontents>
+            <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+            <Embed-Transitive>true</Embed-Transitive>
+            <Embed-Directory>lib</Embed-Directory>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/oracle-plugin/pom.xml
+++ b/oracle-plugin/pom.xml
@@ -105,6 +105,35 @@
         <groupId>io.cdap</groupId>
         <artifactId>cdap-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>5.1.2</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <_exportcontents>
+              io.cdap.plugin.oracle.*;
+              io.cdap.plugin.db.batch.source.*;
+              io.cdap.plugin.db.batch.sink.*;
+              org.apache.commons.lang;
+              org.apache.commons.logging.*;
+              org.codehaus.jackson.*
+            </_exportcontents>
+            <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+            <Embed-Transitive>true</Embed-Transitive>
+            <Embed-Directory>lib</Embed-Directory>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -506,33 +506,6 @@
           </dependency>
         </dependencies>
       </plugin>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>5.1.2</version>
-        <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <_exportcontents>
-              io.cdap.plugin.*;
-              org.apache.commons.lang;
-              org.apache.commons.logging.*;
-              org.codehaus.jackson.*
-            </_exportcontents>
-            <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
-            <Embed-Transitive>true</Embed-Transitive>
-            <Embed-Directory>lib</Embed-Directory>
-          </instructions>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>bundle</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 

--- a/postgresql-plugin/pom.xml
+++ b/postgresql-plugin/pom.xml
@@ -91,6 +91,32 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>5.1.2</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <_exportcontents>
+              io.cdap.plugin.postgres.*;
+              io.cdap.plugin.db.batch.source.*;
+              io.cdap.plugin.db.batch.sink.*;
+            </_exportcontents>
+            <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+            <Embed-Transitive>true</Embed-Transitive>
+            <Embed-Directory>lib</Embed-Directory>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>io.cdap</groupId>
         <artifactId>cdap-maven-plugin</artifactId>
       </plugin>

--- a/saphana-plugin/pom.xml
+++ b/saphana-plugin/pom.xml
@@ -80,9 +80,14 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+        <version>5.1.2</version>
+        <extensions>true</extensions>
         <configuration>
           <instructions>
             <_exportcontents>
+              io.cdap.plugin.saphana.*;
+              io.cdap.plugin.db.batch.source.*;
+              io.cdap.plugin.db.batch.sink.*;
               io.cdap.plugin.saphana.*;
               org.apache.commons.lang;
               org.apache.commons.logging.*;
@@ -93,6 +98,14 @@
             <Embed-Directory>lib</Embed-Directory>
           </instructions>
         </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>io.cdap</groupId>

--- a/teradata-plugin/pom.xml
+++ b/teradata-plugin/pom.xml
@@ -85,18 +85,33 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+        <version>5.1.2</version>
+        <extensions>true</extensions>
         <configuration>
           <instructions>
             <_exportcontents>
               io.cdap.plugin.teradata.*;
-              io.cdap.plugin.db.*;
               io.cdap.plugin.util.*;
+              io.cdap.plugin.db.batch.source.*;
+              io.cdap.plugin.db.batch.sink.*;
+              io.cdap.plugin.saphana.*;
+              org.apache.commons.lang;
+              org.apache.commons.logging.*;
+              org.codehaus.jackson.*
             </_exportcontents>
             <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>
             <Embed-Directory>lib</Embed-Directory>
           </instructions>
         </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>io.cdap</groupId>


### PR DESCRIPTION
Jira: https://cdap.atlassian.net/browse/CDAP-19417

If MySQL plugin is used with other DB plugins in the same pipeline, it fails with an error `io.cdap.plugin.db.DBRecord cannot be cast to io.cdap.plugin.db.DBRecord`. This PR fixes the class loading error by making each individual plugin export its own contents