### PR TITLE
Remove redundant version identifiers which can go out of sync

### DIFF
--- a/cloudsql-postgresql-plugin/pom.xml
+++ b/cloudsql-postgresql-plugin/pom.xml
@@ -25,7 +25,6 @@
 
   <name>CloudSQL PostgreSQL plugin</name>
   <artifactId>cloudsql-postgresql-plugin</artifactId>
-  <version>1.10.0-SNAPSHOT</version>
   <modelVersion>4.0.0</modelVersion>
 
   <dependencies>
@@ -46,7 +45,7 @@
     <dependency>
       <groupId>io.cdap.plugin</groupId>
       <artifactId>postgresql-plugin</artifactId>
-      <version>1.10.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Context https://github.com/data-integrations/database-plugins/pull/338