### PR TITLE
PLUGIN-1374: Update mySql plugin so that rewriteBatchedStatements is set to true

### DIFF
--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnectorConfig.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnectorConfig.java
@@ -28,6 +28,7 @@ public class MysqlConnectorConfig extends AbstractDBSpecificConnectorConfig {
   private static final String MYSQL_CONNECTION_STRING_FORMAT = "jdbc:mysql://%s:%s";
   private static final String JDBC_PROPERTY_CONNECT_TIMEOUT = "connectTimeout";
   private static final String JDBC_PROPERTY_SOCKET_TIMEOUT = "socketTimeout";
+  private static final String JDBC_REWRITE_BATCHED_STATEMENTS = "rewriteBatchedStatements";
 
   public MysqlConnectorConfig(String host, int port, String user, String password, String jdbcPluginName,
                               String connectionArguments) {
@@ -56,6 +57,7 @@ public class MysqlConnectorConfig extends AbstractDBSpecificConnectorConfig {
     // the unit below is milli-second
     prop.put(JDBC_PROPERTY_CONNECT_TIMEOUT, "20000");
     prop.put(JDBC_PROPERTY_SOCKET_TIMEOUT, "20000");
+    prop.put(JDBC_REWRITE_BATCHED_STATEMENTS, "true");
     return prop;
   }
 }

--- a/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlFailedConnectionTest.java
+++ b/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlFailedConnectionTest.java
@@ -32,6 +32,7 @@ public class MysqlFailedConnectionTest extends DBSpecificFailedConnectionTest {
 
     super.test(JDBC_DRIVER_CLASS_NAME, connector, "Failed to create connection to database via connection string: " +
                                                     "jdbc:mysql://localhost:3306 and arguments: {user=username, " +
+                                                    "rewriteBatchedStatements=true, "  +
                                                     "connectTimeout=20000, socketTimeout=20000}. Error: " +
                                                     "ConnectException: Connection refused (Connection refused).");
   }


### PR DESCRIPTION
Setting rewriteBatchedStatements to be true by default using MysqlConnectorConfig

Testing - 

1. On local CDAP sandbox, using the plugin changes, a bigQuery to MySQL sink write for 300k records takes around 1 minute - 
<img width="1156" alt="image" src="https://user-images.githubusercontent.com/12438767/189219171-434b9c7b-e209-40a4-ba19-0779098e1038.png">
This is without using any advanced parameters - 
<img width="1780" alt="image" src="https://user-images.githubusercontent.com/12438767/189219783-a1f396a5-4988-4f8a-90ed-0eb0bdd23d87.png">


2. Without the above change, when using the plugin build using the develop branch, the pipeline runs substantially slow, for the same dataset, as can be seen from the snapshot below, around 80k records takes more than 25 minutes to transfer - 
<img width="1321" alt="image" src="https://user-images.githubusercontent.com/12438767/189228010-9614aae1-b440-4c87-9656-3934b8e7366f.png">

The above testing validates the need to set the default value as true for rewriteBatchedStatements parameter.
