### PR TITLE
[CDAP-20224] Remove Explore References from `database-plugins`

### DIFF
--- a/aurora-mysql-plugin/src/test/java/io/cdap/plugin/aurora/mysql/AuroraMysqlPluginTestBase.java
+++ b/aurora-mysql-plugin/src/test/java/io/cdap/plugin/aurora/mysql/AuroraMysqlPluginTestBase.java
@@ -24,7 +24,6 @@ import io.cdap.cdap.api.plugin.PluginClass;
 import io.cdap.cdap.datapipeline.DataPipelineApp;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.plugin.auroradb.mysql.AuroraMysqlAction;
 import io.cdap.plugin.auroradb.mysql.AuroraMysqlPostAction;
 import io.cdap.plugin.auroradb.mysql.AuroraMysqlSink;
@@ -36,7 +35,6 @@ import io.cdap.plugin.db.batch.sink.ETLDBOutputFormat;
 import io.cdap.plugin.db.batch.source.DataDrivenETLDBInputFormat;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,9 +70,6 @@ public abstract class AuroraMysqlPluginTestBase extends DatabasePluginTestBase {
   protected static final int PRECISION = 10;
   protected static final int SCALE = 6;
   private static int startCount;
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   @BeforeClass
   public static void setupTest() throws Exception {

--- a/aurora-postgresql-plugin/src/test/java/io/cdap/plugin/auroradb/postgres/AuroraPostgresPluginTestBase.java
+++ b/aurora-postgresql-plugin/src/test/java/io/cdap/plugin/auroradb/postgres/AuroraPostgresPluginTestBase.java
@@ -24,7 +24,6 @@ import io.cdap.cdap.api.plugin.PluginClass;
 import io.cdap.cdap.datapipeline.DataPipelineApp;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.plugin.db.ConnectionConfig;
 import io.cdap.plugin.db.DBRecord;
 import io.cdap.plugin.db.batch.DatabasePluginTestBase;
@@ -32,7 +31,6 @@ import io.cdap.plugin.db.batch.sink.ETLDBOutputFormat;
 import io.cdap.plugin.db.batch.source.DataDrivenETLDBInputFormat;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.postgresql.Driver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,9 +65,6 @@ public abstract class AuroraPostgresPluginTestBase extends DatabasePluginTestBas
   protected static final int PRECISION = 10;
   protected static final int SCALE = 6;
   private static int startCount;
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   @BeforeClass
   public static void setupTest() throws Exception {

--- a/db2-plugin/src/test/java/io/cdap/plugin/db2/Db2PluginTestBase.java
+++ b/db2-plugin/src/test/java/io/cdap/plugin/db2/Db2PluginTestBase.java
@@ -23,7 +23,6 @@ import io.cdap.cdap.api.plugin.PluginClass;
 import io.cdap.cdap.datapipeline.DataPipelineApp;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.plugin.db.ConnectionConfig;
 import io.cdap.plugin.db.DBRecord;
 import io.cdap.plugin.db.batch.DatabasePluginTestBase;
@@ -31,7 +30,6 @@ import io.cdap.plugin.db.batch.sink.ETLDBOutputFormat;
 import io.cdap.plugin.db.batch.source.DataDrivenETLDBInputFormat;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,9 +65,6 @@ public abstract class Db2PluginTestBase extends DatabasePluginTestBase {
   protected static final int PRECISION = 10;
   protected static final int SCALE = 6;
   private static int startCount;
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   static {
     Calendar calendar = Calendar.getInstance();

--- a/generic-database-plugin/src/test/java/io/cdap/plugin/GenericDatabasePluginTestBase.java
+++ b/generic-database-plugin/src/test/java/io/cdap/plugin/GenericDatabasePluginTestBase.java
@@ -25,7 +25,6 @@ import io.cdap.cdap.api.plugin.PluginClass;
 import io.cdap.cdap.datapipeline.DataPipelineApp;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.plugin.db.ConnectionConfig;
 import io.cdap.plugin.db.DBRecord;
 import io.cdap.plugin.db.batch.DatabasePluginTestBase;
@@ -78,9 +77,6 @@ public abstract class GenericDatabasePluginTestBase extends DatabasePluginTestBa
 
   @ClassRule
   public static TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   @BeforeClass
   public static void setupTest() throws Exception {

--- a/mariadb-plugin/src/test/java/io/cdap/plugin/mariadb/MariadbPluginTestBase.java
+++ b/mariadb-plugin/src/test/java/io/cdap/plugin/mariadb/MariadbPluginTestBase.java
@@ -24,7 +24,6 @@ import io.cdap.cdap.api.plugin.PluginClass;
 import io.cdap.cdap.datapipeline.DataPipelineApp;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.plugin.db.ConnectionConfig;
 import io.cdap.plugin.db.DBRecord;
 import io.cdap.plugin.db.batch.DatabasePluginTestBase;
@@ -32,7 +31,6 @@ import io.cdap.plugin.db.batch.sink.ETLDBOutputFormat;
 import io.cdap.plugin.db.batch.source.DataDrivenETLDBInputFormat;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,9 +69,6 @@ public abstract class MariadbPluginTestBase extends DatabasePluginTestBase {
   protected static final ZoneId UTC_ZONE = ZoneId.ofOffset("UTC", ZoneOffset.UTC);
   protected static final Map<String, String> BASE_PROPS = new HashMap<>();
   private static int startCount;
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   static {
     Calendar calendar = Calendar.getInstance();

--- a/memsql-plugin/src/test/java/io/cdap/plugin/memsql/MemsqlPluginTestBase.java
+++ b/memsql-plugin/src/test/java/io/cdap/plugin/memsql/MemsqlPluginTestBase.java
@@ -24,7 +24,6 @@ import io.cdap.cdap.api.plugin.PluginClass;
 import io.cdap.cdap.datapipeline.DataPipelineApp;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.plugin.db.ConnectionConfig;
 import io.cdap.plugin.db.DBRecord;
 import io.cdap.plugin.db.batch.DatabasePluginTestBase;
@@ -36,7 +35,6 @@ import io.cdap.plugin.memsql.sink.MemsqlSink;
 import io.cdap.plugin.memsql.source.MemsqlSource;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,9 +73,6 @@ public abstract class MemsqlPluginTestBase extends DatabasePluginTestBase {
   protected static final int SCALE = 6;
   protected static final ZoneId UTC_ZONE = ZoneId.ofOffset("UTC", ZoneOffset.UTC);
   private static int startCount;
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   static {
     Calendar calendar = Calendar.getInstance();

--- a/mssql-plugin/src/test/java/io/cdap/plugin/mssql/SqlServerPluginTestBase.java
+++ b/mssql-plugin/src/test/java/io/cdap/plugin/mssql/SqlServerPluginTestBase.java
@@ -24,7 +24,6 @@ import io.cdap.cdap.api.plugin.PluginClass;
 import io.cdap.cdap.datapipeline.DataPipelineApp;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.plugin.db.ConnectionConfig;
 import io.cdap.plugin.db.DBRecord;
 import io.cdap.plugin.db.batch.DatabasePluginTestBase;
@@ -32,7 +31,6 @@ import io.cdap.plugin.db.batch.sink.ETLDBOutputFormat;
 import io.cdap.plugin.db.batch.source.DataDrivenETLDBInputFormat;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,9 +79,6 @@ public abstract class SqlServerPluginTestBase extends DatabasePluginTestBase {
   protected static final LocalTime TIME_MICROS = LocalTime.of(16, 17, 18, 123456000);
   protected static final ZoneId UTC = ZoneId.ofOffset("UTC", ZoneOffset.UTC);
   private static int startCount;
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   @BeforeClass
   public static void setupTest() throws Exception {

--- a/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlPluginTestBase.java
+++ b/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlPluginTestBase.java
@@ -24,7 +24,6 @@ import io.cdap.cdap.api.plugin.PluginClass;
 import io.cdap.cdap.datapipeline.DataPipelineApp;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.plugin.db.ConnectionConfig;
 import io.cdap.plugin.db.DBRecord;
 import io.cdap.plugin.db.batch.DatabasePluginTestBase;
@@ -32,7 +31,6 @@ import io.cdap.plugin.db.batch.sink.ETLDBOutputFormat;
 import io.cdap.plugin.db.batch.source.DataDrivenETLDBInputFormat;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,9 +69,6 @@ public abstract class MysqlPluginTestBase extends DatabasePluginTestBase {
   protected static final ZoneId UTC_ZONE = ZoneId.ofOffset("UTC", ZoneOffset.UTC);
   private static int startCount;
   protected static final Map<String, String> BASE_PROPS = new HashMap<>();
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   static {
     Calendar calendar = Calendar.getInstance();

--- a/netezza-plugin/src/test/java/io/cdap/plugin/netezza/NetezzaPluginTestBase.java
+++ b/netezza-plugin/src/test/java/io/cdap/plugin/netezza/NetezzaPluginTestBase.java
@@ -24,7 +24,6 @@ import io.cdap.cdap.api.plugin.PluginClass;
 import io.cdap.cdap.datapipeline.DataPipelineApp;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.plugin.db.ConnectionConfig;
 import io.cdap.plugin.db.DBRecord;
 import io.cdap.plugin.db.batch.DatabasePluginTestBase;
@@ -32,7 +31,6 @@ import io.cdap.plugin.db.batch.sink.ETLDBOutputFormat;
 import io.cdap.plugin.db.batch.source.DataDrivenETLDBInputFormat;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,9 +66,6 @@ public abstract class NetezzaPluginTestBase extends DatabasePluginTestBase {
   protected static final int PRECISION = 16;
   protected static final int SCALE = 6;
   private static int startCount;
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   static {
     Calendar calendar = Calendar.getInstance();

--- a/oracle-plugin/src/test/java/io/cdap/plugin/oracle/OraclePluginTestBase.java
+++ b/oracle-plugin/src/test/java/io/cdap/plugin/oracle/OraclePluginTestBase.java
@@ -23,7 +23,6 @@ import io.cdap.cdap.api.plugin.PluginClass;
 import io.cdap.cdap.datapipeline.DataPipelineApp;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.plugin.db.ConnectionConfig;
 import io.cdap.plugin.db.DBRecord;
 import io.cdap.plugin.db.batch.DatabasePluginTestBase;
@@ -31,7 +30,6 @@ import io.cdap.plugin.db.batch.sink.ETLDBOutputFormat;
 import io.cdap.plugin.db.batch.source.DataDrivenETLDBInputFormat;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,9 +77,6 @@ public abstract class OraclePluginTestBase extends DatabasePluginTestBase {
   protected static final ZoneId UTC = ZoneId.ofOffset("UTC", ZoneOffset.UTC);
 
   private static int startCount;
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   static {
     Calendar calendar = Calendar.getInstance();

--- a/postgresql-plugin/src/test/java/io/cdap/plugin/postgres/PostgresPluginTestBase.java
+++ b/postgresql-plugin/src/test/java/io/cdap/plugin/postgres/PostgresPluginTestBase.java
@@ -24,7 +24,6 @@ import io.cdap.cdap.api.plugin.PluginClass;
 import io.cdap.cdap.datapipeline.DataPipelineApp;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.plugin.db.ConnectionConfig;
 import io.cdap.plugin.db.DBRecord;
 import io.cdap.plugin.db.batch.DatabasePluginTestBase;
@@ -32,7 +31,6 @@ import io.cdap.plugin.db.batch.sink.ETLDBOutputFormat;
 import io.cdap.plugin.db.batch.source.DataDrivenETLDBInputFormat;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.postgresql.Driver;
 import org.postgresql.util.PGTime;
 import org.postgresql.util.PGobject;
@@ -83,9 +81,6 @@ public abstract class PostgresPluginTestBase extends DatabasePluginTestBase {
     ZoneOffset.of("+03")
   );
   private static int startCount;
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   static {
     Calendar calendar = Calendar.getInstance();

--- a/teradata-plugin/src/test/java/io/cdap/plugin/teradata/TeradataPluginTestBase.java
+++ b/teradata-plugin/src/test/java/io/cdap/plugin/teradata/TeradataPluginTestBase.java
@@ -23,7 +23,6 @@ import io.cdap.cdap.api.plugin.PluginClass;
 import io.cdap.cdap.datapipeline.DataPipelineApp;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.plugin.db.ConnectionConfig;
 import io.cdap.plugin.db.DBRecord;
 import io.cdap.plugin.db.batch.DatabasePluginTestBase;
@@ -35,7 +34,6 @@ import io.cdap.plugin.teradata.sink.TeradataSink;
 import io.cdap.plugin.teradata.source.TeradataSource;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,9 +71,6 @@ public abstract class TeradataPluginTestBase extends DatabasePluginTestBase {
   protected static final int SCALE = 6;
   protected static final ZoneId UTC_ZONE = ZoneId.ofOffset("UTC", ZoneOffset.UTC);
   private static int startCount;
-
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   static {
     Calendar calendar = Calendar.getInstance();


### PR DESCRIPTION
- As part of cdapio/cdap/pull/14802, the module `cdap-explore` and its references and occurrences are removed from CDAP repository.
- Similar references in `database-plugins` need to be removed.
[JIRA](https://cdap.atlassian.net/browse/CDAP-20224)