### PR TITLE
Added functionality to create tables with random names in E2E tests

### DIFF
--- a/mysql-plugin/src/e2e-test/java/io/cdap/plugin/MysqlClient.java
+++ b/mysql-plugin/src/e2e-test/java/io/cdap/plugin/MysqlClient.java
@@ -121,7 +121,6 @@ public class MysqlClient {
     return true;
   }
 
-
   public static void createSourceTable(String sourceTable) throws SQLException, ClassNotFoundException {
     try (Connection connect = getMysqlConnection();
          Statement statement = connect.createStatement()) {

--- a/mysql-plugin/src/e2e-test/java/io/cdap/plugin/common/stepsdesign/TestSetupHooks.java
+++ b/mysql-plugin/src/e2e-test/java/io/cdap/plugin/common/stepsdesign/TestSetupHooks.java
@@ -20,6 +20,7 @@ import io.cdap.e2e.utils.PluginPropertyUtils;
 import io.cdap.plugin.MysqlClient;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
+import org.apache.commons.lang3.RandomStringUtils;
 
 import java.sql.SQLException;
 
@@ -28,8 +29,17 @@ import java.sql.SQLException;
  */
 public class TestSetupHooks {
 
+  private static void setTableName() {
+    String randomString = RandomStringUtils.randomAlphabetic(10);
+    String sourceTableName = String.format("SourceTable_%s", randomString);
+    String targetTableName = String.format("TargetTable_%s", randomString);
+    PluginPropertyUtils.addPluginProp("sourceTable", sourceTableName);
+    PluginPropertyUtils.addPluginProp("targetTable", targetTableName);
+    PluginPropertyUtils.addPluginProp("selectQuery", String.format("select * from %s", sourceTableName));
+  }
+
   @Before(order = 1)
-  public static void overrideUserAndPasswordIfProvided() {
+  public static void initializeDBProperties() {
     String username = System.getenv("username");
     if (username != null && !username.isEmpty()) {
         PluginPropertyUtils.addPluginProp("username", username);
@@ -38,28 +48,13 @@ public class TestSetupHooks {
     if (password != null && !password.isEmpty()) {
       PluginPropertyUtils.addPluginProp("password", password);
     }
-  }
-
-  @Before(order = 1, value = "@MYSQL_SOURCE_TEST")
-  public static void setSelectQuery() {                
-    String sourceTable =  PluginPropertyUtils.pluginProp("sourceTable");
-    PluginPropertyUtils.addPluginProp("selectQuery",
-                                      PluginPropertyUtils.pluginProp("selectQuery").
-                                        replace("${table}", sourceTable));
+    TestSetupHooks.setTableName();
   }
 
   @Before(order = 2, value = "@MYSQL_SOURCE_TEST")
   public static void createTables() throws SQLException, ClassNotFoundException {
     MysqlClient.createSourceTable(PluginPropertyUtils.pluginProp("sourceTable"));
     MysqlClient.createTargetTable(PluginPropertyUtils.pluginProp("targetTable"));
-  }
-
-  @Before(order = 1, value = "@MYSQL_SOURCE_DATATYPES_TEST")
-  public static void setSelectQueryForDatatypes() {
-    String sourceTable =  PluginPropertyUtils.pluginProp("sourceTable");
-    PluginPropertyUtils.addPluginProp("selectQuery",
-                                      PluginPropertyUtils.pluginProp("selectQuery").
-                                        replace("${table}", sourceTable));
   }
 
   @Before(order = 2, value = "@MYSQL_SOURCE_DATATYPES_TEST")

--- a/mysql-plugin/src/e2e-test/resources/pluginParameters.properties
+++ b/mysql-plugin/src/e2e-test/resources/pluginParameters.properties
@@ -4,11 +4,8 @@ username=MYSQL_USERNAME
 password=MYSQL_PASSWORD
 databaseName=sakila
 port=MYSQL_PORT
-selectQuery=select * from ${table}
 sourceRef=source
 targetRef=target
-sourceTable=sourceTable
-targetTable=targetTable
 outputSchema=[{"key":"id","value":"int"},{"key":"lastName","value":"string"}]
 
 datatypesColumns=(ID varchar(100) PRIMARY KEY, COL1 bigint(20), COL2 bigint(20) unsigned, COL3 binary(1), \

--- a/oracle-plugin/src/e2e-test/java/io.cdap.plugin/common.stepsdesign/TestSetupHooks.java
+++ b/oracle-plugin/src/e2e-test/java/io.cdap.plugin/common.stepsdesign/TestSetupHooks.java
@@ -20,6 +20,7 @@ import io.cdap.e2e.utils.PluginPropertyUtils;
 import io.cdap.plugin.OracleClient;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
+import org.apache.commons.lang3.RandomStringUtils;
 
 import java.sql.SQLException;
 
@@ -28,13 +29,16 @@ import java.sql.SQLException;
  */
 public class TestSetupHooks {
 
-  @Before(order = 1, value = "@ORACLE_SOURCE_TEST")
-  public static void setSelectQuery() {
-    String sourceTable =  PluginPropertyUtils.pluginProp("sourceTable");
+  @Before(order = 1)
+  public static void setTableName() {
+    String randomString = RandomStringUtils.randomAlphabetic(10).toUpperCase();
+    String sourceTableName = String.format("SOURCETABLE_%s", randomString);
+    String targetTableName = String.format("TARGETTABLE_%s", randomString);
+    PluginPropertyUtils.addPluginProp("sourceTable", sourceTableName);
+    PluginPropertyUtils.addPluginProp("targetTable", targetTableName);
     String schema = PluginPropertyUtils.pluginProp("schema");
-    PluginPropertyUtils.addPluginProp("selectQuery",
-                                      PluginPropertyUtils.pluginProp("selectQuery").
-                                        replace("${table}", sourceTable).replace("${schema}", schema));
+    PluginPropertyUtils.addPluginProp("selectQuery", String.format("select * from %s.%s", schema,
+                                                                   sourceTableName));
   }
 
   @Before(order = 2, value = "@ORACLE_SOURCE_TEST")
@@ -45,30 +49,12 @@ public class TestSetupHooks {
                                    PluginPropertyUtils.pluginProp("schema"));
   }
 
-  @Before(order = 1, value = "@ORACLE_SOURCE_DATATYPES_TEST")
-  public static void setSelectQueryForAllDatatypes() {
-    String sourceTable =  PluginPropertyUtils.pluginProp("sourceTable");
-    String schema = PluginPropertyUtils.pluginProp("schema");
-    PluginPropertyUtils.addPluginProp("selectQuery",
-                                      PluginPropertyUtils.pluginProp("selectQuery").
-                                        replace("${table}", sourceTable).replace("${schema}", schema));
-  }
-
   @Before(order = 2, value = "@ORACLE_SOURCE_DATATYPES_TEST")
   public static void createAllDatatypesTables() throws SQLException, ClassNotFoundException {
     OracleClient.createSourceDatatypesTable(PluginPropertyUtils.pluginProp("sourceTable"),
                                    PluginPropertyUtils.pluginProp("schema"));
     OracleClient.createTargetDatatypesTable(PluginPropertyUtils.pluginProp("targetTable"),
                                    PluginPropertyUtils.pluginProp("schema"));
-  }
-
-  @Before(order = 1, value = "@ORACLE_SOURCE_DATATYPES_TEST2")
-  public static void setSelectQueryForLongDatatype() {
-    String sourceTable =  PluginPropertyUtils.pluginProp("sourceTable");
-    String schema = PluginPropertyUtils.pluginProp("schema");
-    PluginPropertyUtils.addPluginProp("selectQuery",
-                                      PluginPropertyUtils.pluginProp("selectQuery").
-                                        replace("${table}", sourceTable).replace("${schema}", schema));
   }
 
   @Before(order = 2, value = "@ORACLE_SOURCE_DATATYPES_TEST2")
@@ -79,30 +65,12 @@ public class TestSetupHooks {
                                             PluginPropertyUtils.pluginProp("schema"));
   }
 
-  @Before(order = 1, value = "@ORACLE_SOURCE_LONGRAW_TEST")
-  public static void setSelectQueryForDatatypesLongRaw() {
-    String sourceTable =  PluginPropertyUtils.pluginProp("sourceTable");
-    String schema = PluginPropertyUtils.pluginProp("schema");
-    PluginPropertyUtils.addPluginProp("selectQuery",
-                                      PluginPropertyUtils.pluginProp("selectQuery").
-                                        replace("${table}", sourceTable).replace("${schema}", schema));
-  }
-
   @Before(order = 2, value = "@ORACLE_SOURCE_LONGRAW_TEST")
   public static void createDatatypesTablesLongRaw() throws SQLException, ClassNotFoundException {
     OracleClient.createSourceLongRawTable(PluginPropertyUtils.pluginProp("sourceTable"),
                                             PluginPropertyUtils.pluginProp("schema"));
     OracleClient.createTargetLongRawTable(PluginPropertyUtils.pluginProp("targetTable"),
                                             PluginPropertyUtils.pluginProp("schema"));
-  }
-
-  @Before(order = 1, value = "@ORACLE_SOURCE_DATATYPES_TEST4")
-  public static void setSelectQueryForLongVarchar() {
-    String sourceTable =  PluginPropertyUtils.pluginProp("sourceTable");
-    String schema = PluginPropertyUtils.pluginProp("schema");
-    PluginPropertyUtils.addPluginProp("selectQuery",
-                                      PluginPropertyUtils.pluginProp("selectQuery").
-                                        replace("${table}", sourceTable).replace("${schema}", schema));
   }
 
   @Before(order = 2, value = "@ORACLE_SOURCE_DATATYPES_TEST4")

--- a/oracle-plugin/src/e2e-test/resources/pluginParameters.properties
+++ b/oracle-plugin/src/e2e-test/resources/pluginParameters.properties
@@ -1,10 +1,7 @@
 driverName=oracle
 databaseName=xe
-selectQuery=select * from ${schema}.${table}
 sourceRef=source
 targetRef=target
-sourceTable=SOURCETABLE
-targetTable=TARGETTABLE
 schema=HR
 host=ORACLE_HOST
 port=ORACLE_PORT


### PR DESCRIPTION
Added functionality to create tables with random names in Oracle and MySQL E2E tests.

Fixes the issue where multiple instances of Github actions test running for E2E tests result in `Table does not exist` error and causes failure of the test run.