### PR TITLE
Remove redundant version identifiers which can go out of sync to fix the build

### DIFF
--- a/cloudsql-postgresql-plugin/pom.xml
+++ b/cloudsql-postgresql-plugin/pom.xml
@@ -25,7 +25,6 @@
 
   <name>CloudSQL PostgreSQL plugin</name>
   <artifactId>cloudsql-postgresql-plugin</artifactId>
-  <version>1.8.4</version>
   <modelVersion>4.0.0</modelVersion>
 
   <dependencies>
@@ -46,7 +45,7 @@
     <dependency>
       <groupId>io.cdap.plugin</groupId>
       <artifactId>postgresql-plugin</artifactId>
-      <version>1.8.4</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION

Due to redundancy, people need to be careful to update multiple places like this https://github.com/data-integrations/database-plugins/pull/295/files#diff-65bd1d2be2ff9ffbd95f2d6eba801e9fd4592fdcac2cc4cfd15d894d4af716b8

Otherwise it can be missed (https://github.com/data-integrations/database-plugins/pull/336/files#diff-65bd1d2be2ff9ffbd95f2d6eba801e9fd4592fdcac2cc4cfd15d894d4af716b8)

Failing build
https://github.com/cdapio/cdap-build/actions/runs/3971238482/jobs/6812701089

Error
```
Could not resolve dependencies for project io.cdap.plugin:cloudsql-postgresql-plugin:jar:1.8.4: Failed to collect dependencies at io.cdap.plugin:database-commons:jar:1.8.4: Failed to read artifact descriptor for io.cdap.plugin:database-commons:jar:1.8.4: Could not find artifact io.cdap.plugin:database-plugins-parent:pom:1.8.4 in sonatype (https://oss.sonatype.org/content/groups/public) -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal on project cloudsql-postgresql-plugin: Could not resolve dependencies for project io.cdap.plugin:cloudsql-postgresql-plugin:jar:1.8.4: Failed to collect dependencies at io.cdap.plugin:database-commons:jar:1.8.4
```
