### PR TITLE
Add Sampling Options for Multiple Database Connectors

### DIFF
--- a/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLConnector.java
+++ b/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLConnector.java
@@ -72,13 +72,8 @@ public class CloudSQLMySQLConnector extends AbstractDBSpecificConnector<DBRecord
   }
 
   @Override
-  protected String getTableQuery(String database, String schema, String table) {
-    return String.format("SELECT * FROM `%s`.`%s`", database, table);
-  }
-
-  @Override
-  protected String getTableQuery(String database, String schema, String table, int limit) {
-    return String.format("SELECT * FROM `%s`.`%s` LIMIT %d", database, table, limit);
+  protected String getTableName(String database, String schema, String table) {
+    return String.format("`%s`.`%s`", database, table);
   }
 
   @Override

--- a/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLConnector.java
+++ b/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLConnector.java
@@ -84,13 +84,8 @@ public class CloudSQLPostgreSQLConnector extends AbstractDBSpecificConnector<Pos
   }
 
   @Override
-  protected String getTableQuery(String database, String schema, String table) {
-    return String.format("SELECT * FROM \"%s\".\"%s\"", schema, table);
-  }
-
-  @Override
-  protected String getTableQuery(String database, String schema, String table, int limit) {
-    return String.format("SELECT * FROM \"%s\".\"%s\" LIMIT %d", schema, table, limit);
+  protected String getTableName(String database, String schema, String table) {
+    return String.format("\"%s\".\"%s\"", schema, table);
   }
 
   @Override

--- a/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnector.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnector.java
@@ -117,16 +117,19 @@ public abstract class AbstractDBSpecificConnector<T extends DBWritable> extends 
     return config.getConnectionString();
   }
 
+  protected String getTableName(String database, String schema, String table) {
+    return schema == null ? String.format("\"%s\".\"%s\"", database, table)
+      : String.format("\"%s\".\"%s\".\"%s\"", database, schema, table);
+  }
+
   protected String getTableQuery(String database, String schema, String table) {
-    return schema == null ? String.format("SELECT * FROM \"%s\".\"%s\"", database, table)
-      : String.format("SELECT * FROM \"%s\".\"%s\".\"%s\"", database, schema, table);
+    String tableName = getTableName(database, schema, table);
+    return String.format("SELECT * FROM %s", tableName);
   }
 
   protected String getTableQuery(String database, String schema, String table, int limit) {
-    return schema == null ?
-      String.format("SELECT * FROM \"%s\".\"%s\" LIMIT %d", database, table, limit) :
-      String.format(
-        "SELECT * FROM \"%s\".\"%s\".\"%s\" LIMIT %d", database, schema, table, limit);
+    String tableName = getTableName(database, schema, table);
+    return String.format("SELECT * FROM %s LIMIT %d", tableName, limit);
   }
 
   protected Schema loadTableSchema(Connection connection, String query) throws SQLException {

--- a/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnector.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnector.java
@@ -89,7 +89,8 @@ public abstract class AbstractDBSpecificConnector<T extends DBWritable> extends 
       DBConfiguration.configureDB(connectionConfigAccessor.getConfiguration(), driverClass.getName(),
                      getConnectionString(path.getDatabase()), config.getUser(), config.getPassword());
     }
-    String tableQuery = getTableQuery(path.getDatabase(), path.getSchema(), path.getTable(), request.getLimit());
+    String tableQuery = getTableQuery(path.getDatabase(), path.getSchema(), path.getTable(), request.getLimit(),
+                                      request.getProperties().get("sampleType"), request.getProperties().get("strata"));
     DataDrivenETLDBInputFormat.setInput(connectionConfigAccessor.getConfiguration(), getDBRecordType(),
                                         tableQuery, null, false);
     connectionConfigAccessor.setConnectionArguments(Maps.fromProperties(config.getConnectionArgumentsProperties()));
@@ -127,6 +128,52 @@ public abstract class AbstractDBSpecificConnector<T extends DBWritable> extends 
       String.format("SELECT * FROM \"%s\".\"%s\" LIMIT %d", database, table, limit) :
       String.format(
         "SELECT * FROM \"%s\".\"%s\".\"%s\" LIMIT %d", database, schema, table, limit);
+  }
+
+  protected String getTableQuery(String database, String schema, String table, int limit, String sampleType,
+                                 String strata) {
+    String tableName = schema == null ?
+      String.format("\"%s\".\"%s\"", database, table) :
+      String.format("\"%s\".\"%s\".\"%s\"", database, schema, table);
+
+    String query;
+    switch (sampleType) {
+      case "random":
+        query = String.format("WITH table AS (\n" +
+                                "  SELECT *, RAND() AS r\n" +
+                                "  FROM %s\n" +
+                                "  WHERE RAND() < 2*%d/(SELECT COUNT(*) FROM %s)\n" +
+                                ")\n" +
+                                "SELECT * EXCEPT (r)\n" +
+                                "FROM table\n" +
+                                "ORDER BY r\n" +
+                                "LIMIT %d", tableName, limit, tableName, limit);
+        break;
+      case "stratified":
+        if (strata == null) {
+          throw new IllegalArgumentException("No strata column given.");
+        }
+        query = String.format("WITH table AS (\n" +
+                                "  SELECT *\n" +
+                                "  FROM %s\n" +
+                                "), table_stats AS (\n" +
+                                "  SELECT *, SUM(stratum_count) OVER() total \n" +
+                                "  FROM (\n" +
+                                "    SELECT %s, COUNT(*) stratum_count \n" +
+                                "    FROM table\n" +
+                                "    GROUP BY 1\n" +
+                                "  )\n" +
+                                ")\n" +
+                                "SELECT * EXCEPT (stratum_count, total)\n" +
+                                "FROM table\n" +
+                                "JOIN table_stats\n" +
+                                "USING(%s)\n" +
+                                "WHERE RAND()< %d/total\n", tableName, strata, strata, limit);
+        break;
+      default:
+        query = getTableQuery(database, schema, table, limit);
+    }
+    return query;
   }
 
   protected Schema loadTableSchema(Connection connection, String query) throws SQLException {

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerConnector.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerConnector.java
@@ -147,10 +147,14 @@ public class SqlServerConnector extends AbstractDBSpecificConnector<SqlServerSou
         // Alternative method, which is quicker and almost guarantees the correct number of rows,
         // but isn't uniformly random (i.e. rows are usually clustered together)
         // return String.format("SELECT TOP %d * FROM %s TABLESAMPLE(%d ROWS)", limit, tableName, limit*2);
-      // case "stratified":
-      //  if (strata == null) {
-      //    throw new IllegalArgumentException("No strata column given.");
-      //  }
+       case "stratified":
+        if (strata == null) {
+          throw new IllegalArgumentException("No strata column given.");
+        }
+         return String.format("SELECT * FROM %s " +
+                 "WHERE (ABS(CAST((BINARY_CHECKSUM(*) * RAND()) as int)) %% 100) " +
+                 "< %d / (SELECT COUNT(*) FROM %s)" +
+                 "ORDER BY %s", tableName, limit * 100, tableName, strata);
       // TODO: add in stratified sampling here
       default:
         return super.getTableQuery(database, schema, table, limit);

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerConnector.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerConnector.java
@@ -77,7 +77,7 @@ public class SqlServerConnector extends AbstractDBSpecificConnector<SqlServerSou
       .addRelatedPlugin(new PluginSpec(SqlServerConstants.PLUGIN_NAME, BatchSource.PLUGIN_TYPE, sourceProperties))
       .addRelatedPlugin(new PluginSpec(SqlServerConstants.PLUGIN_NAME, BatchSink.PLUGIN_TYPE, sinkProperties))
       .addSupportedSampleType("random")
-      .addSupportedSampleType("stratified");
+      .addSupportedSampleType("randomSorted");
 
     String database = path.getDatabase();
     if (database != null) {

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerConnector.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerConnector.java
@@ -129,4 +129,25 @@ public class SqlServerConnector extends AbstractDBSpecificConnector<SqlServerSou
     }
     return super.getSchema(sqlType, typeName, scale, precision, columnName, isSigned, handleAsDecimal);
   }
+
+  @Override
+  protected String getTableQuery(String database, String schema, String table, int limit, String sampleType,
+                                 String strata) {
+    if (sampleType == null) {
+      return super.getTableQuery(database, schema, table, limit);
+    }
+    String tableName = getTableName(database, schema, table);
+    switch (sampleType) {
+      case "random":
+        // This query doesn't guarantee exactly "limit" number of rows
+        return String.format("SELECT * FROM %s TABLESAMPLE(%d ROWS)", tableName, limit);
+      // case "stratified":
+      //  if (strata == null) {
+      //    throw new IllegalArgumentException("No strata column given.");
+      //  }
+      // TODO: add in stratified sampling here
+      default:
+        return super.getTableQuery(database, schema, table, limit);
+    }
+  }
 }

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerConnector.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerConnector.java
@@ -75,7 +75,9 @@ public class SqlServerConnector extends AbstractDBSpecificConnector<SqlServerSou
     setConnectionProperties(sinkProperties, request);
     builder
       .addRelatedPlugin(new PluginSpec(SqlServerConstants.PLUGIN_NAME, BatchSource.PLUGIN_TYPE, sourceProperties))
-      .addRelatedPlugin(new PluginSpec(SqlServerConstants.PLUGIN_NAME, BatchSink.PLUGIN_TYPE, sinkProperties));
+      .addRelatedPlugin(new PluginSpec(SqlServerConstants.PLUGIN_NAME, BatchSink.PLUGIN_TYPE, sinkProperties))
+      .addSupportedSampleType("random")
+      .addSupportedSampleType("stratified");
 
     String database = path.getDatabase();
     if (database != null) {

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerConnector.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerConnector.java
@@ -126,23 +126,14 @@ public class SqlServerConnector extends AbstractDBSpecificConnector<SqlServerSou
     String tableName = getTableName(database, schema, table);
     switch (sampleType) {
       case "random":
-        if (strata == null) {
-          // This query doesn't guarantee exactly "limit" number of rows
-          return String.format("SELECT * FROM %s " +
-                                 "WHERE (ABS(CAST((BINARY_CHECKSUM(*) * RAND()) as int)) %% 100) " +
-                                 "< %d / (SELECT COUNT(*) FROM %s)",
-                               tableName, limit * 100, tableName);
-
-          // Alternative method, which is quicker and almost guarantees the correct number of rows,
-          // but isn't uniformly random (i.e. rows are usually clustered together)
-          // return String.format("SELECT TOP %d * FROM %s TABLESAMPLE(%d ROWS)", limit, tableName, limit*2);
-        } else {
-          return String.format("SELECT * FROM %s " +
-                                 "WHERE (ABS(CAST((BINARY_CHECKSUM(*) * RAND()) as int)) %% 100) " +
-                                 "< %d / (SELECT COUNT(*) FROM %s)" +
-                                 "ORDER BY %s",
-                               tableName, limit * 100, tableName, strata);
-        }
+        // This query doesn't guarantee exactly "limit" number of rows
+        return String.format("SELECT * FROM %s " +
+                               "WHERE (ABS(CAST((BINARY_CHECKSUM(*) * RAND()) as int)) %% 100) " +
+                               "< %d / (SELECT COUNT(*) FROM %s)",
+                             tableName, limit * 100, tableName);
+        // Alternative method, which is quicker and almost guarantees the correct number of rows,
+        // but isn't uniformly random (i.e. rows are usually clustered together)
+        // return String.format("SELECT TOP %d * FROM %s TABLESAMPLE(%d ROWS)", limit, tableName, limit*2);
       default:
         return getTableQuery(database, schema, table, limit);
     }

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerConnector.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerConnector.java
@@ -76,8 +76,7 @@ public class SqlServerConnector extends AbstractDBSpecificConnector<SqlServerSou
     builder
       .addRelatedPlugin(new PluginSpec(SqlServerConstants.PLUGIN_NAME, BatchSource.PLUGIN_TYPE, sourceProperties))
       .addRelatedPlugin(new PluginSpec(SqlServerConstants.PLUGIN_NAME, BatchSink.PLUGIN_TYPE, sinkProperties))
-      .addSupportedSampleType("random")
-      .addSupportedSampleType("randomSorted");
+      .addSupportedSampleType("random");
 
     String database = path.getDatabase();
     if (database != null) {
@@ -127,24 +126,23 @@ public class SqlServerConnector extends AbstractDBSpecificConnector<SqlServerSou
     String tableName = getTableName(database, schema, table);
     switch (sampleType) {
       case "random":
-        // This query doesn't guarantee exactly "limit" number of rows
-        return String.format("SELECT * FROM %s " +
-                               "WHERE (ABS(CAST((BINARY_CHECKSUM(*) * RAND()) as int)) %% 100) " +
-                               "< %d / (SELECT COUNT(*) FROM %s)",
-                             tableName, limit * 100, tableName);
-
-      // Alternative method, which is quicker and almost guarantees the correct number of rows,
-      // but isn't uniformly random (i.e. rows are usually clustered together)
-      // return String.format("SELECT TOP %d * FROM %s TABLESAMPLE(%d ROWS)", limit, tableName, limit*2);
-      case "stratified":
         if (strata == null) {
-          throw new IllegalArgumentException("No strata column given.");
+          // This query doesn't guarantee exactly "limit" number of rows
+          return String.format("SELECT * FROM %s " +
+                                 "WHERE (ABS(CAST((BINARY_CHECKSUM(*) * RAND()) as int)) %% 100) " +
+                                 "< %d / (SELECT COUNT(*) FROM %s)",
+                               tableName, limit * 100, tableName);
+
+          // Alternative method, which is quicker and almost guarantees the correct number of rows,
+          // but isn't uniformly random (i.e. rows are usually clustered together)
+          // return String.format("SELECT TOP %d * FROM %s TABLESAMPLE(%d ROWS)", limit, tableName, limit*2);
+        } else {
+          return String.format("SELECT * FROM %s " +
+                                 "WHERE (ABS(CAST((BINARY_CHECKSUM(*) * RAND()) as int)) %% 100) " +
+                                 "< %d / (SELECT COUNT(*) FROM %s)" +
+                                 "ORDER BY %s",
+                               tableName, limit * 100, tableName, strata);
         }
-        return String.format("SELECT * FROM %s " +
-                               "WHERE (ABS(CAST((BINARY_CHECKSUM(*) * RAND()) as int)) %% 100) " +
-                               "< %d / (SELECT COUNT(*) FROM %s)" +
-                               "ORDER BY %s",
-                             tableName, limit * 100, tableName, strata);
       default:
         return getTableQuery(database, schema, table, limit);
     }

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerConnector.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerConnector.java
@@ -112,8 +112,9 @@ public class SqlServerConnector extends AbstractDBSpecificConnector<SqlServerSou
 
   @Override
   protected String getTableQuery(String database, String schema, String table, int limit) {
+    String tableName = getTableName(database, schema, table);
     return String.format(
-      "SELECT TOP(%d) * FROM \"%s\".\"%s\".\"%s\"", limit, database, schema, table);
+      "SELECT TOP(%d) * FROM %s", limit, tableName);
   }
 
   @Override

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerConnector.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerConnector.java
@@ -141,8 +141,9 @@ public class SqlServerConnector extends AbstractDBSpecificConnector<SqlServerSou
       case "random":
         // This query doesn't guarantee exactly "limit" number of rows
         return String.format("SELECT * FROM %s " +
-                "WHERE (ABS(CAST((BINARY_CHECKSUM(*) * RAND()) as int)) %% 100) " +
-                "< %d / (SELECT COUNT(*) FROM %s)", tableName, limit * 100, tableName);
+                               "WHERE (ABS(CAST((BINARY_CHECKSUM(*) * RAND()) as int)) %% 100) " +
+                               "< %d / (SELECT COUNT(*) FROM %s)",
+                             tableName, limit * 100, tableName);
 
         // Alternative method, which is quicker and almost guarantees the correct number of rows,
         // but isn't uniformly random (i.e. rows are usually clustered together)
@@ -152,12 +153,12 @@ public class SqlServerConnector extends AbstractDBSpecificConnector<SqlServerSou
           throw new IllegalArgumentException("No strata column given.");
         }
          return String.format("SELECT * FROM %s " +
-                 "WHERE (ABS(CAST((BINARY_CHECKSUM(*) * RAND()) as int)) %% 100) " +
-                 "< %d / (SELECT COUNT(*) FROM %s)" +
-                 "ORDER BY %s", tableName, limit * 100, tableName, strata);
-      // TODO: add in stratified sampling here
+                                "WHERE (ABS(CAST((BINARY_CHECKSUM(*) * RAND()) as int)) %% 100) " +
+                                "< %d / (SELECT COUNT(*) FROM %s)" +
+                                "ORDER BY %s",
+                              tableName, limit * 100, tableName, strata);
       default:
-        return super.getTableQuery(database, schema, table, limit);
+        return getTableQuery(database, schema, table, limit);
     }
   }
 }

--- a/mssql-plugin/src/test/java/io/cdap/plugin/mssql/SqlServerConnectorUnitTest.java
+++ b/mssql-plugin/src/test/java/io/cdap/plugin/mssql/SqlServerConnectorUnitTest.java
@@ -52,24 +52,13 @@ public class SqlServerConnectorUnitTest {
                                       tableName, 10000, tableName),
                         CONNECTOR.getTableQuery("db", "schema", "table",
                                                 100, "random", null));
-    // stratified query
+    // sorted random query
     Assert.assertEquals(String.format("SELECT * FROM %s " +
                                         "WHERE (ABS(CAST((BINARY_CHECKSUM(*) * RAND()) as int)) %% 100) " +
                                         "< %d / (SELECT COUNT(*) FROM %s)" +
                                         "ORDER BY %s",
                                       tableName, 10000, tableName, "strata"),
                         CONNECTOR.getTableQuery("db", "schema", "table",
-                                                100, "stratified", "strata"));
-  }
-
-  /**
-   * Test for null strata exception
-   *
-   * @throws IllegalArgumentException
-   */
-  @Test
-  public void getTableQueryNullStrataTest() throws IllegalArgumentException {
-    expectedEx.expect(IllegalArgumentException.class);
-    CONNECTOR.getTableQuery("db", "schema", "table", 100, "stratified", null);
+                                                100, "random", "strata"));
   }
 }

--- a/mssql-plugin/src/test/java/io/cdap/plugin/mssql/SqlServerConnectorUnitTest.java
+++ b/mssql-plugin/src/test/java/io/cdap/plugin/mssql/SqlServerConnectorUnitTest.java
@@ -52,12 +52,11 @@ public class SqlServerConnectorUnitTest {
                                       tableName, 10000, tableName),
                         CONNECTOR.getTableQuery("db", "schema", "table",
                                                 100, "random", null));
-    // sorted random query
+    // random query, strata input
     Assert.assertEquals(String.format("SELECT * FROM %s " +
                                         "WHERE (ABS(CAST((BINARY_CHECKSUM(*) * RAND()) as int)) %% 100) " +
-                                        "< %d / (SELECT COUNT(*) FROM %s)" +
-                                        "ORDER BY %s",
-                                      tableName, 10000, tableName, "strata"),
+                                        "< %d / (SELECT COUNT(*) FROM %s)",
+                                      tableName, 10000, tableName),
                         CONNECTOR.getTableQuery("db", "schema", "table",
                                                 100, "random", "strata"));
   }

--- a/mssql-plugin/src/test/java/io/cdap/plugin/mssql/SqlServerConnectorUnitTest.java
+++ b/mssql-plugin/src/test/java/io/cdap/plugin/mssql/SqlServerConnectorUnitTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.mssql;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Unit tests for {@link SqlServerConnector}
+ */
+public class SqlServerConnectorUnitTest {
+  @Rule
+  public ExpectedException expectedEx = ExpectedException.none();
+
+  private static final SqlServerConnector CONNECTOR = new SqlServerConnector(null);
+
+  /**
+   * Unit tests for getTableQuery()
+   */
+  @Test
+  public void getTableQueryTest() {
+    String tableName = "\"db\".\"schema\".\"table\"";
+
+    // default query, sampleType "first"
+    Assert.assertEquals(String.format("SELECT TOP %d * FROM %s", 100, tableName),
+                        CONNECTOR.getTableQuery("db", "schema", "table",
+                                                100, "first", null));
+    // default query, sampleType null
+    Assert.assertEquals(String.format("SELECT TOP %d * FROM %s", 100, tableName),
+                        CONNECTOR.getTableQuery("db", "schema", "table",
+                                                100, null, null));
+    // random query
+    Assert.assertEquals(String.format("SELECT * FROM %s " +
+                                        "WHERE (ABS(CAST((BINARY_CHECKSUM(*) * RAND()) as int)) %% 100) " +
+                                        "< %d / (SELECT COUNT(*) FROM %s)",
+                                      tableName, 10000, tableName),
+                        CONNECTOR.getTableQuery("db", "schema", "table",
+                                                100, "random", null));
+    // stratified query
+    Assert.assertEquals(String.format("SELECT * FROM %s " +
+                                        "WHERE (ABS(CAST((BINARY_CHECKSUM(*) * RAND()) as int)) %% 100) " +
+                                        "< %d / (SELECT COUNT(*) FROM %s)" +
+                                        "ORDER BY %s",
+                                      tableName, 10000, tableName, "strata"),
+                        CONNECTOR.getTableQuery("db", "schema", "table",
+                                                100, "stratified", "strata"));
+  }
+
+  /**
+   * Test for null strata exception
+   *
+   * @throws IllegalArgumentException
+   */
+  @Test
+  public void getTableQueryNullStrataTest() throws IllegalArgumentException {
+    expectedEx.expect(IllegalArgumentException.class);
+    CONNECTOR.getTableQuery("db", "schema", "table", 100, "stratified", null);
+  }
+}

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
@@ -107,15 +107,19 @@ public class MysqlConnector extends AbstractDBSpecificConnector<DBRecord> {
       case "random":
         // This query doesn't guarantee exactly "limit" number of rows
         // Note that we input "limit" with a trailing zero so that division gives an exact result
-        return String.format("SELECT * FROM %s " +
-                "WHERE rand() < %d.0 / (SELECT COUNT(*) FROM %s)", tableName, limit, tableName);
-      // case "stratified":
-      //  if (strata == null) {
-      //    throw new IllegalArgumentException("No strata column given.");
-      //  }
-      // TODO: add in stratified sampling here
+        return String.format("SELECT * FROM %s\n" +
+                               "WHERE rand() < %d.0 / (SELECT COUNT(*) FROM %s)",
+                             tableName, limit, tableName);
+      case "stratified":
+       if (strata == null) {
+         throw new IllegalArgumentException("No strata column given.");
+       }
+       return String.format("SELECT * FROM %s\n" +
+                              "WHERE rand() < %d.0 / (SELECT COUNT(*) FROM %s)\n" +
+                              "ORDER BY %s",
+                            tableName, limit, tableName, strata);
       default:
-        return super.getTableQuery(database, schema, table, limit);
+        return getTableQuery(database, schema, table, limit);
     }
 
   }

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
@@ -70,7 +70,9 @@ public class MysqlConnector extends AbstractDBSpecificConnector<DBRecord> {
     setConnectionProperties(properties, request);
     builder
       .addRelatedPlugin(new PluginSpec(MysqlConstants.PLUGIN_NAME, BatchSource.PLUGIN_TYPE, properties))
-      .addRelatedPlugin(new PluginSpec(MysqlConstants.PLUGIN_NAME, BatchSink.PLUGIN_TYPE, properties));
+      .addRelatedPlugin(new PluginSpec(MysqlConstants.PLUGIN_NAME, BatchSink.PLUGIN_TYPE, properties))
+      .addSupportedSampleType("random")
+      .addSupportedSampleType("stratified");
 
     String table = path.getTable();
     if (table == null) {

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
@@ -106,18 +106,11 @@ public class MysqlConnector extends AbstractDBSpecificConnector<DBRecord> {
     String tableName = getTableName(database, schema, table);
     switch (sampleType) {
       case "random":
-        if (strata == null) {
-          // This query doesn't guarantee exactly "limit" number of rows
-          // Note that we input "limit" with a trailing zero so that division gives an exact result
-          return String.format("SELECT * FROM %s\n" +
-                                 "WHERE rand() < %d.0 / (SELECT COUNT(*) FROM %s)",
-                               tableName, limit, tableName);
-        } else {
-          return String.format("SELECT * FROM %s\n" +
-                                 "WHERE rand() < %d.0 / (SELECT COUNT(*) FROM %s)\n" +
-                                 "ORDER BY %s",
-                               tableName, limit, tableName, strata);
-        }
+        // This query doesn't guarantee exactly "limit" number of rows
+        // Note that we input "limit" with a trailing zero so that division gives an exact result
+        return String.format("SELECT * FROM %s\n" +
+                               "WHERE rand() < %d.0 / (SELECT COUNT(*) FROM %s)",
+                             tableName, limit, tableName);
       default:
         return getTableQuery(database, schema, table, limit);
     }

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
@@ -87,13 +87,8 @@ public class MysqlConnector extends AbstractDBSpecificConnector<DBRecord> {
   }
 
   @Override
-  protected String getTableQuery(String database, String schema, String table) {
-    return String.format("SELECT * FROM `%s`.`%s`", database, table);
-  }
-
-  @Override
-  protected String getTableQuery(String database, String schema, String table, int limit) {
-    return String.format("SELECT * FROM `%s`.`%s` LIMIT %d", database, table, limit);
+  protected String getTableName(String database, String schema, String table) {
+    return String.format("`%s`.`%s`", database, table);
   }
 
   @Override

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
@@ -100,7 +100,7 @@ public class MysqlConnector extends AbstractDBSpecificConnector<DBRecord> {
   protected String getTableQuery(String database, String schema, String table, int limit, String sampleType,
                                  String strata) {
     if (sampleType == null) {
-      return super.getTableQuery(database, schema, table, limit);
+      return getTableQuery(database, schema, table, limit);
     }
     String tableName = getTableName(database, schema, table);
     switch (sampleType) {

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
@@ -89,13 +89,13 @@ public class MysqlConnector extends AbstractDBSpecificConnector<DBRecord> {
   }
 
   @Override
-  protected String getTableName(String database, String schema, String table) {
-    return String.format("`%s`.`%s`", database, table);
+  public StructuredRecord transform(LongWritable longWritable, DBRecord record) {
+    return record.getRecord();
   }
 
   @Override
-  public StructuredRecord transform(LongWritable longWritable, DBRecord record) {
-    return record.getRecord();
+  protected String getTableName(String database, String schema, String table) {
+    return String.format("`%s`.`%s`", database, table);
   }
 
   @Override

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
@@ -72,7 +72,7 @@ public class MysqlConnector extends AbstractDBSpecificConnector<DBRecord> {
       .addRelatedPlugin(new PluginSpec(MysqlConstants.PLUGIN_NAME, BatchSource.PLUGIN_TYPE, properties))
       .addRelatedPlugin(new PluginSpec(MysqlConstants.PLUGIN_NAME, BatchSink.PLUGIN_TYPE, properties))
       .addSupportedSampleType("random")
-      .addSupportedSampleType("stratified");
+      .addSupportedSampleType("randomSorted");
 
     String table = path.getTable();
     if (table == null) {

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
@@ -95,4 +95,28 @@ public class MysqlConnector extends AbstractDBSpecificConnector<DBRecord> {
   public StructuredRecord transform(LongWritable longWritable, DBRecord record) {
     return record.getRecord();
   }
+
+  @Override
+  protected String getTableQuery(String database, String schema, String table, int limit, String sampleType,
+                                 String strata) {
+    if (sampleType == null) {
+      return super.getTableQuery(database, schema, table, limit);
+    }
+    String tableName = getTableName(database, schema, table);
+    switch (sampleType) {
+      case "random":
+        // This query doesn't guarantee exactly "limit" number of rows
+        // Note that we input "limit" with a trailing zero so that division gives an exact result
+        return String.format("SELECT * FROM %s " +
+                "WHERE rand() < %d.0 / (SELECT COUNT(*) FROM %s)", tableName, limit, tableName);
+      // case "stratified":
+      //  if (strata == null) {
+      //    throw new IllegalArgumentException("No strata column given.");
+      //  }
+      // TODO: add in stratified sampling here
+      default:
+        return super.getTableQuery(database, schema, table, limit);
+    }
+
+  }
 }

--- a/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlConnectorUnitTest.java
+++ b/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlConnectorUnitTest.java
@@ -60,24 +60,13 @@ public class MysqlConnectorUnitTest {
                                       tableName, 100, tableName),
                         CONNECTOR.getTableQuery("db", "schema", "table",
                                                 100, "random", null));
-    // stratified query
+    // sorted random query
     Assert.assertEquals(String.format("SELECT * FROM %s\n" +
                                         "WHERE rand() < %d.0 / (SELECT COUNT(*) FROM %s)\n" +
                                         "ORDER BY %s",
                                       tableName, 100, tableName, "strata"),
                         CONNECTOR.getTableQuery("db", "schema", "table",
-                                                100, "stratified", "strata"));
-  }
-
-  /**
-   * Test for getTableQuery() null strata exception
-   *
-   * @throws IllegalArgumentException
-   */
-  @Test
-  public void getTableQueryNullStrataTest() throws IllegalArgumentException {
-    expectedEx.expect(IllegalArgumentException.class);
-    CONNECTOR.getTableQuery("db", "schema", "table", 100, "stratified", null);
+                                                100, "random", "strata"));
   }
 
 }

--- a/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlConnectorUnitTest.java
+++ b/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlConnectorUnitTest.java
@@ -28,14 +28,15 @@ public class MysqlConnectorUnitTest {
   @Rule
   public ExpectedException expectedEx = ExpectedException.none();
 
+  private static final MysqlConnector CONNECTOR = new MysqlConnector(null);
+
   /**
    * Unit test for getTableName()
    */
   @Test
   public void getTableNameTest() {
-    MysqlConnector connector = new MysqlConnector(null);
     Assert.assertEquals("`db`.`table`",
-                        connector.getTableName("db", "schema", "table"));
+                        CONNECTOR.getTableName("db", "schema", "table"));
   }
 
   /**
@@ -43,29 +44,28 @@ public class MysqlConnectorUnitTest {
    */
   @Test
   public void getTableQueryTest() {
-    MysqlConnector connector = new MysqlConnector(null);
-    String tableName = connector.getTableName("db", "schema", "table");
+    String tableName = CONNECTOR.getTableName("db", "schema", "table");
 
     // default query, sampleType "first"
     Assert.assertEquals(String.format("SELECT * FROM %s LIMIT 100", tableName),
-                        connector.getTableQuery("db", "schema", "table",
+                        CONNECTOR.getTableQuery("db", "schema", "table",
                                                 100, "first", null));
     // default query, sampleType null
     Assert.assertEquals(String.format("SELECT * FROM %s LIMIT 100", tableName),
-                        connector.getTableQuery("db", "schema", "table",
+                        CONNECTOR.getTableQuery("db", "schema", "table",
                                                 100, null, null));
     // random query
     Assert.assertEquals(String.format("SELECT * FROM %s\n" +
                                         "WHERE rand() < %d.0 / (SELECT COUNT(*) FROM %s)",
                                       tableName, 100, tableName),
-                        connector.getTableQuery("db", "schema", "table",
+                        CONNECTOR.getTableQuery("db", "schema", "table",
                                                 100, "random", null));
     // stratified query
     Assert.assertEquals(String.format("SELECT * FROM %s\n" +
                                         "WHERE rand() < %d.0 / (SELECT COUNT(*) FROM %s)\n" +
                                         "ORDER BY %s",
                                       tableName, 100, tableName, "strata"),
-                        connector.getTableQuery("db", "schema", "table",
+                        CONNECTOR.getTableQuery("db", "schema", "table",
                                                 100, "stratified", "strata"));
   }
 
@@ -77,8 +77,7 @@ public class MysqlConnectorUnitTest {
   @Test
   public void getTableQueryNullStrataTest() throws IllegalArgumentException {
     expectedEx.expect(IllegalArgumentException.class);
-    MysqlConnector connector = new MysqlConnector(null);
-    connector.getTableQuery("db", "schema", "table", 100, "stratified", null);
+    CONNECTOR.getTableQuery("db", "schema", "table", 100, "stratified", null);
   }
 
 }

--- a/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlConnectorUnitTest.java
+++ b/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlConnectorUnitTest.java
@@ -60,11 +60,10 @@ public class MysqlConnectorUnitTest {
                                       tableName, 100, tableName),
                         CONNECTOR.getTableQuery("db", "schema", "table",
                                                 100, "random", null));
-    // sorted random query
+    // random query, strata input
     Assert.assertEquals(String.format("SELECT * FROM %s\n" +
-                                        "WHERE rand() < %d.0 / (SELECT COUNT(*) FROM %s)\n" +
-                                        "ORDER BY %s",
-                                      tableName, 100, tableName, "strata"),
+                                        "WHERE rand() < %d.0 / (SELECT COUNT(*) FROM %s)",
+                                      tableName, 100, tableName),
                         CONNECTOR.getTableQuery("db", "schema", "table",
                                                 100, "random", "strata"));
   }

--- a/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlConnectorUnitTest.java
+++ b/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlConnectorUnitTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.mysql;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Unit tests for {@link MysqlConnector}
+ */
+public class MysqlConnectorUnitTest {
+  @Rule
+  public ExpectedException expectedEx = ExpectedException.none();
+
+  /**
+   * Unit test for getTableName()
+   */
+  @Test
+  public void getTableNameTest() {
+    MysqlConnector connector = new MysqlConnector(null);
+    Assert.assertEquals("`db`.`table`",
+                        connector.getTableName("db", "schema", "table"));
+  }
+
+  /**
+   * Unit tests for getTableQuery()
+   */
+  @Test
+  public void getTableQueryTest() {
+    MysqlConnector connector = new MysqlConnector(null);
+    String tableName = connector.getTableName("db", "schema", "table");
+
+    // default query, sampleType "first"
+    Assert.assertEquals(String.format("SELECT * FROM %s LIMIT 100", tableName),
+                        connector.getTableQuery("db", "schema", "table",
+                                                100, "first", null));
+    // default query, sampleType null
+    Assert.assertEquals(String.format("SELECT * FROM %s LIMIT 100", tableName),
+                        connector.getTableQuery("db", "schema", "table",
+                                                100, null, null));
+    // random query
+    Assert.assertEquals(String.format("SELECT * FROM %s\n" +
+                                        "WHERE rand() < %d.0 / (SELECT COUNT(*) FROM %s)",
+                                      tableName, 100, tableName),
+                        connector.getTableQuery("db", "schema", "table",
+                                                100, "random", null));
+    // stratified query
+    Assert.assertEquals(String.format("SELECT * FROM %s\n" +
+                                        "WHERE rand() < %d.0 / (SELECT COUNT(*) FROM %s)\n" +
+                                        "ORDER BY %s",
+                                      tableName, 100, tableName, "strata"),
+                        connector.getTableQuery("db", "schema", "table",
+                                                100, "stratified", "strata"));
+  }
+
+  /**
+   * Test for getTableQuery() null strata exception
+   *
+   * @throws IllegalArgumentException
+   */
+  @Test
+  public void getTableQueryNullStrataTest() throws IllegalArgumentException {
+    expectedEx.expect(IllegalArgumentException.class);
+    MysqlConnector connector = new MysqlConnector(null);
+    connector.getTableQuery("db", "schema", "table", 100, "stratified", null);
+  }
+
+}

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
@@ -78,7 +78,9 @@ public class OracleConnector extends AbstractDBSpecificConnector<OracleSourceDBR
     setConnectionProperties(sinkProperties, request);
     builder
       .addRelatedPlugin(new PluginSpec(OracleConstants.PLUGIN_NAME, BatchSource.PLUGIN_TYPE, sourceProperties))
-      .addRelatedPlugin(new PluginSpec(OracleConstants.PLUGIN_NAME, BatchSink.PLUGIN_TYPE, sinkProperties));
+      .addRelatedPlugin(new PluginSpec(OracleConstants.PLUGIN_NAME, BatchSink.PLUGIN_TYPE, sinkProperties))
+      .addSupportedSampleType("random")
+      .addSupportedSampleType("stratified");
 
     String schema = path.getSchema();
     if (schema != null) {

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
@@ -167,16 +167,23 @@ public class OracleConnector extends AbstractDBSpecificConnector<OracleSourceDBR
       case "random":
         // This query guarantees exactly "limit" rows.
         // Note that it is very slow on large tables, since it assigns _every_ row a number and then sorts them
-        return String.format("SELECT * FROM (" +
-                "SELECT * FROM %s ORDER BY DBMS_RANDOM.RANDOM)" +
-                "WHERE rownum <= %d", tableName, limit);
-      // case "stratified":
-      //  if (strata == null) {
-      //    throw new IllegalArgumentException("No strata column given.");
-      //  }
-      // TODO: add in stratified sampling here
+        return String.format("SELECT * FROM (\n" +
+                               "SELECT * FROM %s ORDER BY DBMS_RANDOM.RANDOM\n" +
+                               ")\n" +
+                               "WHERE rownum <= %d",
+                             tableName, limit);
+      case "stratified":
+       if (strata == null) {
+         throw new IllegalArgumentException("No strata column given.");
+       }
+       return String.format("SELECT * FROM (\n" +
+                              "SELECT * FROM %s ORDER BY DBMS_RANDOM.RANDOM\n" +
+                              ")\n" +
+                              "WHERE rownum <= %d\n" +
+                              "ORDER BY %s",
+                            tableName, limit, strata);
       default:
-        return super.getTableQuery(database, schema, table, limit);
+        return getTableQuery(database, schema, table, limit);
     }
   }
 }

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
@@ -80,7 +80,7 @@ public class OracleConnector extends AbstractDBSpecificConnector<OracleSourceDBR
       .addRelatedPlugin(new PluginSpec(OracleConstants.PLUGIN_NAME, BatchSource.PLUGIN_TYPE, sourceProperties))
       .addRelatedPlugin(new PluginSpec(OracleConstants.PLUGIN_NAME, BatchSink.PLUGIN_TYPE, sinkProperties))
       .addSupportedSampleType("random")
-      .addSupportedSampleType("stratified");
+      .addSupportedSampleType("randomSorted");
 
     String schema = path.getSchema();
     if (schema != null) {

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
@@ -154,22 +154,13 @@ public class OracleConnector extends AbstractDBSpecificConnector<OracleSourceDBR
     String tableName = getTableName(database, schema, table);
     switch (sampleType) {
       case "random":
-        if (strata == null) {
-          // This query guarantees exactly "limit" rows.
-          // Note that it is very slow on large tables, since it assigns _every_ row a number and then sorts them
-          return String.format("SELECT * FROM (\n" +
-                                 "SELECT * FROM %s ORDER BY DBMS_RANDOM.RANDOM\n" +
-                                 ")\n" +
-                                 "WHERE rownum <= %d",
-                               tableName, limit);
-        } else {
-          return String.format("SELECT * FROM (\n" +
-                                 "SELECT * FROM %s ORDER BY DBMS_RANDOM.RANDOM\n" +
-                                 ")\n" +
-                                 "WHERE rownum <= %d\n" +
-                                 "ORDER BY %s",
-                               tableName, limit, strata);
-        }
+        // This query guarantees exactly "limit" rows.
+        // Note that it is very slow on large tables, since it assigns _every_ row a number and then sorts them
+        return String.format("SELECT * FROM (\n" +
+                               "SELECT * FROM %s ORDER BY DBMS_RANDOM.RANDOM\n" +
+                               ")\n" +
+                               "WHERE rownum <= %d",
+                             tableName, limit);
       default:
         return getTableQuery(database, schema, table, limit);
     }

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
@@ -134,13 +134,14 @@ public class OracleConnector extends AbstractDBSpecificConnector<OracleSourceDBR
   }
 
   @Override
-  protected String getTableQuery(String database, String schema, String table) {
-    return String.format("SELECT * from \"%s\".\"%s\"", schema, table);
+  protected String getTableName(String database, String schema, String table) {
+    return String.format("\"%s\".\"%s\"", schema, table);
   }
 
   @Override
   protected String getTableQuery(String database, String schema, String table, int limit) {
-    return String.format("SELECT * FROM \"%s\".\"%s\" WHERE ROWNUM <= %d", schema, table, limit);
+    String tableName = getTableName(database, schema, table);
+    return String.format("SELECT * FROM %s WHERE ROWNUM <= %d", tableName, limit);
   }
 
   @Override

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
@@ -165,10 +165,11 @@ public class OracleConnector extends AbstractDBSpecificConnector<OracleSourceDBR
     String tableName = getTableName(database, schema, table);
     switch (sampleType) {
       case "random":
-        // This query doesn't guarantee exactly "limit" number of rows
-        // It instead selects each row with probability limit/num_rows.
-        return String.format("SELECT * FROM %s " +
-                "SAMPLE(100.0 * %d / (SELECT COUNT(*) FROM %s))", tableName, limit, tableName);
+        // This query guarantees exactly "limit" rows.
+        // Note that it is very slow on large tables, since it assigns _every_ row a number and then sorts them
+        return String.format("SELECT * FROM (" +
+                "SELECT * FROM %s ORDER BY DBMS_RANDOM.RANDOM)" +
+                "WHERE rownum <= %d", tableName, limit);
       // case "stratified":
       //  if (strata == null) {
       //    throw new IllegalArgumentException("No strata column given.");

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
@@ -160,7 +160,7 @@ public class OracleConnector extends AbstractDBSpecificConnector<OracleSourceDBR
   protected String getTableQuery(String database, String schema, String table, int limit, String sampleType,
                                  String strata) {
     if (sampleType == null) {
-      return super.getTableQuery(database, schema, table, limit);
+      return getTableQuery(database, schema, table, limit);
     }
     String tableName = getTableName(database, schema, table);
     switch (sampleType) {

--- a/oracle-plugin/src/test/java/io/cdap/plugin/oracle/OracleConnectorUnitTest.java
+++ b/oracle-plugin/src/test/java/io/cdap/plugin/oracle/OracleConnectorUnitTest.java
@@ -59,7 +59,7 @@ public class OracleConnectorUnitTest {
                                       tableName, 100),
                         CONNECTOR.getTableQuery("db", "schema", "table",
                                                 100, "random", null));
-    // stratified query
+    // sorted random query
     Assert.assertEquals(String.format("SELECT * FROM (\n" +
                                         "SELECT * FROM %s ORDER BY DBMS_RANDOM.RANDOM\n" +
                                         ")\n" +
@@ -67,17 +67,6 @@ public class OracleConnectorUnitTest {
                                         "ORDER BY %s",
                                       tableName, 100, "strata"),
                         CONNECTOR.getTableQuery("db", "schema", "table",
-                                                100, "stratified", "strata"));
-  }
-
-  /**
-   * Test for null strata exception
-   *
-   * @throws IllegalArgumentException
-   */
-  @Test
-  public void getTableQueryNullStrataTest() throws IllegalArgumentException {
-    expectedEx.expect(IllegalArgumentException.class);
-    CONNECTOR.getTableQuery("db", "schema", "table", 100, "stratified", null);
+                                                100, "random", "strata"));
   }
 }

--- a/oracle-plugin/src/test/java/io/cdap/plugin/oracle/OracleConnectorUnitTest.java
+++ b/oracle-plugin/src/test/java/io/cdap/plugin/oracle/OracleConnectorUnitTest.java
@@ -59,13 +59,12 @@ public class OracleConnectorUnitTest {
                                       tableName, 100),
                         CONNECTOR.getTableQuery("db", "schema", "table",
                                                 100, "random", null));
-    // sorted random query
+    // random query, strata input
     Assert.assertEquals(String.format("SELECT * FROM (\n" +
                                         "SELECT * FROM %s ORDER BY DBMS_RANDOM.RANDOM\n" +
                                         ")\n" +
-                                        "WHERE rownum <= %d\n" +
-                                        "ORDER BY %s",
-                                      tableName, 100, "strata"),
+                                        "WHERE rownum <= %d",
+                                      tableName, 100),
                         CONNECTOR.getTableQuery("db", "schema", "table",
                                                 100, "random", "strata"));
   }

--- a/oracle-plugin/src/test/java/io/cdap/plugin/oracle/OracleConnectorUnitTest.java
+++ b/oracle-plugin/src/test/java/io/cdap/plugin/oracle/OracleConnectorUnitTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.oracle;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class OracleConnectorUnitTest {
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+    private static final OracleConnector CONNECTOR = new OracleConnector(null);
+
+    /**
+     * Unit test for getTableName()
+     */
+    @Test
+    public void getTableNameTest() {
+      Assert.assertEquals("\"schema\".\"table\"",
+                          CONNECTOR.getTableName("db", "schema", "table"));
+    }
+
+  /**
+   * Unit tests for getTableQuery()
+   */
+  @Test
+  public void getTableQueryTest() {
+    String tableName = CONNECTOR.getTableName("db", "schema", "table");
+
+    // default query, sampleType "first"
+    Assert.assertEquals(String.format("SELECT * FROM %s WHERE ROWNUM <= %d", tableName, 100),
+                        CONNECTOR.getTableQuery("db", "schema", "table",
+                                                100, "first", null));
+    // default query, sampleType null
+    Assert.assertEquals(String.format("SELECT * FROM %s WHERE ROWNUM <= %d", tableName, 100),
+                        CONNECTOR.getTableQuery("db", "schema", "table",
+                                                100, null, null));
+    // random query
+    Assert.assertEquals(String.format("SELECT * FROM (\n" +
+                                        "SELECT * FROM %s ORDER BY DBMS_RANDOM.RANDOM\n" +
+                                        ")\n" +
+                                        "WHERE rownum <= %d",
+                                      tableName, 100),
+                        CONNECTOR.getTableQuery("db", "schema", "table",
+                                                100, "random", null));
+    // stratified query
+    Assert.assertEquals(String.format("SELECT * FROM (\n" +
+                                        "SELECT * FROM %s ORDER BY DBMS_RANDOM.RANDOM\n" +
+                                        ")\n" +
+                                        "WHERE rownum <= %d\n" +
+                                        "ORDER BY %s",
+                                      tableName, 100, "strata"),
+                        CONNECTOR.getTableQuery("db", "schema", "table",
+                                                100, "stratified", "strata"));
+  }
+
+  /**
+   * Test for null strata exception
+   *
+   * @throws IllegalArgumentException
+   */
+  @Test
+  public void getTableQueryNullStrataTest() throws IllegalArgumentException {
+    expectedEx.expect(IllegalArgumentException.class);
+    CONNECTOR.getTableQuery("db", "schema", "table", 100, "stratified", null);
+  }
+}

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresConnector.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresConnector.java
@@ -126,17 +126,10 @@ public class PostgresConnector extends AbstractDBSpecificConnector<PostgresDBRec
     String tableName = getTableName(database, schema, table);
     switch (sampleType) {
       case "random":
-        if (strata == null) {
-          // This query doesn't guarantee exactly "limit" number of rows
-          return String.format("SELECT * FROM %s\n" +
-                                 "TABLESAMPLE BERNOULLI (100.0 * %d / (SELECT COUNT(*) FROM %s))",
-                               tableName, limit, tableName);
-        } else {
-          return String.format("SELECT * FROM %s\n" +
-                                 "TABLESAMPLE BERNOULLI (100.0 * %d / (SELECT COUNT(*) FROM %s))\n" +
-                                 "ORDER BY %s",
-                               tableName, limit, tableName, strata);
-        }
+        // This query doesn't guarantee exactly "limit" number of rows
+        return String.format("SELECT * FROM %s\n" +
+                               "TABLESAMPLE BERNOULLI (100.0 * %d / (SELECT COUNT(*) FROM %s))",
+                             tableName, limit, tableName);
       default:
         return getTableQuery(database, schema, table, limit);
     }

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresConnector.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresConnector.java
@@ -81,7 +81,7 @@ public class PostgresConnector extends AbstractDBSpecificConnector<PostgresDBRec
       .addRelatedPlugin(new PluginSpec(PostgresConstants.PLUGIN_NAME, BatchSource.PLUGIN_TYPE, sourceProperties))
       .addRelatedPlugin(new PluginSpec(PostgresConstants.PLUGIN_NAME, BatchSink.PLUGIN_TYPE, sinkProperties))
       .addSupportedSampleType("random")
-      .addSupportedSampleType("stratified");
+      .addSupportedSampleType("randomSorted");
 
     String schema = path.getSchema();
     if (schema != null) {

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresConnector.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresConnector.java
@@ -120,7 +120,7 @@ public class PostgresConnector extends AbstractDBSpecificConnector<PostgresDBRec
   protected String getTableQuery(String database, String schema, String table, int limit, String sampleType,
                                  String strata) {
     if (sampleType == null) {
-      return super.getTableQuery(database, schema, table, limit);
+      return getTableQuery(database, schema, table, limit);
     }
     String tableName = getTableName(database, schema, table);
     switch (sampleType) {

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresConnector.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresConnector.java
@@ -116,4 +116,26 @@ public class PostgresConnector extends AbstractDBSpecificConnector<PostgresDBRec
     return String.format("\"%s\".\"%s\"", schema, table);
   }
 
+  @Override
+  protected String getTableQuery(String database, String schema, String table, int limit, String sampleType,
+                                 String strata) {
+    if (sampleType == null) {
+      return super.getTableQuery(database, schema, table, limit);
+    }
+    String tableName = getTableName(database, schema, table);
+    switch (sampleType) {
+      case "random":
+        // This query doesn't guarantee exactly "limit" number of rows
+        return String.format("SELECT * FROM %s " +
+                "TABLESAMPLE BERNOULLI (100.0 * %d / (SELECT COUNT(*) FROM %s))", tableName, limit, tableName);
+        // case "stratified":
+        //  if (strata == null) {
+        //    throw new IllegalArgumentException("No strata column given.");
+        //  }
+        // TODO: add in stratified sampling here
+      default:
+        return super.getTableQuery(database, schema, table, limit);
+    }
+
+  }
 }

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresConnector.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresConnector.java
@@ -112,13 +112,8 @@ public class PostgresConnector extends AbstractDBSpecificConnector<PostgresDBRec
   }
 
   @Override
-  protected String getTableQuery(String database, String schema, String table) {
-    return String.format("SELECT * FROM \"%s\".\"%s\"", schema, table);
-  }
-
-  @Override
-  protected String getTableQuery(String database, String schema, String table, int limit) {
-    return String.format("SELECT * FROM \"%s\".\"%s\" LIMIT %d", schema, table, limit);
+  protected String getTableName(String database, String schema, String table) {
+    return String.format("\"%s\".\"%s\"", schema, table);
   }
 
 }

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresConnector.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresConnector.java
@@ -79,7 +79,9 @@ public class PostgresConnector extends AbstractDBSpecificConnector<PostgresDBRec
     setConnectionProperties(sinkProperties, request);
     builder
       .addRelatedPlugin(new PluginSpec(PostgresConstants.PLUGIN_NAME, BatchSource.PLUGIN_TYPE, sourceProperties))
-      .addRelatedPlugin(new PluginSpec(PostgresConstants.PLUGIN_NAME, BatchSink.PLUGIN_TYPE, sinkProperties));
+      .addRelatedPlugin(new PluginSpec(PostgresConstants.PLUGIN_NAME, BatchSink.PLUGIN_TYPE, sinkProperties))
+      .addSupportedSampleType("random")
+      .addSupportedSampleType("stratified");
 
     String schema = path.getSchema();
     if (schema != null) {

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresConnector.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresConnector.java
@@ -136,6 +136,5 @@ public class PostgresConnector extends AbstractDBSpecificConnector<PostgresDBRec
       default:
         return super.getTableQuery(database, schema, table, limit);
     }
-
   }
 }

--- a/postgresql-plugin/src/test/java/io/cdap/plugin/postgres/PostgresConnectorUnitTest.java
+++ b/postgresql-plugin/src/test/java/io/cdap/plugin/postgres/PostgresConnectorUnitTest.java
@@ -60,11 +60,10 @@ public class PostgresConnectorUnitTest {
                                       tableName, 100, tableName),
                         CONNECTOR.getTableQuery("db", "schema", "table",
                                                 100, "random", null));
-    // sorted random query
+    // random query, strata input
     Assert.assertEquals(String.format("SELECT * FROM %s\n" +
-                                        "TABLESAMPLE BERNOULLI (100.0 * %d / (SELECT COUNT(*) FROM %s))\n" +
-                                        "ORDER BY %s",
-                                      tableName, 100, tableName, "strata"),
+                                        "TABLESAMPLE BERNOULLI (100.0 * %d / (SELECT COUNT(*) FROM %s))",
+                                      tableName, 100, tableName),
                         CONNECTOR.getTableQuery("db", "schema", "table",
                                                 100, "random", "strata"));
   }

--- a/postgresql-plugin/src/test/java/io/cdap/plugin/postgres/PostgresConnectorUnitTest.java
+++ b/postgresql-plugin/src/test/java/io/cdap/plugin/postgres/PostgresConnectorUnitTest.java
@@ -75,7 +75,7 @@ public class PostgresConnectorUnitTest {
    * @throws IllegalArgumentException
    */
   @Test
-  public void getTableQueryNullStrataTest() {
+  public void getTableQueryNullStrataTest() throws IllegalArgumentException {
     expectedEx.expect(IllegalArgumentException.class);
     PostgresConnector connector = new PostgresConnector(null);
     connector.getTableQuery("db", "schema", "table", 100, "stratified", null);

--- a/postgresql-plugin/src/test/java/io/cdap/plugin/postgres/PostgresConnectorUnitTest.java
+++ b/postgresql-plugin/src/test/java/io/cdap/plugin/postgres/PostgresConnectorUnitTest.java
@@ -60,23 +60,12 @@ public class PostgresConnectorUnitTest {
                                       tableName, 100, tableName),
                         CONNECTOR.getTableQuery("db", "schema", "table",
                                                 100, "random", null));
-    // stratified query
+    // sorted random query
     Assert.assertEquals(String.format("SELECT * FROM %s\n" +
                                         "TABLESAMPLE BERNOULLI (100.0 * %d / (SELECT COUNT(*) FROM %s))\n" +
                                         "ORDER BY %s",
                                       tableName, 100, tableName, "strata"),
                         CONNECTOR.getTableQuery("db", "schema", "table",
-                                                100, "stratified", "strata"));
-  }
-
-  /**
-   * Test for null strata exception
-   *
-   * @throws IllegalArgumentException
-   */
-  @Test
-  public void getTableQueryNullStrataTest() throws IllegalArgumentException {
-    expectedEx.expect(IllegalArgumentException.class);
-    CONNECTOR.getTableQuery("db", "schema", "table", 100, "stratified", null);
+                                                100, "random", "strata"));
   }
 }

--- a/postgresql-plugin/src/test/java/io/cdap/plugin/postgres/PostgresConnectorUnitTest.java
+++ b/postgresql-plugin/src/test/java/io/cdap/plugin/postgres/PostgresConnectorUnitTest.java
@@ -28,14 +28,15 @@ public class PostgresConnectorUnitTest {
   @Rule
   public ExpectedException expectedEx = ExpectedException.none();
 
+  private static final PostgresConnector CONNECTOR = new PostgresConnector(null);
+
   /**
    * Unit test for getTableName()
    */
   @Test
   public void getTableNameTest() {
-    PostgresConnector connector = new PostgresConnector(null);
     Assert.assertEquals("\"schema\".\"table\"",
-                        connector.getTableName("db", "schema", "table"));
+                        CONNECTOR.getTableName("db", "schema", "table"));
   }
 
   /**
@@ -43,29 +44,28 @@ public class PostgresConnectorUnitTest {
    */
   @Test
   public void getTableQueryTest() {
-    PostgresConnector connector = new PostgresConnector(null);
-    String tableName = connector.getTableName("db", "schema", "table");
+    String tableName = CONNECTOR.getTableName("db", "schema", "table");
 
     // default query, sampleType "first"
     Assert.assertEquals(String.format("SELECT * FROM %s LIMIT 100", tableName),
-                        connector.getTableQuery("db", "schema", "table",
+                        CONNECTOR.getTableQuery("db", "schema", "table",
                                                 100, "first", null));
     // default query, sampleType null
     Assert.assertEquals(String.format("SELECT * FROM %s LIMIT 100", tableName),
-                        connector.getTableQuery("db", "schema", "table",
+                        CONNECTOR.getTableQuery("db", "schema", "table",
                                                 100, null, null));
     // random query
     Assert.assertEquals(String.format("SELECT * FROM %s\n" +
                                         "TABLESAMPLE BERNOULLI (100.0 * %d / (SELECT COUNT(*) FROM %s))",
                                       tableName, 100, tableName),
-                        connector.getTableQuery("db", "schema", "table",
+                        CONNECTOR.getTableQuery("db", "schema", "table",
                                                 100, "random", null));
     // stratified query
     Assert.assertEquals(String.format("SELECT * FROM %s\n" +
                                         "TABLESAMPLE BERNOULLI (100.0 * %d / (SELECT COUNT(*) FROM %s))\n" +
                                         "ORDER BY %s",
                                       tableName, 100, tableName, "strata"),
-                        connector.getTableQuery("db", "schema", "table",
+                        CONNECTOR.getTableQuery("db", "schema", "table",
                                                 100, "stratified", "strata"));
   }
 
@@ -77,7 +77,6 @@ public class PostgresConnectorUnitTest {
   @Test
   public void getTableQueryNullStrataTest() throws IllegalArgumentException {
     expectedEx.expect(IllegalArgumentException.class);
-    PostgresConnector connector = new PostgresConnector(null);
-    connector.getTableQuery("db", "schema", "table", 100, "stratified", null);
+    CONNECTOR.getTableQuery("db", "schema", "table", 100, "stratified", null);
   }
 }

--- a/postgresql-plugin/src/test/java/io/cdap/plugin/postgres/PostgresConnectorUnitTest.java
+++ b/postgresql-plugin/src/test/java/io/cdap/plugin/postgres/PostgresConnectorUnitTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.postgres;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Unit tests for {@link PostgresConnector}
+ */
+public class PostgresConnectorUnitTest {
+  @Rule
+  public ExpectedException expectedEx = ExpectedException.none();
+
+  /**
+   * Unit test for getTableName()
+   */
+  @Test
+  public void getTableNameTest() {
+    PostgresConnector connector = new PostgresConnector(null);
+    Assert.assertEquals("\"schema\".\"table\"",
+                        connector.getTableName("db", "schema", "table"));
+  }
+
+  /**
+   * Unit tests for getTableQuery()
+   */
+  @Test
+  public void getTableQueryTest() {
+    PostgresConnector connector = new PostgresConnector(null);
+    String tableName = connector.getTableName("db", "schema", "table");
+
+    // default query, sampleType "first"
+    Assert.assertEquals(String.format("SELECT * FROM %s LIMIT 100", tableName),
+                        connector.getTableQuery("db", "schema", "table",
+                                                100, "first", null));
+    // default query, sampleType null
+    Assert.assertEquals(String.format("SELECT * FROM %s LIMIT 100", tableName),
+                        connector.getTableQuery("db", "schema", "table",
+                                                100, null, null));
+    // random query
+    Assert.assertEquals(String.format("SELECT * FROM %s\n" +
+                                        "TABLESAMPLE BERNOULLI (100.0 * %d / (SELECT COUNT(*) FROM %s))",
+                                      tableName, 100, tableName),
+                        connector.getTableQuery("db", "schema", "table",
+                                                100, "random", null));
+    // stratified query
+    Assert.assertEquals(String.format("SELECT * FROM %s\n" +
+                                        "TABLESAMPLE BERNOULLI (100.0 * %d / (SELECT COUNT(*) FROM %s))\n" +
+                                        "ORDER BY %s",
+                                      tableName, 100, tableName, "strata"),
+                        connector.getTableQuery("db", "schema", "table",
+                                                100, "stratified", "strata"));
+  }
+
+  /**
+   * Test for null strata exception
+   *
+   * @throws IllegalArgumentException
+   */
+  @Test
+  public void getTableQueryNullStrataTest() {
+    expectedEx.expect(IllegalArgumentException.class);
+    PostgresConnector connector = new PostgresConnector(null);
+    connector.getTableQuery("db", "schema", "table", 100, "stratified", null);
+  }
+}


### PR DESCRIPTION
# Add Sampling Options for Multiple Database Connectors

## Description
Added `random` sampling option to PostgreSQL, MySQL, OracleDB, and SQLServer connections in Wrangler, checking for `sampleType` in sample properties to determine which option (first [default] or random) to use.

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: none