### PR TITLE
Fix SqlServer random query unit test

### DIFF
--- a/mssql-plugin/src/test/java/io/cdap/plugin/mssql/SqlServerConnectorUnitTest.java
+++ b/mssql-plugin/src/test/java/io/cdap/plugin/mssql/SqlServerConnectorUnitTest.java
@@ -36,17 +36,18 @@ public class SqlServerConnectorUnitTest {
   @Test
   public void getTableQueryTest() {
     String tableName = "\"db\".\"schema\".\"table\"";
+    int limit = 100;
 
     // default query
-    Assert.assertEquals(String.format("SELECT TOP %d * FROM %s", 100, tableName),
+    Assert.assertEquals(String.format("SELECT TOP %d * FROM %s", limit, tableName),
                         CONNECTOR.getTableQuery("db", "schema", "table",
-                                                100));
+                                                limit));
 
     // random query
     Assert.assertEquals(String.format("SELECT * FROM %s " +
                                         "WHERE (ABS(CAST((BINARY_CHECKSUM(*) * RAND()) as int)) %% 100) " +
                                         "< %d / (SELECT COUNT(*) FROM %s)",
-                                      tableName, 100, tableName),
-                        CONNECTOR.getRandomQuery(tableName, 100));
+                                      tableName, limit * 100, tableName),
+                        CONNECTOR.getRandomQuery(tableName, limit));
   }
 }


### PR DESCRIPTION
# Fix SqlServer random query unit test

## Description
Fixed an incorrect SqlServer connector unit test in `mssql-plugin`.

## PR Type
- [x] Bug Fix
- [ ] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: none