### PR TITLE
Add Sampling Options for Multiple Database Connectors

### DIFF
--- a/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLConnector.java
+++ b/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLConnector.java
@@ -72,13 +72,8 @@ public class CloudSQLMySQLConnector extends AbstractDBSpecificConnector<DBRecord
   }
 
   @Override
-  protected String getTableQuery(String database, String schema, String table) {
-    return String.format("SELECT * FROM `%s`.`%s`", database, table);
-  }
-
-  @Override
-  protected String getTableQuery(String database, String schema, String table, int limit) {
-    return String.format("SELECT * FROM `%s`.`%s` LIMIT %d", database, table, limit);
+  protected String getTableName(String database, String schema, String table) {
+    return String.format("`%s`.`%s`", database, table);
   }
 
   @Override

--- a/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLConnector.java
+++ b/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLConnector.java
@@ -79,18 +79,13 @@ public class CloudSQLPostgreSQLConnector extends AbstractDBSpecificConnector<Pos
   }
 
   @Override
-  protected SchemaReader getSchemaReader() {
-    return new PostgresSchemaReader();
+  protected SchemaReader getSchemaReader(String sessionID) {
+    return new PostgresSchemaReader(sessionID);
   }
 
   @Override
-  protected String getTableQuery(String database, String schema, String table) {
-    return String.format("SELECT * FROM \"%s\".\"%s\"", schema, table);
-  }
-
-  @Override
-  protected String getTableQuery(String database, String schema, String table, int limit) {
-    return String.format("SELECT * FROM \"%s\".\"%s\" LIMIT %d", schema, table, limit);
+  protected String getTableName(String database, String schema, String table) {
+    return String.format("\"%s\".\"%s\"", schema, table);
   }
 
   @Override

--- a/database-commons/src/main/java/io/cdap/plugin/db/ConnectionConfigAccessor.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/ConnectionConfigAccessor.java
@@ -111,5 +111,4 @@ public class ConnectionConfigAccessor {
   public Configuration getConfiguration() {
     return configuration;
   }
-
 }

--- a/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnector.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Cask Data, Inc.
+ * Copyright © 2021-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -23,13 +23,13 @@ import io.cdap.cdap.etl.api.batch.BatchConnector;
 import io.cdap.cdap.etl.api.connector.ConnectorContext;
 import io.cdap.cdap.etl.api.connector.ConnectorSpecRequest;
 import io.cdap.cdap.etl.api.connector.SampleRequest;
+import io.cdap.cdap.etl.api.connector.SampleType;
 import io.cdap.plugin.common.ConfigUtil;
 import io.cdap.plugin.common.SourceInputFormatProvider;
 import io.cdap.plugin.common.db.AbstractDBConnector;
 import io.cdap.plugin.common.db.DBConnectorPath;
 import io.cdap.plugin.common.util.ExceptionUtils;
 import io.cdap.plugin.db.CommonSchemaReader;
-import io.cdap.plugin.db.ConnectionConfig;
 import io.cdap.plugin.db.ConnectionConfigAccessor;
 import io.cdap.plugin.db.SchemaReader;
 import io.cdap.plugin.db.batch.source.DataDrivenETLDBInputFormat;
@@ -44,9 +44,12 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Map;
+import java.util.UUID;
+import javax.annotation.Nullable;
 
 /**
  * An Abstract DB Specific Connector those specific DB connectors can inherits
+ *
  * @param <T> the Record type that specific DB Record Reader may return while sample the data with InputFormat
  */
 public abstract class AbstractDBSpecificConnector<T extends DBWritable> extends AbstractDBConnector
@@ -63,7 +66,7 @@ public abstract class AbstractDBSpecificConnector<T extends DBWritable> extends 
 
   protected abstract Class<? extends DBWritable> getDBRecordType();
 
-  protected SchemaReader getSchemaReader() {
+  protected SchemaReader getSchemaReader(String sessionID) {
     return new CommonSchemaReader();
   }
 
@@ -84,14 +87,16 @@ public abstract class AbstractDBSpecificConnector<T extends DBWritable> extends 
     ConnectionConfigAccessor connectionConfigAccessor = new ConnectionConfigAccessor();
     if (config.getUser() == null && config.getPassword() == null) {
       DBConfiguration.configureDB(connectionConfigAccessor.getConfiguration(), driverClass.getName(),
-                     getConnectionString(path.getDatabase()));
+                                  getConnectionString(path.getDatabase()));
     } else {
       DBConfiguration.configureDB(connectionConfigAccessor.getConfiguration(), driverClass.getName(),
-                     getConnectionString(path.getDatabase()), config.getUser(), config.getPassword());
+                                  getConnectionString(path.getDatabase()), config.getUser(), config.getPassword());
     }
-    String tableQuery = getTableQuery(path.getDatabase(), path.getSchema(), path.getTable(), request.getLimit());
+    String sessionID = generateSessionID();
+    String tableQuery = getTableQuery(path.getDatabase(), path.getSchema(), path.getTable(), request.getLimit(),
+      request.getProperties().get("sampleType"), request.getProperties().get("strata"), sessionID);
     DataDrivenETLDBInputFormat.setInput(connectionConfigAccessor.getConfiguration(), getDBRecordType(),
-                                        tableQuery, null, false);
+      tableQuery, null, false);
     connectionConfigAccessor.setConnectionArguments(Maps.fromProperties(config.getConnectionArgumentsProperties()));
     connectionConfigAccessor.getConfiguration().setInt(MRJobConfig.NUM_MAPS, 1);
     Map<String, String> additionalArguments = config.getAdditionalArguments();
@@ -99,41 +104,81 @@ public abstract class AbstractDBSpecificConnector<T extends DBWritable> extends 
       connectionConfigAccessor.getConfiguration().set(argument.getKey(), argument.getValue());
     }
     try {
-      connectionConfigAccessor.setSchema(loadTableSchema(getConnection(path),  tableQuery).toString());
+      Long timeoutMs = request.getTimeoutMs();
+      Integer timeoutSec = timeoutMs != null ? (int) (timeoutMs / 1000) : null;
+      connectionConfigAccessor
+        .setSchema(loadTableSchema(getConnection(path), tableQuery, timeoutSec, sessionID).toString());
     } catch (SQLException e) {
       throw new IOException(String.format("Failed to get table schema due to: %s.",
-                                          ExceptionUtils.getRootCauseMessage(e)), e);
+        ExceptionUtils.getRootCauseMessage(e)), e);
     }
-
 
     return new SourceInputFormatProvider(DataDrivenETLDBInputFormat.class, connectionConfigAccessor.getConfiguration());
   }
 
   protected Connection getConnection(DBConnectorPath path) {
-    return getConnection(getConnectionString(path.getDatabase()) , config.getConnectionArgumentsProperties());
+    return getConnection(getConnectionString(path.getDatabase()), config.getConnectionArgumentsProperties());
   }
 
   protected String getConnectionString(String database) {
     return config.getConnectionString();
   }
 
+  protected String getTableName(String database, String schema, String table) {
+    return schema == null ? String.format("\"%s\".\"%s\"", database, table)
+      : String.format("\"%s\".\"%s\".\"%s\"", database, schema, table);
+  }
+
   protected String getTableQuery(String database, String schema, String table) {
-    return schema == null ? String.format("SELECT * FROM \"%s\".\"%s\"", database, table)
-      : String.format("SELECT * FROM \"%s\".\"%s\".\"%s\"", database, schema, table);
+    String tableName = getTableName(database, schema, table);
+    return String.format("SELECT * FROM %s", tableName);
   }
 
   protected String getTableQuery(String database, String schema, String table, int limit) {
-    return schema == null ?
-      String.format("SELECT * FROM \"%s\".\"%s\" LIMIT %d", database, table, limit) :
-      String.format(
-        "SELECT * FROM \"%s\".\"%s\".\"%s\" LIMIT %d", database, schema, table, limit);
+    String tableName = getTableName(database, schema, table);
+    return String.format("SELECT * FROM %s LIMIT %d", tableName, limit);
   }
 
-  protected Schema loadTableSchema(Connection connection, String query) throws SQLException {
+  protected String getTableQuery(String database, String schema, String table, int limit, String sampleType,
+                                 String strata, String sessionID) throws IOException {
+    if (sampleType == null) {
+      return getTableQuery(database, schema, table, limit);
+    }
+    String tableName = getTableName(database, schema, table);
+    switch (SampleType.fromString(sampleType)) {
+      case RANDOM:
+        return getRandomQuery(tableName, limit);
+      case STRATIFIED:
+        if (strata == null) {
+          throw new IllegalArgumentException("No strata column given.");
+        }
+        return getStratifiedQuery(tableName, limit, strata, sessionID);
+      default:
+        return getTableQuery(database, schema, table, limit);
+    }
+  }
+
+  // Get the query to use for randomized sampling.
+  // By default, databases don't support randomized sampling; this method must be overridden
+  protected String getRandomQuery(String tableName, int limit) throws IOException {
+    throw new IOException("Connection does not support random sampling.");
+  }
+
+  // Get the query to use for stratified sampling.
+  // By default, databases don't support stratified sampling; this method must be overridden
+  protected String getStratifiedQuery(String tableName, int limit, String strata, String sessionID) throws IOException {
+    throw new IOException("Connection does not support stratified sampling.");
+  }
+
+  protected Schema loadTableSchema(Connection connection, String query, @Nullable Integer timeoutSec, String sessionID)
+    throws SQLException {
     Statement statement = connection.createStatement();
     statement.setMaxRows(1);
+    if (timeoutSec != null) {
+      statement.setQueryTimeout(timeoutSec);
+    }
     ResultSet resultSet = statement.executeQuery(query);
-    return Schema.recordOf("outputSchema", getSchemaReader().getSchemaFields(resultSet));
+    return Schema.recordOf("outputSchema", getSchemaReader(sessionID).getSchemaFields(resultSet));
   }
 
   protected void setConnectionProperties(Map<String, String> properties, ConnectorSpecRequest request) {
@@ -144,7 +189,12 @@ public abstract class AbstractDBSpecificConnector<T extends DBWritable> extends 
   @Override
   protected Schema getTableSchema(Connection connection, String database,
                                   String schema, String table) throws SQLException {
+    String sessionID = generateSessionID();
+    return loadTableSchema(getConnection(), getTableQuery(database, schema, table),
+      null, sessionID);
+  }
 
-    return loadTableSchema(getConnection(),  getTableQuery(database, schema, table));
+  protected String generateSessionID() {
+    return UUID.randomUUID().toString().replace('-', '_');
   }
 }

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerSourceSchemaReader.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerSourceSchemaReader.java
@@ -34,6 +34,17 @@ public class SqlServerSourceSchemaReader extends CommonSchemaReader {
   public static final int SQL_VARIANT = -156;
   public static final String DATETIME_TYPE_PREFIX = "datetime";
 
+  private final String sessionID;
+
+  public SqlServerSourceSchemaReader() {
+    this(null);
+  }
+
+  public SqlServerSourceSchemaReader(String sessionID) {
+    super();
+    this.sessionID = sessionID;
+  }
+
   @Override
   public Schema getSchema(ResultSetMetaData metadata, int index) throws SQLException {
     int columnSqlType = metadata.getColumnType(index);
@@ -71,5 +82,14 @@ public class SqlServerSourceSchemaReader extends CommonSchemaReader {
    */
   public static boolean shouldConvertToDatetime(String typeName) {
     return typeName.startsWith(DATETIME_TYPE_PREFIX);
+  }
+
+  @Override
+  public boolean shouldIgnoreColumn(ResultSetMetaData metadata, int index) throws SQLException {
+    if (sessionID == null) {
+      return false;
+    }
+    return metadata.getColumnName(index).equals("c_" + sessionID) ||
+      metadata.getColumnName(index).equals("sqn_" + sessionID);
   }
 }

--- a/mssql-plugin/src/test/java/io/cdap/plugin/mssql/SqlServerConnectorUnitTest.java
+++ b/mssql-plugin/src/test/java/io/cdap/plugin/mssql/SqlServerConnectorUnitTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.mssql;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Unit tests for {@link SqlServerConnector}
+ */
+public class SqlServerConnectorUnitTest {
+  @Rule
+  public ExpectedException expectedEx = ExpectedException.none();
+
+  private static final SqlServerConnector CONNECTOR = new SqlServerConnector(null);
+
+  /**
+   * Unit tests for getTableQuery()
+   */
+  @Test
+  public void getTableQueryTest() {
+    String tableName = "\"db\".\"schema\".\"table\"";
+
+    // default query
+    Assert.assertEquals(String.format("SELECT TOP %d * FROM %s", 100, tableName),
+                        CONNECTOR.getTableQuery("db", "schema", "table",
+                                                100));
+
+    // random query
+    Assert.assertEquals(String.format("SELECT * FROM %s " +
+                                        "WHERE (ABS(CAST((BINARY_CHECKSUM(*) * RAND()) as int)) %% 100) " +
+                                        "< %d / (SELECT COUNT(*) FROM %s)",
+                                      tableName, 100, tableName),
+                        CONNECTOR.getRandomQuery(tableName, 100));
+  }
+}

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Cask Data, Inc.
+ * Copyright © 2021-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -27,10 +27,11 @@ import io.cdap.cdap.etl.api.connector.Connector;
 import io.cdap.cdap.etl.api.connector.ConnectorSpec;
 import io.cdap.cdap.etl.api.connector.ConnectorSpecRequest;
 import io.cdap.cdap.etl.api.connector.PluginSpec;
+import io.cdap.cdap.etl.api.connector.SampleType;
 import io.cdap.plugin.common.Constants;
 import io.cdap.plugin.common.ReferenceNames;
 import io.cdap.plugin.common.db.DBConnectorPath;
-import io.cdap.plugin.db.DBRecord;
+import io.cdap.plugin.db.SchemaReader;
 import io.cdap.plugin.db.connector.AbstractDBSpecificConnector;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.lib.db.DBWritable;
@@ -60,6 +61,11 @@ public class MysqlConnector extends AbstractDBSpecificConnector<MysqlDBRecord> {
   }
 
   @Override
+  protected SchemaReader getSchemaReader(String sessionID) {
+    return new MysqlSchemaReader(sessionID);
+  }
+
+  @Override
   protected Class<? extends DBWritable> getDBRecordType() {
     return MysqlDBRecord.class;
   }
@@ -70,7 +76,9 @@ public class MysqlConnector extends AbstractDBSpecificConnector<MysqlDBRecord> {
     setConnectionProperties(properties, request);
     builder
       .addRelatedPlugin(new PluginSpec(MysqlConstants.PLUGIN_NAME, BatchSource.PLUGIN_TYPE, properties))
-      .addRelatedPlugin(new PluginSpec(MysqlConstants.PLUGIN_NAME, BatchSink.PLUGIN_TYPE, properties));
+      .addRelatedPlugin(new PluginSpec(MysqlConstants.PLUGIN_NAME, BatchSink.PLUGIN_TYPE, properties))
+      .addSupportedSampleType(SampleType.RANDOM)
+      .addSupportedSampleType(SampleType.STRATIFIED);
 
     String table = path.getTable();
     if (table == null) {
@@ -87,13 +95,38 @@ public class MysqlConnector extends AbstractDBSpecificConnector<MysqlDBRecord> {
   }
 
   @Override
-  protected String getTableQuery(String database, String schema, String table) {
-    return String.format("SELECT * FROM `%s`.`%s`", database, table);
+  public StructuredRecord transform(LongWritable longWritable, MysqlDBRecord record) {
+    return record.getRecord();
   }
 
   @Override
-  protected String getTableQuery(String database, String schema, String table, int limit) {
-    return String.format("SELECT * FROM `%s`.`%s` LIMIT %d", database, table, limit);
+  protected String getTableName(String database, String schema, String table) {
+    return String.format("`%s`.`%s`", database, table);
+  }
+
+  @Override
+  protected String getRandomQuery(String tableName, int limit) {
+    // This query doesn't guarantee exactly "limit" number of rows
+    // Note that we input "limit" with a trailing zero so that division gives an exact result
+    return String.format("SELECT * FROM %s\n" +
+                           "WHERE rand() < %d.0 / (SELECT COUNT(*) FROM %s)",
+                         tableName, limit, tableName);
+  }
+
+  @Override
+  protected String getStratifiedQuery(String tableName, int limit, String strata, String sessionID) {
+    return String.format("WITH t_%s AS (\n" +
+        "    SELECT *,\n" +
+        "    ROW_NUMBER() OVER (ORDER BY %s, RAND()) AS sqn_%s,\n" +
+        "    COUNT(*) OVER () AS c_%s\n" +
+        "    FROM %s\n" +
+        "  )\n" +
+        "SELECT * FROM t_%s\n" +
+        "WHERE MOD(sqn_%s, GREATEST(1, CAST(c_%s / %d AS UNSIGNED))) = 1\n" +
+        "ORDER BY %s\n" +
+        "LIMIT %d",
+      sessionID, strata, sessionID, sessionID, tableName, sessionID, sessionID, sessionID,
+      limit, strata, limit);
   }
 
   @Override

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlSchemaReader.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlSchemaReader.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.mysql;
+
+import io.cdap.plugin.db.CommonSchemaReader;
+
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+
+/**
+ * Schema reader for mapping Mysql DB type
+ */
+public class MysqlSchemaReader extends CommonSchemaReader {
+
+  private final String sessionID;
+
+  public MysqlSchemaReader(String sessionID) {
+    super();
+    this.sessionID = sessionID;
+  }
+
+  @Override
+  public boolean shouldIgnoreColumn(ResultSetMetaData metadata, int index) throws SQLException {
+    return metadata.getColumnName(index).equals("c_" + sessionID) ||
+      metadata.getColumnName(index).equals("sqn_" + sessionID);
+  }
+}

--- a/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlConnectorUnitTest.java
+++ b/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlConnectorUnitTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.mysql;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Unit tests for {@link MysqlConnector}
+ */
+public class MysqlConnectorUnitTest {
+  @Rule
+  public ExpectedException expectedEx = ExpectedException.none();
+
+  private static final MysqlConnector CONNECTOR = new MysqlConnector(null);
+
+  /**
+   * Unit test for getTableName()
+   */
+  @Test
+  public void getTableNameTest() {
+    Assert.assertEquals("`db`.`table`",
+                        CONNECTOR.getTableName("db", "schema", "table"));
+  }
+
+  /**
+   * Unit tests for getTableQuery()
+   */
+  @Test
+  public void getTableQueryTest() {
+    String tableName = CONNECTOR.getTableName("db", "schema", "table");
+
+    // random query
+    Assert.assertEquals(String.format("SELECT * FROM %s\n" +
+                                        "WHERE rand() < %d.0 / (SELECT COUNT(*) FROM %s)",
+                                      tableName, 100, tableName),
+                        CONNECTOR.getRandomQuery(tableName, 100));
+  }
+}

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSourceSchemaReader.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSourceSchemaReader.java
@@ -56,6 +56,17 @@ public class OracleSourceSchemaReader extends CommonSchemaReader {
     Types.DECIMAL
   );
 
+  private final String sessionID;
+
+  public OracleSourceSchemaReader() {
+    this(null);
+  }
+
+  public OracleSourceSchemaReader(String sessionID) {
+    super();
+    this.sessionID = sessionID;
+  }
+
   @Override
   public Schema getSchema(ResultSetMetaData metadata, int index) throws SQLException {
     int sqlType = metadata.getColumnType(index);
@@ -95,5 +106,14 @@ public class OracleSourceSchemaReader extends CommonSchemaReader {
       default:
         return super.getSchema(metadata, index);
     }
+  }
+
+  @Override
+  public boolean shouldIgnoreColumn(ResultSetMetaData metadata, int index) throws SQLException {
+    if (sessionID == null) {
+      return false;
+    }
+    return metadata.getColumnName(index).equals("c_" + sessionID) ||
+      metadata.getColumnName(index).equals("s_" + sessionID);
   }
 }

--- a/oracle-plugin/src/test/java/io/cdap/plugin/oracle/OracleConnectorUnitTest.java
+++ b/oracle-plugin/src/test/java/io/cdap/plugin/oracle/OracleConnectorUnitTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.oracle;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class OracleConnectorUnitTest {
+  @Rule
+  public ExpectedException expectedEx = ExpectedException.none();
+
+  private static final OracleConnector CONNECTOR = new OracleConnector(null);
+
+  /**
+   * Unit test for getTableName()
+   */
+  @Test
+  public void getTableNameTest() {
+    Assert.assertEquals("\"schema\".\"table\"",
+                        CONNECTOR.getTableName("db", "schema", "table"));
+  }
+
+  /**
+   * Unit tests for getTableQuery()
+   */
+  @Test
+  public void getTableQueryTest() {
+    String tableName = CONNECTOR.getTableName("db", "schema", "table");
+
+    // default query
+    Assert.assertEquals(String.format("SELECT * FROM %s WHERE ROWNUM <= %d", tableName, 100),
+                        CONNECTOR.getTableQuery("db", "schema", "table",
+                                                100));
+
+    // random query
+    Assert.assertEquals(String.format("SELECT * FROM (\n" +
+                                        "SELECT * FROM %s ORDER BY DBMS_RANDOM.RANDOM\n" +
+                                        ")\n" +
+                                        "WHERE rownum <= %d",
+                                      tableName, 100),
+                        CONNECTOR.getRandomQuery(tableName, 100));
+  }
+}

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSchemaReader.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSchemaReader.java
@@ -38,6 +38,17 @@ public class PostgresSchemaReader extends CommonSchemaReader {
     "bit", "timetz", "money"
   );
 
+  private final String sessionID;
+
+  public PostgresSchemaReader() {
+    this(null);
+  }
+
+  public PostgresSchemaReader(String sessionID) {
+    super();
+    this.sessionID = sessionID;
+  }
+
   @Override
   public Schema getSchema(ResultSetMetaData metadata, int index) throws SQLException {
     String typeName = metadata.getColumnTypeName(index);
@@ -48,5 +59,14 @@ public class PostgresSchemaReader extends CommonSchemaReader {
     }
 
     return super.getSchema(metadata, index);
+  }
+
+  @Override
+  public boolean shouldIgnoreColumn(ResultSetMetaData metadata, int index) throws SQLException {
+    if (sessionID == null) {
+      return false;
+    }
+    return metadata.getColumnName(index).equals("c_" + sessionID) ||
+      metadata.getColumnName(index).equals("sqn_" + sessionID);
   }
 }

--- a/postgresql-plugin/src/test/java/io/cdap/plugin/postgres/PostgresConnectorUnitTest.java
+++ b/postgresql-plugin/src/test/java/io/cdap/plugin/postgres/PostgresConnectorUnitTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.postgres;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Unit tests for {@link PostgresConnector}
+ */
+public class PostgresConnectorUnitTest {
+  @Rule
+  public ExpectedException expectedEx = ExpectedException.none();
+
+  private static final PostgresConnector CONNECTOR = new PostgresConnector(null);
+
+  /**
+   * Unit test for getTableName()
+   */
+  @Test
+  public void getTableNameTest() {
+    Assert.assertEquals("\"schema\".\"table\"",
+                        CONNECTOR.getTableName("db", "schema", "table"));
+  }
+
+  /**
+   * Unit tests for getTableQuery()
+   */
+  @Test
+  public void getTableQueryTest() {
+    String tableName = CONNECTOR.getTableName("db", "schema", "table");
+
+    // random query
+    Assert.assertEquals(String.format("SELECT * FROM %s\n" +
+                                        "TABLESAMPLE BERNOULLI (100.0 * %d / (SELECT COUNT(*) FROM %s))",
+                                      tableName, 100, tableName),
+                        CONNECTOR.getRandomQuery(tableName, 100));
+  }
+}


### PR DESCRIPTION
# Add Sampling Options for Multiple Database Connectors

## Description
Added `random` sampling option and unit tests to PostgreSQL, MySQL, OracleDB, and SQLServer connections in Wrangler, checking for `sampleType` in sample properties to determine which option (first [default] or random) to use.

Also refactored all DB connectors in `database-plugins` to use a `getTableName()`function within `getTableQuery()` instead of the previous hardcoded SQL queries (merged from #277). The refactor should be backwards-compatible.

Related PRs:
- [cdap #14495](https://github.com/cdapio/cdap/pull/14495)
- [google-cloud #1084](https://github.com/data-integrations/google-cloud/pull/1084)
- [wrangler #573](https://github.com/data-integrations/wrangler/pull/573)
- [cdap-ui #603](https://github.com/cdapio/cdap-ui/pull/603)

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: none