### PR TITLE
Remove duplicate method from MysqlConnector

### DIFF
--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnector.java
@@ -95,11 +95,6 @@ public class MysqlConnector extends AbstractDBSpecificConnector<MysqlDBRecord> {
   }
 
   @Override
-  public StructuredRecord transform(LongWritable longWritable, MysqlDBRecord record) {
-    return record.getRecord();
-  }
-
-  @Override
   protected String getTableName(String database, String schema, String table) {
     return String.format("`%s`.`%s`", database, table);
   }


### PR DESCRIPTION
Recent PR to add sampling options accidentally duplicated a method in `MysqlConnector`, causing builds to fail. This PR reverses that change.