### PR TITLE
Bump e2e framework to 0.2.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -710,7 +710,7 @@
         <dependency>
           <groupId>io.cdap.tests.e2e</groupId>
           <artifactId>cdap-e2e-framework</artifactId>
-          <version>0.1.0-SNAPSHOT</version>
+          <version>0.2.0-SNAPSHOT</version>
           <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Bump version to match https://github.com/cdapio/cdap-e2e-tests/commit/db32e51869ea1428aaa76dc4e1d14842b87d9a6d