### PR TITLE
Added datatypes sanity test for MySQL Plugin

### DIFF
--- a/database-commons/src/main/java/io/cdap/plugin/db/DBRecord.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/DBRecord.java
@@ -331,7 +331,8 @@ public class DBRecord implements Writable, DBWritable, Configurable {
         writeInt(stmt, fieldIndex, sqlIndex, fieldValue);
         break;
       case LONG:
-        stmt.setLong(sqlIndex, (Long) fieldValue);
+        long fieldValueLong = ((Number) fieldValue).longValue();
+        stmt.setLong(sqlIndex, fieldValueLong);
         break;
       case FLOAT:
         // both real and float are set with the same method on prepared statement

--- a/database-commons/src/main/java/io/cdap/plugin/db/sink/FieldsValidator.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/sink/FieldsValidator.java
@@ -52,7 +52,9 @@ public interface FieldsValidator {
    * @param fieldType        field type.
    * @param fieldLogicalType filed logical type.
    * @param sqlType          code of sql type.
+   * @param precision
    * @return 'true' if field is compatible to be written, 'false' otherwise.
    */
-  boolean isFieldCompatible(Schema.Type fieldType, Schema.LogicalType fieldLogicalType, int sqlType);
+  boolean isFieldCompatible(Schema.Type fieldType, Schema.LogicalType fieldLogicalType, int sqlType, int precision,
+                            boolean isSigned);
 }

--- a/database-commons/src/test/java/io/cdap/plugin/db/sink/CommonFieldsValidatorTest.java
+++ b/database-commons/src/test/java/io/cdap/plugin/db/sink/CommonFieldsValidatorTest.java
@@ -36,34 +36,62 @@ public class CommonFieldsValidatorTest {
 
   @Test
   public void testIsFieldCompatible() {
-    validateFieldCompatible(Schema.Type.INT, Schema.LogicalType.DATE, Types.DATE, true);
-    validateFieldCompatible(Schema.Type.INT, Schema.LogicalType.TIME_MILLIS, Types.TIME, true);
-    validateFieldCompatible(Schema.Type.LONG, Schema.LogicalType.TIME_MICROS, Types.TIME, true);
-    validateFieldCompatible(Schema.Type.LONG, Schema.LogicalType.TIMESTAMP_MILLIS, Types.TIMESTAMP, true);
-    validateFieldCompatible(Schema.Type.LONG, Schema.LogicalType.TIMESTAMP_MICROS, Types.TIMESTAMP, true);
-    validateFieldCompatible(Schema.Type.BYTES, Schema.LogicalType.DECIMAL, Types.NUMERIC, true);
-    validateFieldCompatible(Schema.Type.BYTES, Schema.LogicalType.DECIMAL, Types.DECIMAL, true);
-    validateFieldCompatible(Schema.Type.NULL, null, 0, true);
-    validateFieldCompatible(Schema.Type.BOOLEAN, null, Types.BOOLEAN, true);
-    validateFieldCompatible(Schema.Type.BOOLEAN, null, Types.BIT, true);
-    validateFieldCompatible(Schema.Type.INT, null, Types.INTEGER, true);
-    validateFieldCompatible(Schema.Type.INT, null, Types.SMALLINT, true);
-    validateFieldCompatible(Schema.Type.INT, null, Types.TINYINT, true);
-    validateFieldCompatible(Schema.Type.FLOAT, null, Types.REAL, true);
-    validateFieldCompatible(Schema.Type.FLOAT, null, Types.FLOAT, true);
-    validateFieldCompatible(Schema.Type.DOUBLE, null, Types.DOUBLE, true);
-    validateFieldCompatible(Schema.Type.BYTES, null, Types.BINARY, true);
-    validateFieldCompatible(Schema.Type.BYTES, null, Types.VARBINARY, true);
-    validateFieldCompatible(Schema.Type.BYTES, null, Types.LONGVARBINARY, true);
-    validateFieldCompatible(Schema.Type.BYTES, null, Types.BLOB, true);
-    validateFieldCompatible(Schema.Type.STRING, null, Types.VARCHAR, true);
-    validateFieldCompatible(Schema.Type.STRING, null, Types.CHAR, true);
-    validateFieldCompatible(Schema.Type.STRING, null, Types.CLOB, true);
-    validateFieldCompatible(Schema.Type.STRING, null, Types.LONGNVARCHAR, true);
-    validateFieldCompatible(Schema.Type.STRING, null, Types.LONGVARCHAR, true);
-    validateFieldCompatible(Schema.Type.STRING, null, Types.NCHAR, true);
-    validateFieldCompatible(Schema.Type.STRING, null, Types.NCLOB, true);
-    validateFieldCompatible(Schema.Type.LONG, null, Types.TIMESTAMP, false);
+    validateFieldCompatible(Schema.Type.INT, Schema.LogicalType.DATE, Types.DATE, true, 0,
+                            true);
+    validateFieldCompatible(Schema.Type.INT, Schema.LogicalType.TIME_MILLIS, Types.TIME, true,
+                            0, true);
+    validateFieldCompatible(Schema.Type.LONG, Schema.LogicalType.TIME_MICROS, Types.TIME, true,
+                            0, true);
+    validateFieldCompatible(Schema.Type.LONG, Schema.LogicalType.TIMESTAMP_MILLIS, Types.TIMESTAMP, true,
+                            0, true);
+    validateFieldCompatible(Schema.Type.LONG, Schema.LogicalType.TIMESTAMP_MICROS, Types.TIMESTAMP, true,
+                            0, true);
+    validateFieldCompatible(Schema.Type.BYTES, Schema.LogicalType.DECIMAL, Types.NUMERIC, true,
+                            0, true);
+    validateFieldCompatible(Schema.Type.BYTES, Schema.LogicalType.DECIMAL, Types.DECIMAL, true,
+                            0, true);
+    validateFieldCompatible(Schema.Type.NULL, null, 0, true, 0,
+                            true);
+    validateFieldCompatible(Schema.Type.BOOLEAN, null, Types.BOOLEAN, true, 0,
+                            true);
+    validateFieldCompatible(Schema.Type.BOOLEAN, null, Types.BIT, true, 0,
+                            true);
+    validateFieldCompatible(Schema.Type.INT, null, Types.INTEGER, true, 0,
+                            true);
+    validateFieldCompatible(Schema.Type.INT, null, Types.SMALLINT, true, 0,
+                            true);
+    validateFieldCompatible(Schema.Type.INT, null, Types.TINYINT, true, 0,
+                            true);
+    validateFieldCompatible(Schema.Type.FLOAT, null, Types.REAL, true, 0,
+                            true);
+    validateFieldCompatible(Schema.Type.FLOAT, null, Types.FLOAT, true, 0,
+                            true);
+    validateFieldCompatible(Schema.Type.DOUBLE, null, Types.DOUBLE, true, 0,
+                            true);
+    validateFieldCompatible(Schema.Type.BYTES, null, Types.BINARY, true, 0,
+                            true);
+    validateFieldCompatible(Schema.Type.BYTES, null, Types.VARBINARY, true, 0,
+                            true);
+    validateFieldCompatible(Schema.Type.BYTES, null, Types.LONGVARBINARY, true,
+                            0, true);
+    validateFieldCompatible(Schema.Type.BYTES, null, Types.BLOB, true, 0,
+                            true);
+    validateFieldCompatible(Schema.Type.STRING, null, Types.VARCHAR, true, 0,
+                            true);
+    validateFieldCompatible(Schema.Type.STRING, null, Types.CHAR, true, 0,
+                            true);
+    validateFieldCompatible(Schema.Type.STRING, null, Types.CLOB, true, 0,
+                            true);
+    validateFieldCompatible(Schema.Type.STRING, null, Types.LONGNVARCHAR, true,
+                            0, true);
+    validateFieldCompatible(Schema.Type.STRING, null, Types.LONGVARCHAR, true, 0,
+                            true);
+    validateFieldCompatible(Schema.Type.STRING, null, Types.NCHAR, true, 0,
+                            true);
+    validateFieldCompatible(Schema.Type.STRING, null, Types.NCLOB, true, 0,
+                            true);
+    validateFieldCompatible(Schema.Type.LONG, null, Types.TIMESTAMP, false, 0,
+                            true);
   }
 
   @Test
@@ -186,11 +214,12 @@ public class CommonFieldsValidatorTest {
   }
 
   public void validateFieldCompatible(Schema.Type fieldType, Schema.LogicalType fieldLogicalType, int sqlType,
-                                      boolean isCompatible) {
+                                      boolean isCompatible, int precision, boolean isSigned) {
     String errorMessage = String.format("Expected type '%s' is %s with sql type '%d'",
                                         fieldType,
                                         isCompatible ? "compatible" : "not compatible",
                                         sqlType);
-    Assert.assertEquals(errorMessage, isCompatible, VALIDATOR.isFieldCompatible(fieldType, fieldLogicalType, sqlType));
+    Assert.assertEquals(errorMessage, isCompatible, VALIDATOR.isFieldCompatible(fieldType, fieldLogicalType, sqlType,
+                                                                                precision, isSigned));
   }
 }

--- a/db2-plugin/src/main/java/io/cdap/plugin/db2/DB2FieldsValidator.java
+++ b/db2-plugin/src/main/java/io/cdap/plugin/db2/DB2FieldsValidator.java
@@ -36,10 +36,12 @@ public class DB2FieldsValidator extends CommonFieldsValidator {
 
     int sqlType = metadata.getColumnType(index);
     String colTypeName = metadata.getColumnTypeName(index);
+    boolean isSigned = metadata.isSigned(index);
+    int precision = metadata.getPrecision(index);
 
     // Handle logical types first
     if (fieldLogicalType != null) {
-      return super.isFieldCompatible(fieldType, fieldLogicalType, sqlType);
+      return super.isFieldCompatible(fieldType, fieldLogicalType, sqlType, precision, isSigned);
     }
 
     switch (fieldType) {
@@ -49,7 +51,7 @@ public class DB2FieldsValidator extends CommonFieldsValidator {
           || DB2SchemaReader.DB2_DECFLOAT.equals(colTypeName)
           || super.isFieldCompatible(field, metadata, index);
       default:
-        return super.isFieldCompatible(fieldType, null, sqlType);
+        return super.isFieldCompatible(fieldType, null, sqlType, precision, isSigned);
     }
   }
 }

--- a/memsql-plugin/src/main/java/io/cdap/plugin/memsql/sink/MemsqlFieldsValidator.java
+++ b/memsql-plugin/src/main/java/io/cdap/plugin/memsql/sink/MemsqlFieldsValidator.java
@@ -27,12 +27,13 @@ import java.sql.Types;
 public class MemsqlFieldsValidator extends CommonFieldsValidator {
 
   @Override
-  public boolean isFieldCompatible(Schema.Type fieldType, Schema.LogicalType fieldLogicalType, int sqlType) {
+  public boolean isFieldCompatible(Schema.Type fieldType, Schema.LogicalType fieldLogicalType, int sqlType,
+                                   int precision, boolean isSigned) {
     // In MemqSQL bool stores as tinyint
     if (fieldType == Schema.Type.BOOLEAN && sqlType == Types.TINYINT) {
       return true;
     }
 
-    return super.isFieldCompatible(fieldType, fieldLogicalType, sqlType);
+    return super.isFieldCompatible(fieldType, fieldLogicalType, sqlType, precision, isSigned);
   }
 }

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlFieldsValidator.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlFieldsValidator.java
@@ -34,10 +34,12 @@ public class SqlFieldsValidator extends CommonFieldsValidator {
     Schema.LogicalType fieldLogicalType = fieldSchema.getLogicalType();
 
     int sqlType = metadata.getColumnType(index);
+    boolean isSigned = metadata.isSigned(index);
+    int precision = metadata.getPrecision(index);
 
     // Handle logical types first
     if (fieldLogicalType != null) {
-      return super.isFieldCompatible(fieldType, fieldLogicalType, sqlType);
+      return super.isFieldCompatible(fieldType, fieldLogicalType, sqlType, precision, isSigned);
     }
 
     switch (fieldType) {
@@ -53,7 +55,7 @@ public class SqlFieldsValidator extends CommonFieldsValidator {
           || sqlType == SqlServerSinkSchemaReader.SQL_VARIANT
           || super.isFieldCompatible(field, metadata, index);
       default:
-        return super.isFieldCompatible(fieldType, null, sqlType);
+        return super.isFieldCompatible(fieldType, null, sqlType, precision, isSigned);
     }
   }
 }

--- a/mysql-plugin/src/e2e-test/features/mysql/Datatypes.feature
+++ b/mysql-plugin/src/e2e-test/features/mysql/Datatypes.feature
@@ -15,8 +15,8 @@
 #
 
 @Mysql
-Feature: Mysql - Verify Mysql source data transfer
-  @MYSQL_SOURCE_TEST @MYSQL_SINK_TEST @Mysql_Required
+Feature: Mysql - Verify Mysql source data transfer for different datatypes
+  @MYSQL_SOURCE_DATATYPES_TEST @MYSQL_SINK_TEST @Mysql_Required
   Scenario: To verify data is getting transferred from Mysql to Mysql successfully
     Given Open Datafusion Project to configure pipeline
     When Expand Plugin group in the LHS plugins list: "Source"
@@ -34,7 +34,7 @@ Feature: Mysql - Verify Mysql source data transfer
     Then Replace input plugin property: "database" with value: "databaseName"
     Then Enter textarea plugin property: "importQuery" with value: "selectQuery"
     Then Click on the Get Schema button
-    Then Verify the Output Schema matches the Expected Schema: "outputSchema"
+    Then Verify the Output Schema matches the Expected Schema: "datatypesSchema"
     Then Validate "MySQL" plugin properties
     Then Close the Plugin Properties page
     Then Navigate to the properties page of plugin: "MySQL2"
@@ -52,7 +52,6 @@ Feature: Mysql - Verify Mysql source data transfer
     Then Preview and run the pipeline
     Then Verify the preview of pipeline is "success"
     Then Click on preview data for MySQL sink
-    Then Verify preview output schema matches the outputSchema captured in properties
     Then Close the preview data
     Then Deploy the pipeline
     Then Run the Pipeline in Runtime

--- a/mysql-plugin/src/e2e-test/java/io/cdap/plugin/common/stepsdesign/TestSetupHooks.java
+++ b/mysql-plugin/src/e2e-test/java/io/cdap/plugin/common/stepsdesign/TestSetupHooks.java
@@ -54,6 +54,20 @@ public class TestSetupHooks {
     MysqlClient.createTargetTable(PluginPropertyUtils.pluginProp("targetTable"));
   }
 
+  @Before(order = 1, value = "@MYSQL_SOURCE_DATATYPES_TEST")
+  public static void setSelectQueryForDatatypes() {
+    String sourceTable =  PluginPropertyUtils.pluginProp("sourceTable");
+    PluginPropertyUtils.addPluginProp("selectQuery",
+                                      PluginPropertyUtils.pluginProp("selectQuery").
+                                        replace("${table}", sourceTable));
+  }
+
+  @Before(order = 2, value = "@MYSQL_SOURCE_DATATYPES_TEST")
+  public static void createDatatypesTable() throws SQLException, ClassNotFoundException {
+    MysqlClient.createSourceDatatypesTable(PluginPropertyUtils.pluginProp("sourceTable"));
+    MysqlClient.createTargetDatatypesTable(PluginPropertyUtils.pluginProp("targetTable"));
+  }
+
   @After(order = 2, value = "@MYSQL_SINK_TEST")
   public static void dropTables() throws SQLException, ClassNotFoundException {
     MysqlClient.dropTables(new String[]{PluginPropertyUtils.pluginProp("sourceTable"),

--- a/mysql-plugin/src/e2e-test/java/io/cdap/plugin/mysql/stepsdesign/Mysql.java
+++ b/mysql-plugin/src/e2e-test/java/io/cdap/plugin/mysql/stepsdesign/Mysql.java
@@ -35,21 +35,16 @@ public class Mysql implements CdfHelper {
     openSinkPluginPreviewData("Mysql");
   }
 
-
-  @Then("Get count of no of records transferred to target MySQL Table")
-  public void getCountOfNoOfRecordsTransferredToTargetMysqlTable() throws SQLException, ClassNotFoundException {
+  @Then("Validate the values of records transferred to target table is equal to the values from source table")
+  public void validateTheValuesOfRecordsTransferredToTargetTableIsEqualToTheValuesFromSourceTable() throws
+    SQLException, ClassNotFoundException {
     int countRecords = MysqlClient.countRecord(PluginPropertyUtils.pluginProp("targetTable"));
-    BeforeActions.scenario.write("**********No of Records Transferred******************:" + countRecords);
     Assert.assertEquals("Number of records transferred should be equal to records out ",
                         countRecords, recordOut());
-  }
-
-  @Then("Validate records transferred to target table is equal to number of records from source table")
-  public void validateRecordsTransferredToTargetTableIsEqualToNumberOfRecordsFromSourceTable()
-    throws SQLException, ClassNotFoundException {
-    int countRecordsTarget = MysqlClient.countRecord(PluginPropertyUtils.pluginProp("targetTable"));
-    int countRecordsSource = MysqlClient.countRecord(PluginPropertyUtils.pluginProp("sourceTable"));
-    BeforeActions.scenario.write("Number of records transferred:" + countRecordsSource);
-    Assert.assertEquals(countRecordsSource, countRecordsTarget);
+    BeforeActions.scenario.write(" ******** Number of records transferred ********:" + countRecords);
+    boolean recordsMatched = MysqlClient.validateRecordValues(PluginPropertyUtils.pluginProp("sourceTable"),
+                                                           PluginPropertyUtils.pluginProp("targetTable"));
+    Assert.assertTrue("Value of records transferred to the target table should be equal to the value " +
+                        "of the records in the source table", recordsMatched);
   }
 }

--- a/mysql-plugin/src/e2e-test/resources/pluginParameters.properties
+++ b/mysql-plugin/src/e2e-test/resources/pluginParameters.properties
@@ -10,3 +10,31 @@ targetRef=target
 sourceTable=sourceTable
 targetTable=targetTable
 outputSchema=[{"key":"id","value":"int"},{"key":"lastName","value":"string"}]
+
+datatypesColumns=(ID varchar(100) PRIMARY KEY, COL1 bigint(20), COL2 bigint(20) unsigned, COL3 binary(1), \
+  COL4 bit(1), COL5 blob, COL6 tinyint(1), COL7 char(1), COL8 date, COL9 datetime, COL10 decimal(10,0), COL11 double, \
+  COL12 enum('A','B','C'), COL13 float, COL14 int(11), COL15 int(10) unsigned, COL16 mediumblob, COL17 mediumtext, \
+  COL18 longblob, COL19 longtext, COL20 mediumint(9), COL21 mediumint(8) unsigned, COL22 set('X','y','Z'), \
+  COL23 smallint(6), COL24 smallint(5) unsigned, COL25 text, COL26 time, COL27 timestamp, COL28 tinyblob, \
+  COL29 tinyint(4), COL30 tinyint(3) unsigned, COL31 tinytext, COL32 varbinary(100), COL33 json)
+datatypesColumnsList=(ID,COL1,COL2,COL3,COL4,COL5,COL6,COL7,COL8,COL9,COL10,COL11,COL12,COL13,COL14,COL15,COL16,COL17,\
+  COL18,COL19,COL20,COL21,COL22,COL23,COL24,COL25,COL26,COL27,COL28,COL29,COL30,COL31,COL32,COL33)
+datatypesValues=VALUES ('User1',1000000000000000000,1000000000000000000,1,1,\
+  HEX('27486920546869732069732061206C6F6E6720746578742E27'),1,'A','2023-01-01','2023-01-01 00:00:00',1234,\
+  1234.5678,'A',22.0,-1234,1234,HEX('27486920546869732069732061206C6F6E6720746578742E27'),\
+  'This is a test message',HEX('27486920546869732069732061206C6F6E6720746578742E27'),\
+  'This is a test message\n\n',-1234,1234,'X',-1234,1234,'This is a test message','00:00:00','2023-01-01 00:00:00',\
+  HEX('27486920546869732069732061206C6F6E6720746578742E27'),-100,100,'This is a test message',1,\
+  '{"key1": "value1", "key2": "value2"}')
+datatypesSchema=[{"key":"ID","value":"string"},{"key":"COL1","value":"long"},{"key":"COL2","value":"decimal"},\
+  {"key":"COL3","value":"bytes"},{"key":"COL4","value":"boolean"},{"key":"COL5","value":"bytes"},\
+  {"key":"COL6","value":"boolean"},{"key":"COL7","value":"string"},{"key":"COL8","value":"date"},\
+  {"key":"COL9","value":"timestamp"},{"key":"COL10","value":"decimal"},{"key":"COL11","value":"double"},\
+  {"key":"COL12","value":"string"},{"key":"COL13","value":"float"},{"key":"COL14","value":"int"},\
+  {"key":"COL15","value":"long"},{"key":"COL16","value":"bytes"},{"key":"COL17","value":"string"},\
+  {"key":"COL18","value":"bytes"},{"key":"COL19","value":"string"},{"key":"COL20","value":"int"},\
+  {"key":"COL21","value":"long"},{"key":"COL22","value":"string"},{"key":"COL23","value":"int"},\
+  {"key":"COL24","value":"int"},{"key":"COL25","value":"string"},{"key":"COL26","value":"time"},\
+  {"key":"COL27","value":"timestamp"},{"key":"COL28","value":"bytes"},{"key":"COL29","value":"int"},\
+  {"key":"COL30","value":"int"},{"key":"COL31","value":"string"},{"key":"COL32","value":"bytes"},\
+  {"key":"COL33","value":"string"}]

--- a/netezza-plugin/src/main/java/io/cdap/plugin/netezza/NetezzaFieldsValidator.java
+++ b/netezza-plugin/src/main/java/io/cdap/plugin/netezza/NetezzaFieldsValidator.java
@@ -25,11 +25,12 @@ import io.cdap.plugin.db.sink.CommonFieldsValidator;
 public class NetezzaFieldsValidator extends CommonFieldsValidator {
 
   @Override
-  public boolean isFieldCompatible(Schema.Type fieldType, Schema.LogicalType fieldLogicalType, int sqlType) {
+  public boolean isFieldCompatible(Schema.Type fieldType, Schema.LogicalType fieldLogicalType, int sqlType,
+                                   int precision, boolean isSigned) {
     if (fieldLogicalType == null && sqlType == NetezzaDBRecord.INTERVAL && fieldType == Schema.Type.STRING) {
       return true;
     } else {
-      return super.isFieldCompatible(fieldType, fieldLogicalType, sqlType);
+      return super.isFieldCompatible(fieldType, fieldLogicalType, sqlType, precision, isSigned);
     }
   }
 }

--- a/teradata-plugin/src/main/java/io/cdap/plugin/teradata/sink/TeradataFieldsValidator.java
+++ b/teradata-plugin/src/main/java/io/cdap/plugin/teradata/sink/TeradataFieldsValidator.java
@@ -37,6 +37,8 @@ public class TeradataFieldsValidator extends CommonFieldsValidator {
 
     int sqlType = metadata.getColumnType(index);
     String sqlTypeName = metadata.getColumnTypeName(index);
+    boolean isSigned = metadata.isSigned(index);
+    int precision = metadata.getPrecision(index);
 
     // In Teradata FLOAT and DOUBLE are same types
     if (fieldType == Schema.Type.DOUBLE && sqlType == Types.FLOAT) {
@@ -48,6 +50,6 @@ public class TeradataFieldsValidator extends CommonFieldsValidator {
       return true;
     }
 
-    return isFieldCompatible(fieldType, fieldLogicalType, sqlType);
+    return isFieldCompatible(fieldType, fieldLogicalType, sqlType, precision, isSigned);
   }
 }


### PR DESCRIPTION
Added MySQL Plugin Sanity Test in E2E test for querying all supported datatypes.

Also fixed issues related to unsigned int, unsigned mediumint, unsigned bigint where these are detected as wrong datatypes by MySQL Plugin: [PLUGIN-1505](https://cdap.atlassian.net/browse/PLUGIN-1505), [PLUGIN-1506](https://cdap.atlassian.net/browse/PLUGIN-1506), [PLUGIN-1507](https://cdap.atlassian.net/browse/PLUGIN-1507).

[PLUGIN-1505]: https://cdap.atlassian.net/browse/PLUGIN-1505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLUGIN-1506]: https://cdap.atlassian.net/browse/PLUGIN-1506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLUGIN-1507]: https://cdap.atlassian.net/browse/PLUGIN-1507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ