### PR TITLE
[PLUGIN-1119] Converting precision less decimal/numbers into String type.

### DIFF
--- a/oracle-plugin/docs/Oracle-batchsink.md
+++ b/oracle-plugin/docs/Oracle-batchsink.md
@@ -65,7 +65,8 @@ Data Types Mapping
     | VARCHAR2                       | string                |                                                        |
     | NVARCHAR2                      | string                |                                                        |
     | VARCHAR                        | string                |                                                        |
-    | NUMBER                         | decimal               |                                                        |
+    | NUMBER                         | string                | For NUMBER types defined without a precision and scale |
+    | NUMBER                         | decimal               | For NUMBER types with a defined precision and scale    |
     | FLOAT                          | double                |                                                        |
     | LONG                           | string                |                                                        |
     | DATE                           | timestamp             |                                                        |

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSourceDBRecord.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSourceDBRecord.java
@@ -214,12 +214,17 @@ public class OracleSourceDBRecord extends DBRecord {
         if (Double.class.getTypeName().equals(resultSet.getMetaData().getColumnClassName(columnIndex))) {
           recordBuilder.set(field.getName(), resultSet.getDouble(columnIndex));
         } else {
-          // It's required to pass 'scale' parameter since in the case of Oracle, scale of 'BigDecimal' depends on the
-          // scale set in the logical schema. For example for value '77.12' if the scale set in the logical schema is
-          // set to 4 then the number will change to '77.1200'. Also if the value is '22.1274' and the logical schema
-          // scale is set to 2 then the decimal value used will be '22.13' after rounding.
-          BigDecimal decimal = resultSet.getBigDecimal(columnIndex, getScale(field.getSchema()));
-          recordBuilder.setDecimal(field.getName(), decimal);
+          if (precision == 0) {
+            // In case of precision less decimal convert the field to String type
+            recordBuilder.set(field.getName(), resultSet.getString(columnIndex));
+          } else {
+            // It's required to pass 'scale' parameter since in the case of Oracle, scale of 'BigDecimal' depends on the
+            // scale set in the logical schema. For example for value '77.12' if the scale set in the logical schema is
+            // set to 4 then the number will change to '77.1200'. Also if the value is '22.1274' and the logical schema
+            // scale is set to 2 then the decimal value used will be '22.13' after rounding.
+            BigDecimal decimal = resultSet.getBigDecimal(columnIndex, getScale(field.getSchema()));
+            recordBuilder.setDecimal(field.getName(), decimal);
+          }
         }
     }
   }

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSourceSchemaReader.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSourceSchemaReader.java
@@ -105,13 +105,12 @@ public class OracleSourceSchemaReader extends CommonSchemaReader {
           // For a Number type without specified precision and scale, precision will be 0 and scale will be -127
           if (precision == 0) {
             // reference : https://docs.oracle.com/cd/B28359_01/server.111/b28318/datatype.htm#CNCPT1832
-            precision = 38;
-            scale = 0;
-            LOG.warn(String.format("%s type with undefined precision and scale is detected, "
-                    + "there may be a precision loss while running the pipeline. "
-                    + "Please define an output precision and scale for field '%s' to avoid precision loss.",
+            LOG.warn(String.format("Field '%s' is a %s type without precision and scale, "
+                    + "converting into STRING type to avoid any precision loss.",
+                metadata.getColumnName(index),
                 metadata.getColumnTypeName(index),
                 metadata.getColumnName(index)));
+            return Schema.of(Schema.Type.STRING);
           }
           return Schema.decimalOf(precision, scale);
         }


### PR DESCRIPTION
Jira ticket: https://cdap.atlassian.net/browse/PLUGIN-1119

Changes to ensure that, Precision less Number types in Oracle Source gets converted into String types to avoid any precision loss.

Validations performed:
1. The getSchema shows String type against precision less number types.
2. Pipeline execution without getSchema converts the Number type to String type in the sink.
3. Pipeline execution with getSchema converts the Number type to String type in the sink.
4. Any other type selected manually for the field in the output schema of Oracle plugin, results into failure of type mismatch during pipeline execution.
