### PR TITLE
CDAP-19532 | allow precision 0 for Oracle Number data type in generic database plugin - Fix tests

### DIFF
--- a/database-commons/src/test/java/io/cdap/plugin/db/CommonSchemaReaderTest.java
+++ b/database-commons/src/test/java/io/cdap/plugin/db/CommonSchemaReaderTest.java
@@ -154,7 +154,7 @@ public class CommonSchemaReaderTest {
     Assert.assertEquals(Schema.of(Schema.Type.BYTES), reader.getSchema(metadata, 4));
   }
 
-  @Test(expected = SQLException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void testGetSchemaThrowsExceptionOnNumericWithZeroPrecision() throws SQLException {
     when(metadata.getColumnType(eq(1))).thenReturn(Types.NUMERIC);
     when(metadata.getPrecision(eq(1))).thenReturn(0);


### PR DESCRIPTION
JIRA: https://cdap.atlassian.net/browse/CDAP-19532