### PR TITLE
Add FQN support for DB plugins

### DIFF
--- a/cloudsql-mysql-plugin/pom.xml
+++ b/cloudsql-mysql-plugin/pom.xml
@@ -126,7 +126,7 @@
               io.cdap.plugin.cloudsql.mysql.*;
               io.cdap.plugin.db.batch.source.*;
               io.cdap.plugin.db.batch.sink.*;
-              org.apache.commons.lang;
+              org.apache.commons.lang.*;
               org.apache.commons.logging.*;
               org.codehaus.jackson.*
             </_exportcontents>

--- a/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLSink.java
+++ b/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLSink.java
@@ -26,13 +26,18 @@ import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.batch.BatchSink;
+import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.cdap.etl.api.connector.Connector;
+import io.cdap.plugin.common.Asset;
 import io.cdap.plugin.common.ConfigUtil;
+import io.cdap.plugin.common.LineageRecorder;
 import io.cdap.plugin.db.CommonSchemaReader;
 import io.cdap.plugin.db.SchemaReader;
 import io.cdap.plugin.db.batch.config.AbstractDBSpecificSinkConfig;
 import io.cdap.plugin.db.batch.sink.AbstractDBSink;
 import io.cdap.plugin.util.CloudSQLUtil;
+import io.cdap.plugin.util.DBUtils;
+import org.apache.commons.lang.StringUtils;
 
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -70,6 +75,29 @@ public class CloudSQLMySQLSink extends AbstractDBSink<CloudSQLMySQLSink.CloudSQL
   @Override
   protected SchemaReader getSchemaReader() {
     return new CommonSchemaReader();
+  }
+
+  @Override
+  protected LineageRecorder getLineageRecorder(BatchSinkContext context) {
+    String host;
+    String location = "";
+    if (CloudSQLUtil.PRIVATE_INSTANCE.equalsIgnoreCase(cloudsqlMysqlSinkConfig.getConnection().getInstanceType())) {
+      // connection is the private IP address
+      host = cloudsqlMysqlSinkConfig.getConnection().getConnectionName();
+    } else {
+      // connection is of the form <projectId>:<region>:<instanceName>
+      String[] connectionParams = cloudsqlMysqlSinkConfig.getConnection().getConnectionName().split(":");
+      host = connectionParams[2];
+      location = connectionParams[1];
+    }
+    String fqn = DBUtils.constructFQN("mysql", host, 3306,
+                                      cloudsqlMysqlSinkConfig.getConnection().getDatabase(),
+                                      cloudsqlMysqlSinkConfig.getReferenceName());
+    Asset.Builder assetBuilder = Asset.builder(cloudsqlMysqlSinkConfig.getReferenceName()).setFqn(fqn);
+    if (!StringUtils.isEmpty(location)) {
+      assetBuilder.setLocation(location);
+    }
+    return new LineageRecorder(context, assetBuilder.build());
   }
   
   /** CloudSQL MySQL sink configuration. */

--- a/cloudsql-mysql-plugin/widgets/CloudSQLMySQL-batchsink.json
+++ b/cloudsql-mysql-plugin/widgets/CloudSQLMySQL-batchsink.json
@@ -98,7 +98,7 @@
           "label": "Reference Name",
           "name": "referenceName",
           "widget-attributes": {
-            "placeholder": "Name used to identify this sink for lineage"
+            "placeholder": "Name used to identify this sink for lineage. Typically, the name of the table/view."
           }
         },
         {

--- a/cloudsql-mysql-plugin/widgets/CloudSQLMySQL-batchsource.json
+++ b/cloudsql-mysql-plugin/widgets/CloudSQLMySQL-batchsource.json
@@ -98,7 +98,7 @@
           "label": "Reference Name",
           "name": "referenceName",
           "widget-attributes": {
-            "placeholder": "Name used to identify this source for lineage"
+            "placeholder": "Name used to identify this source for lineage. Typically, the name of the table/view."
           }
         },
         {

--- a/cloudsql-postgresql-plugin/pom.xml
+++ b/cloudsql-postgresql-plugin/pom.xml
@@ -134,9 +134,10 @@
           <instructions>
             <_exportcontents>
               io.cdap.plugin.cloudsql.postgres.*;
+              io.cdap.plugin.postgres.*;
               io.cdap.plugin.db.batch.source.*;
               io.cdap.plugin.db.batch.sink.*;
-              org.apache.commons.lang;
+              org.apache.commons.lang.*;
               org.apache.commons.logging.*;
               org.codehaus.jackson.*
             </_exportcontents>

--- a/cloudsql-postgresql-plugin/widgets/CloudSQLPostgreSQL-batchsink.json
+++ b/cloudsql-postgresql-plugin/widgets/CloudSQLPostgreSQL-batchsink.json
@@ -98,7 +98,7 @@
           "label": "Reference Name",
           "name": "referenceName",
           "widget-attributes": {
-            "placeholder": "Name used to identify this sink for lineage"
+            "placeholder": "Name used to identify this sink for lineage. Typically, the name of the table/view."
           }
         },
         {

--- a/cloudsql-postgresql-plugin/widgets/CloudSQLPostgreSQL-batchsource.json
+++ b/cloudsql-postgresql-plugin/widgets/CloudSQLPostgreSQL-batchsource.json
@@ -98,7 +98,7 @@
           "label": "Reference Name",
           "name": "referenceName",
           "widget-attributes": {
-            "placeholder": "Name used to identify this source for lineage"
+            "placeholder": "Name used to identify this source for lineage. Typically, the name of the table/view."
           }
         },
         {

--- a/database-commons/src/main/java/io/cdap/plugin/db/batch/sink/AbstractDBSink.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/batch/sink/AbstractDBSink.java
@@ -32,6 +32,7 @@ import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.StageConfigurer;
 import io.cdap.cdap.etl.api.batch.BatchRuntimeContext;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
+import io.cdap.cdap.etl.api.batch.BatchSourceContext;
 import io.cdap.cdap.etl.api.validation.InvalidStageException;
 import io.cdap.plugin.common.LineageRecorder;
 import io.cdap.plugin.common.ReferenceBatchSink;
@@ -357,12 +358,16 @@ public abstract class AbstractDBSink<T extends PluginConfig & DatabaseSinkConfig
   }
 
   private void emitLineage(BatchSinkContext context, List<Schema.Field> fields) {
-    LineageRecorder lineageRecorder = new LineageRecorder(context, dbSinkConfig.getReferenceName());
+    LineageRecorder lineageRecorder = getLineageRecorder(context);
 
     if (!fields.isEmpty()) {
       lineageRecorder.recordWrite("Write", "Wrote to DB table.",
                                   fields.stream().map(Schema.Field::getName).collect(Collectors.toList()));
     }
+  }
+
+  protected LineageRecorder getLineageRecorder(BatchSinkContext context) {
+    return new LineageRecorder(context, dbSinkConfig.getReferenceName());
   }
 
   private void executeInitQueries(Connection connection, List<String> initQueries) throws SQLException {

--- a/database-commons/src/main/java/io/cdap/plugin/db/batch/source/AbstractDBSource.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/batch/source/AbstractDBSource.java
@@ -283,7 +283,7 @@ public abstract class AbstractDBSource<T extends PluginConfig & DatabaseSourceCo
       connectionConfigAccessor.setSchema(schemaStr);
     }
 
-    LineageRecorder lineageRecorder = new LineageRecorder(context, sourceConfig.getReferenceName());
+    LineageRecorder lineageRecorder = getLineageRecorder(context);
     Schema schema = sourceConfig.getSchema() == null ? schemaFromDB : sourceConfig.getSchema();
     lineageRecorder.createExternalDataset(schema);
     if (schema != null && schema.getFields() != null) {
@@ -292,6 +292,10 @@ public abstract class AbstractDBSource<T extends PluginConfig & DatabaseSourceCo
     }
     context.setInput(Input.of(sourceConfig.getReferenceName(), new SourceInputFormatProvider(
       DataDrivenETLDBInputFormat.class, connectionConfigAccessor.getConfiguration())));
+  }
+
+  protected LineageRecorder getLineageRecorder(BatchSourceContext context) {
+    return new LineageRecorder(context, sourceConfig.getReferenceName());
   }
 
   protected Class<? extends DBWritable> getDBRecordType() {

--- a/database-commons/src/main/java/io/cdap/plugin/util/CloudSQLUtil.java
+++ b/database-commons/src/main/java/io/cdap/plugin/util/CloudSQLUtil.java
@@ -16,13 +16,11 @@
 
 package io.cdap.plugin.util;
 
-import com.google.common.base.Strings;
 import com.google.common.net.InetAddresses;
 import io.cdap.cdap.etl.api.FailureCollector;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import javax.annotation.Nullable;
 
 /**
  * Utility class for CloudSQL .

--- a/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
+++ b/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
@@ -280,6 +280,10 @@ public final class DBUtils {
     }
   }
 
+  public static String constructFQN(String dbType, String host, int port, String db, String tableName) {
+    return String.format("%s://%s:%s/%s.%s", dbType, host, port, db, tableName);
+  }
+
   private DBUtils() {
     throw new AssertionError("Should not instantiate static utility class.");
   }

--- a/generic-database-plugin/src/main/java/io/cdap/plugin/jdbc/DatabaseSource.java
+++ b/generic-database-plugin/src/main/java/io/cdap/plugin/jdbc/DatabaseSource.java
@@ -16,10 +16,15 @@
 
 package io.cdap.plugin.jdbc;
 
+import com.google.common.base.Strings;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.etl.api.batch.BatchSourceContext;
+import io.cdap.plugin.common.Asset;
+import io.cdap.plugin.common.LineageRecorder;
+import io.cdap.plugin.common.ReferenceNames;
 import io.cdap.plugin.db.ConnectionConfig;
 import io.cdap.plugin.db.batch.source.AbstractDBSource;
 

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerSink.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerSink.java
@@ -26,14 +26,19 @@ import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.batch.BatchSink;
+import io.cdap.cdap.etl.api.batch.BatchSinkContext;
+import io.cdap.cdap.etl.api.batch.BatchSourceContext;
 import io.cdap.cdap.etl.api.connector.Connector;
+import io.cdap.plugin.common.Asset;
 import io.cdap.plugin.common.ConfigUtil;
+import io.cdap.plugin.common.LineageRecorder;
 import io.cdap.plugin.db.ConnectionConfig;
 import io.cdap.plugin.db.DBRecord;
 import io.cdap.plugin.db.SchemaReader;
 import io.cdap.plugin.db.batch.config.AbstractDBSpecificSinkConfig;
 import io.cdap.plugin.db.batch.sink.AbstractDBSink;
 import io.cdap.plugin.db.batch.sink.FieldsValidator;
+import io.cdap.plugin.util.DBUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,6 +77,16 @@ public class SqlServerSink extends AbstractDBSink<SqlServerSink.SqlServerSinkCon
   @Override
   protected FieldsValidator getFieldsValidator() {
     return new SqlFieldsValidator();
+  }
+
+  @Override
+  protected LineageRecorder getLineageRecorder(BatchSinkContext context) {
+    String fqn = DBUtils.constructFQN("mssql",
+                                      sqlServerSinkConfig.getConnection().getHost(),
+                                      sqlServerSinkConfig.getConnection().getPort(),
+                                      sqlServerSinkConfig.database, sqlServerSinkConfig.getReferenceName());
+    Asset asset = Asset.builder(sqlServerSinkConfig.getReferenceName()).setFqn(fqn).build();
+    return new LineageRecorder(context, asset);
   }
 
   /**

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerSource.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerSource.java
@@ -26,12 +26,16 @@ import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.batch.BatchSource;
+import io.cdap.cdap.etl.api.batch.BatchSourceContext;
 import io.cdap.cdap.etl.api.connector.Connector;
+import io.cdap.plugin.common.Asset;
 import io.cdap.plugin.common.ConfigUtil;
+import io.cdap.plugin.common.LineageRecorder;
 import io.cdap.plugin.db.SchemaReader;
 import io.cdap.plugin.db.batch.config.AbstractDBSpecificSourceConfig;
 import io.cdap.plugin.db.batch.source.AbstractDBSource;
 import io.cdap.plugin.db.connector.AbstractDBSpecificConnectorConfig;
+import io.cdap.plugin.util.DBUtils;
 import org.apache.hadoop.mapreduce.lib.db.DBWritable;
 
 import java.util.Collections;
@@ -69,6 +73,16 @@ public class SqlServerSource extends AbstractDBSource<SqlServerSource.SqlServerS
   @Override
   protected Class<? extends DBWritable> getDBRecordType() {
     return SqlServerSourceDBRecord.class;
+  }
+
+  @Override
+  protected LineageRecorder getLineageRecorder(BatchSourceContext context) {
+    String fqn = DBUtils.constructFQN("mssql",
+                                      sqlServerSourceConfig.getConnection().getHost(),
+                                      sqlServerSourceConfig.getConnection().getPort(),
+                                      sqlServerSourceConfig.database, sqlServerSourceConfig.getReferenceName());
+    Asset asset = Asset.builder(sqlServerSourceConfig.getReferenceName()).setFqn(fqn).build();
+    return new LineageRecorder(context, asset);
   }
 
   /**

--- a/mssql-plugin/widgets/SqlServer-batchsink.json
+++ b/mssql-plugin/widgets/SqlServer-batchsink.json
@@ -106,7 +106,7 @@
           "label": "Reference Name",
           "name": "referenceName",
           "widget-attributes": {
-            "placeholder": "Name used to identify this sink for lineage"
+            "placeholder": "Name used to identify this source for lineage. Typically, the name of the table/view."
           }
         },
         {

--- a/mssql-plugin/widgets/SqlServer-batchsource.json
+++ b/mssql-plugin/widgets/SqlServer-batchsource.json
@@ -106,7 +106,7 @@
           "label": "Reference Name",
           "name": "referenceName",
           "widget-attributes": {
-            "placeholder": "Name used to identify this source for lineage"
+            "placeholder": "Name used to identify this source for lineage. Typically, the name of the table/view."
           }
         },
         {

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlSink.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlSink.java
@@ -26,12 +26,16 @@ import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.batch.BatchSink;
+import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.cdap.etl.api.connector.Connector;
+import io.cdap.plugin.common.Asset;
 import io.cdap.plugin.common.ConfigUtil;
+import io.cdap.plugin.common.LineageRecorder;
 import io.cdap.plugin.db.ConnectionConfig;
 import io.cdap.plugin.db.DBRecord;
 import io.cdap.plugin.db.batch.config.AbstractDBSpecificSinkConfig;
 import io.cdap.plugin.db.batch.sink.AbstractDBSink;
+import io.cdap.plugin.util.DBUtils;
 
 import java.util.Collections;
 import java.util.List;
@@ -57,6 +61,16 @@ public class MysqlSink extends AbstractDBSink<MysqlSink.MysqlSinkConfig> {
   @Override
   protected DBRecord getDBRecord(StructuredRecord output) {
     return new MysqlDBRecord(output, columnTypes);
+  }
+
+  @Override
+  protected LineageRecorder getLineageRecorder(BatchSinkContext context) {
+    String fqn = DBUtils.constructFQN("mysql",
+                                      mysqlSinkConfig.getConnection().getHost(),
+                                      mysqlSinkConfig.getConnection().getPort(),
+                                      mysqlSinkConfig.database, mysqlSinkConfig.getReferenceName());
+    Asset asset = Asset.builder(mysqlSinkConfig.getReferenceName()).setFqn(fqn).build();
+    return new LineageRecorder(context, asset);
   }
 
   /**

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlSource.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlSource.java
@@ -24,11 +24,16 @@ import io.cdap.cdap.api.annotation.MetadataProperty;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.etl.api.FailureCollector;
+import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.cdap.etl.api.batch.BatchSource;
+import io.cdap.cdap.etl.api.batch.BatchSourceContext;
 import io.cdap.cdap.etl.api.connector.Connector;
+import io.cdap.plugin.common.Asset;
 import io.cdap.plugin.common.ConfigUtil;
+import io.cdap.plugin.common.LineageRecorder;
 import io.cdap.plugin.db.batch.config.AbstractDBSpecificSourceConfig;
 import io.cdap.plugin.db.batch.source.AbstractDBSource;
+import io.cdap.plugin.util.DBUtils;
 import org.apache.hadoop.mapreduce.lib.db.DBWritable;
 
 import java.util.ArrayList;
@@ -61,6 +66,16 @@ public class MysqlSource extends AbstractDBSource<MysqlSource.MysqlSourceConfig>
   @Override
   protected Class<? extends DBWritable> getDBRecordType() {
     return MysqlDBRecord.class;
+  }
+
+  @Override
+  protected LineageRecorder getLineageRecorder(BatchSourceContext context) {
+    String fqn = DBUtils.constructFQN("mysql",
+                                      mysqlSourceConfig.getConnection().getHost(),
+                                      mysqlSourceConfig.getConnection().getPort(),
+                                      mysqlSourceConfig.database, mysqlSourceConfig.getReferenceName());
+    Asset asset = Asset.builder(mysqlSourceConfig.getReferenceName()).setFqn(fqn).build();
+    return new LineageRecorder(context, asset);
   }
 
   /**

--- a/mysql-plugin/widgets/Mysql-batchsink.json
+++ b/mysql-plugin/widgets/Mysql-batchsink.json
@@ -87,7 +87,7 @@
           "label": "Reference Name",
           "name": "referenceName",
           "widget-attributes": {
-            "placeholder": "Name used to identify this sink for lineage"
+            "placeholder": "Name used to identify this sink for lineage. Typically, the name of the table/view."
           }
         },
         {

--- a/mysql-plugin/widgets/Mysql-batchsource.json
+++ b/mysql-plugin/widgets/Mysql-batchsource.json
@@ -87,7 +87,7 @@
           "label": "Reference Name",
           "name": "referenceName",
           "widget-attributes": {
-            "placeholder": "Name used to identify this source for lineage"
+            "placeholder": "Name used to identify this source for lineage. Typically, the name of the table/view."
           }
         },
         {

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSink.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSink.java
@@ -26,13 +26,17 @@ import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.batch.BatchSink;
+import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.cdap.etl.api.connector.Connector;
+import io.cdap.plugin.common.Asset;
 import io.cdap.plugin.common.ConfigUtil;
+import io.cdap.plugin.common.LineageRecorder;
 import io.cdap.plugin.db.DBRecord;
 import io.cdap.plugin.db.SchemaReader;
 import io.cdap.plugin.db.batch.config.AbstractDBSpecificSinkConfig;
 import io.cdap.plugin.db.batch.sink.AbstractDBSink;
 import io.cdap.plugin.db.batch.sink.FieldsValidator;
+import io.cdap.plugin.util.DBUtils;
 
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -67,6 +71,17 @@ public class OracleSink extends AbstractDBSink<OracleSink.OracleSinkConfig> {
   protected SchemaReader getSchemaReader() {
     return new OracleSinkSchemaReader();
   }
+  @Override
+  protected LineageRecorder getLineageRecorder(BatchSinkContext context) {
+    String fqn = DBUtils.constructFQN("oracle",
+                                      oracleSinkConfig.getConnection().getHost(),
+                                      oracleSinkConfig.getConnection().getPort(),
+                                      oracleSinkConfig.getConnection().getDatabase(),
+                                      oracleSinkConfig.getReferenceName());
+    Asset asset = Asset.builder(oracleSinkConfig.getReferenceName()).setFqn(fqn).build();
+    return new LineageRecorder(context, asset);
+  }
+
 
   /**
    * Oracle action configuration.

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSource.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSource.java
@@ -24,11 +24,15 @@ import io.cdap.cdap.api.annotation.MetadataProperty;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.etl.api.FailureCollector;
+import io.cdap.cdap.etl.api.batch.BatchSourceContext;
 import io.cdap.cdap.etl.api.connector.Connector;
+import io.cdap.plugin.common.Asset;
 import io.cdap.plugin.common.ConfigUtil;
+import io.cdap.plugin.common.LineageRecorder;
 import io.cdap.plugin.db.SchemaReader;
 import io.cdap.plugin.db.batch.config.AbstractDBSpecificSourceConfig;
 import io.cdap.plugin.db.batch.source.AbstractDBSource;
+import io.cdap.plugin.util.DBUtils;
 import org.apache.hadoop.mapreduce.lib.db.DBWritable;
 
 import java.util.Map;
@@ -64,6 +68,17 @@ public class OracleSource extends AbstractDBSource<OracleSource.OracleSourceConf
   @Override
   protected Class<? extends DBWritable> getDBRecordType() {
     return OracleSourceDBRecord.class;
+  }
+
+  @Override
+  protected LineageRecorder getLineageRecorder(BatchSourceContext context) {
+    String fqn = DBUtils.constructFQN("oracle",
+                                      oracleSourceConfig.getConnection().getHost(),
+                                      oracleSourceConfig.getConnection().getPort(),
+                                      oracleSourceConfig.getConnection().getDatabase(),
+                                      oracleSourceConfig.getReferenceName());
+    Asset asset = Asset.builder(oracleSourceConfig.getReferenceName()).setFqn(fqn).build();
+    return new LineageRecorder(context, asset);
   }
 
   /**

--- a/oracle-plugin/widgets/Oracle-batchsink.json
+++ b/oracle-plugin/widgets/Oracle-batchsink.json
@@ -145,7 +145,7 @@
           "label": "Reference Name",
           "name": "referenceName",
           "widget-attributes": {
-            "placeholder": "Name used to identify this sink for lineage"
+            "placeholder": "Name used to identify this sink for lineage. Typically, the name of the table/view."
           }
         },
         {

--- a/oracle-plugin/widgets/Oracle-batchsource.json
+++ b/oracle-plugin/widgets/Oracle-batchsource.json
@@ -151,7 +151,7 @@
           "label": "Reference Name",
           "name": "referenceName",
           "widget-attributes": {
-            "placeholder": "Name used to identify this source for lineage"
+            "placeholder": "Name used to identify this source for lineage. Typically, the name of the table/view."
           }
         },
         {

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSink.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSink.java
@@ -27,8 +27,12 @@ import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.batch.BatchSink;
+import io.cdap.cdap.etl.api.batch.BatchSinkContext;
+import io.cdap.cdap.etl.api.batch.BatchSourceContext;
 import io.cdap.cdap.etl.api.connector.Connector;
+import io.cdap.plugin.common.Asset;
 import io.cdap.plugin.common.ConfigUtil;
+import io.cdap.plugin.common.LineageRecorder;
 import io.cdap.plugin.db.ConnectionConfig;
 import io.cdap.plugin.db.DBRecord;
 import io.cdap.plugin.db.SchemaReader;
@@ -37,6 +41,7 @@ import io.cdap.plugin.db.batch.config.DBSpecificSinkConfig;
 import io.cdap.plugin.db.batch.sink.AbstractDBSink;
 import io.cdap.plugin.db.batch.sink.FieldsValidator;
 import io.cdap.plugin.db.connector.AbstractDBSpecificConnectorConfig;
+import io.cdap.plugin.util.DBUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,6 +97,17 @@ public class PostgresSink extends AbstractDBSink<PostgresSink.PostgresSinkConfig
   @Override
   protected FieldsValidator getFieldsValidator() {
     return new PostgresFieldsValidator();
+  }
+
+  @Override
+  protected LineageRecorder getLineageRecorder(BatchSinkContext context) {
+    String fqn = DBUtils.constructFQN("postgres",
+                                      postgresSinkConfig.getConnection().getHost(),
+                                      postgresSinkConfig.getConnection().getPort(),
+                                      postgresSinkConfig.getConnection().getDatabase(),
+                                      postgresSinkConfig.getReferenceName());
+    Asset asset = Asset.builder(postgresSinkConfig.getReferenceName()).setFqn(fqn).build();
+    return new LineageRecorder(context, asset);
   }
 
   /**

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSource.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSource.java
@@ -25,12 +25,16 @@ import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.batch.BatchSource;
+import io.cdap.cdap.etl.api.batch.BatchSourceContext;
 import io.cdap.cdap.etl.api.connector.Connector;
+import io.cdap.plugin.common.Asset;
 import io.cdap.plugin.common.ConfigUtil;
+import io.cdap.plugin.common.LineageRecorder;
 import io.cdap.plugin.db.SchemaReader;
 import io.cdap.plugin.db.batch.config.AbstractDBSpecificSourceConfig;
 import io.cdap.plugin.db.batch.source.AbstractDBSource;
 import io.cdap.plugin.db.connector.AbstractDBSpecificConnectorConfig;
+import io.cdap.plugin.util.DBUtils;
 import org.apache.hadoop.mapreduce.lib.db.DBWritable;
 
 import java.util.Map;
@@ -66,6 +70,17 @@ public class PostgresSource extends AbstractDBSource<PostgresSource.PostgresSour
   @Override
   protected Class<? extends DBWritable> getDBRecordType() {
     return PostgresDBRecord.class;
+  }
+
+  @Override
+  protected LineageRecorder getLineageRecorder(BatchSourceContext context) {
+    String fqn = DBUtils.constructFQN("postgres",
+                                      postgresSourceConfig.getConnection().getHost(),
+                                      postgresSourceConfig.getConnection().getPort(),
+                                      postgresSourceConfig.getConnection().getDatabase(),
+                                      postgresSourceConfig.getReferenceName());
+    Asset asset = Asset.builder(postgresSourceConfig.getReferenceName()).setFqn(fqn).build();
+    return new LineageRecorder(context, asset);
   }
 
   /**
@@ -114,7 +129,7 @@ public class PostgresSource extends AbstractDBSource<PostgresSource.PostgresSour
     }
 
     @Override
-    protected AbstractDBSpecificConnectorConfig getConnection() {
+    protected PostgresConnectorConfig getConnection() {
       return connection;
     }
 

--- a/postgresql-plugin/widgets/Postgres-batchsink.json
+++ b/postgresql-plugin/widgets/Postgres-batchsink.json
@@ -87,7 +87,7 @@
           "label": "Reference Name",
           "name": "referenceName",
           "widget-attributes": {
-            "placeholder": "Name used to identify this sink for lineage"
+            "placeholder": "Name used to identify this sink for lineage. Typically, the name of the table/view."
           }
         },
         {

--- a/postgresql-plugin/widgets/Postgres-batchsource.json
+++ b/postgresql-plugin/widgets/Postgres-batchsource.json
@@ -92,7 +92,7 @@
           "label": "Reference Name",
           "name": "referenceName",
           "widget-attributes": {
-            "placeholder": "Name used to identify this source for lineage"
+            "placeholder": "Name used to identify this source for lineage. Typically, the name of the table/view."
           }
         },
         {


### PR DESCRIPTION
Jira: https://cdap.atlassian.net/browse/CDAP-19665

Testing:
FQNs generated were
1. Sql Server:
source - sqlserver://ip:1433/AdventureWorks2014.sqlServerSource3
sink - sqlserver://ip:1433/AdventureWorks2014.sqlServerSink3
2. MySql
source - mysql://ip:3306/sakila.mySqlSource0
sink - mysql://ip:3306/sakila.mySqlServerSink0
3. Postgres
source - postgresql://ip:5432/cdf.pgSource0
sink - postgresql://ip:5432/cdf.pgSink0
4. Oracle
source - oracle://ip:1521/ORCL.orclSource0
oracle://ip:1521/ORCL.orclSink0
location is 'global' by default for the above 4 on-prem instances
5. Cloudsql MySql
source -mysql://instName:3306/db.cloudsqlSource
location - us-east1(or one such region)
sink -mysql://instName:3306/db.cloudsqlSink
location - us-east1(or one such region)
6. CloudSql Postgres
source -postgresql://instName: 5432/db.cloudPgSource0
location - us-east1
sink -postgresql://instName: 5432/db.cloudPgSink0
location - us-east1