### PR TITLE
[PLUGIN-1436] fix StringUtils exception

### DIFF
--- a/cloudsql-mysql-plugin/pom.xml
+++ b/cloudsql-mysql-plugin/pom.xml
@@ -42,6 +42,11 @@
       <groupId>io.cdap.plugin</groupId>
       <artifactId>hydrator-common</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.cdap.plugin</groupId>
+      <artifactId>mysql-plugin</artifactId>
+      <version>1.10.0-SNAPSHOT</version>
+    </dependency>
 
     <!-- test dependencies -->
     <dependency>
@@ -126,6 +131,7 @@
               io.cdap.plugin.cloudsql.mysql.*;
               io.cdap.plugin.db.batch.source.*;
               io.cdap.plugin.db.batch.sink.*;
+              io.cdap.plugin.mysql.*;
               org.apache.commons.lang.*;
               org.apache.commons.logging.*;
               org.codehaus.jackson.*

--- a/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLConnector.java
+++ b/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLConnector.java
@@ -31,8 +31,10 @@ import io.cdap.plugin.common.Constants;
 import io.cdap.plugin.common.ReferenceNames;
 import io.cdap.plugin.common.db.DBConnectorPath;
 import io.cdap.plugin.db.ConnectionConfig;
-import io.cdap.plugin.db.DBRecord;
+import io.cdap.plugin.db.SchemaReader;
 import io.cdap.plugin.db.connector.AbstractDBSpecificConnector;
+import io.cdap.plugin.mysql.MysqlDBRecord;
+import io.cdap.plugin.mysql.MysqlSchemaReader;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.lib.db.DBWritable;
 
@@ -46,7 +48,7 @@ import java.util.Map;
 @Name(CloudSQLMySQLConnector.NAME)
 @Description("Connection to access data in CloudSQL MySQL Server databases using JDBC.")
 @Category("Database")
-public class CloudSQLMySQLConnector extends AbstractDBSpecificConnector<DBRecord> {
+public class CloudSQLMySQLConnector extends AbstractDBSpecificConnector<MysqlDBRecord> {
   
   public static final String NAME = CloudSQLMySQLConstants.PLUGIN_NAME;
   private final CloudSQLMySQLConnectorConfig config;
@@ -63,12 +65,17 @@ public class CloudSQLMySQLConnector extends AbstractDBSpecificConnector<DBRecord
 
   @Override
   protected Class<? extends DBWritable> getDBRecordType() {
-    return DBRecord.class;
+    return MysqlDBRecord.class;
   }
 
   @Override
-  public StructuredRecord transform(LongWritable longWritable, DBRecord dbRecord) {
-    return dbRecord.getRecord();
+  public StructuredRecord transform(LongWritable longWritable, MysqlDBRecord mysqlDBRecord) {
+    return mysqlDBRecord.getRecord();
+  }
+
+  @Override
+  protected SchemaReader getSchemaReader(String sessionID) {
+    return new MysqlSchemaReader(sessionID);
   }
 
   @Override

--- a/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLSink.java
+++ b/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLSink.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.cloudsql.mysql;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
@@ -23,6 +24,7 @@ import io.cdap.cdap.api.annotation.Metadata;
 import io.cdap.cdap.api.annotation.MetadataProperty;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.batch.BatchSink;
@@ -31,13 +33,12 @@ import io.cdap.cdap.etl.api.connector.Connector;
 import io.cdap.plugin.common.Asset;
 import io.cdap.plugin.common.ConfigUtil;
 import io.cdap.plugin.common.LineageRecorder;
-import io.cdap.plugin.db.CommonSchemaReader;
-import io.cdap.plugin.db.SchemaReader;
+import io.cdap.plugin.db.DBRecord;
 import io.cdap.plugin.db.batch.config.AbstractDBSpecificSinkConfig;
 import io.cdap.plugin.db.batch.sink.AbstractDBSink;
+import io.cdap.plugin.mysql.MysqlDBRecord;
 import io.cdap.plugin.util.CloudSQLUtil;
 import io.cdap.plugin.util.DBUtils;
-import org.apache.commons.lang.StringUtils;
 
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -71,10 +72,10 @@ public class CloudSQLMySQLSink extends AbstractDBSink<CloudSQLMySQLSink.CloudSQL
     
     super.configurePipeline(pipelineConfigurer);
   }
-  
+
   @Override
-  protected SchemaReader getSchemaReader() {
-    return new CommonSchemaReader();
+  protected DBRecord getDBRecord(StructuredRecord output) {
+    return new MysqlDBRecord(output, columnTypes);
   }
 
   @Override
@@ -94,7 +95,7 @@ public class CloudSQLMySQLSink extends AbstractDBSink<CloudSQLMySQLSink.CloudSQL
                                       cloudsqlMysqlSinkConfig.getConnection().getDatabase(),
                                       cloudsqlMysqlSinkConfig.getReferenceName());
     Asset.Builder assetBuilder = Asset.builder(cloudsqlMysqlSinkConfig.getReferenceName()).setFqn(fqn);
-    if (!StringUtils.isEmpty(location)) {
+    if (!Strings.isNullOrEmpty(location)) {
       assetBuilder.setLocation(location);
     }
     return new LineageRecorder(context, assetBuilder.build());

--- a/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLSource.java
+++ b/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLSource.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.cloudsql.mysql;
 
+import com.google.common.base.Strings;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Metadata;
@@ -30,13 +31,12 @@ import io.cdap.cdap.etl.api.connector.Connector;
 import io.cdap.plugin.common.Asset;
 import io.cdap.plugin.common.ConfigUtil;
 import io.cdap.plugin.common.LineageRecorder;
-import io.cdap.plugin.db.CommonSchemaReader;
-import io.cdap.plugin.db.SchemaReader;
 import io.cdap.plugin.db.batch.config.AbstractDBSpecificSourceConfig;
 import io.cdap.plugin.db.batch.source.AbstractDBSource;
+import io.cdap.plugin.mysql.MysqlDBRecord;
 import io.cdap.plugin.util.CloudSQLUtil;
 import io.cdap.plugin.util.DBUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.mapreduce.lib.db.DBWritable;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -75,8 +75,8 @@ public class CloudSQLMySQLSource extends AbstractDBSource<CloudSQLMySQLSource.Cl
   }
 
   @Override
-  protected SchemaReader getSchemaReader() {
-    return new CommonSchemaReader();
+  protected Class<? extends DBWritable> getDBRecordType() {
+    return MysqlDBRecord.class;
   }
 
   @Override
@@ -112,7 +112,7 @@ public class CloudSQLMySQLSource extends AbstractDBSource<CloudSQLMySQLSource.Cl
                                       cloudsqlMysqlSourceConfig.getConnection().getDatabase(),
                                       cloudsqlMysqlSourceConfig.getReferenceName());
     Asset.Builder assetBuilder = Asset.builder(cloudsqlMysqlSourceConfig.getReferenceName()).setFqn(fqn);
-    if (!StringUtils.isEmpty(location)) {
+    if (!Strings.isNullOrEmpty(location)) {
       assetBuilder.setLocation(location);
     }
     return new LineageRecorder(context, assetBuilder.build());

--- a/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLSink.java
+++ b/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLSink.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.cloudsql.postgres;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
@@ -43,7 +44,6 @@ import io.cdap.plugin.postgres.PostgresFieldsValidator;
 import io.cdap.plugin.postgres.PostgresSchemaReader;
 import io.cdap.plugin.util.CloudSQLUtil;
 import io.cdap.plugin.util.DBUtils;
-import org.apache.commons.lang.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -130,7 +130,7 @@ public class CloudSQLPostgreSQLSink extends AbstractDBSink<CloudSQLPostgreSQLSin
                                       cloudsqlPostgresqlSinkConfig.getConnection().getDatabase(),
                                       cloudsqlPostgresqlSinkConfig.getReferenceName());
     Asset.Builder assetBuilder = Asset.builder(cloudsqlPostgresqlSinkConfig.getReferenceName()).setFqn(fqn);
-    if (!StringUtils.isEmpty(location)) {
+    if (!Strings.isNullOrEmpty(location)) {
       assetBuilder.setLocation(location);
     }
     return new LineageRecorder(context, assetBuilder.build());

--- a/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLSource.java
+++ b/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLSource.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.cloudsql.postgres;
 
+import com.google.common.base.Strings;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Metadata;
@@ -37,7 +38,6 @@ import io.cdap.plugin.postgres.PostgresDBRecord;
 import io.cdap.plugin.postgres.PostgresSchemaReader;
 import io.cdap.plugin.util.CloudSQLUtil;
 import io.cdap.plugin.util.DBUtils;
-import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.mapreduce.lib.db.DBWritable;
 
 import java.util.Collections;
@@ -120,7 +120,7 @@ public class CloudSQLPostgreSQLSource
                                       cloudsqlPostgresqlSourceConfig.getConnection().getDatabase(),
                                       cloudsqlPostgresqlSourceConfig.getReferenceName());
     Asset.Builder assetBuilder = Asset.builder(cloudsqlPostgresqlSourceConfig.getReferenceName()).setFqn(fqn);
-    if (!StringUtils.isEmpty(location)) {
+    if (!Strings.isNullOrEmpty(location)) {
       assetBuilder.setLocation(location);
     }
     return new LineageRecorder(context, assetBuilder.build());


### PR DESCRIPTION
Fixes two issues

- `Caused by: java.lang.ClassNotFoundException: Class io.cdap.plugin.db.DBRecord` in `cloudsql-mysql`
- `Caused by: java.lang.ClassNotFoundException: org.apache.commons.lang.StringUtils` in `cloudsql-mysql` and `cloudsql-postgres`