### PR TITLE
Converting PostgreSQL Timestamp type to Datetime type

### DIFF
--- a/database-commons/src/main/java/io/cdap/plugin/db/DBRecord.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/DBRecord.java
@@ -311,6 +311,9 @@ public class DBRecord implements Writable, DBWritable, Configurable {
         case DECIMAL:
           stmt.setBigDecimal(sqlIndex, record.getDecimal(fieldName));
           break;
+        case DATETIME:
+          stmt.setTimestamp(sqlIndex, Timestamp.valueOf(record.getDateTime(fieldName)));
+          break;
       }
       return;
     }

--- a/database-commons/src/main/java/io/cdap/plugin/db/config/AbstractDBSpecificSourceConfig.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/config/AbstractDBSpecificSourceConfig.java
@@ -122,7 +122,7 @@ public abstract class AbstractDBSpecificSourceConfig extends PluginConfig implem
     }
 
     if (getTransactionIsolationLevel() != null) {
-      TransactionIsolationLevel.validate(getTransactionIsolationLevel(), collector);
+        TransactionIsolationLevel.validate(getTransactionIsolationLevel(), collector);
     }
 
     if (!containsMacro(IMPORT_QUERY) && Strings.isNullOrEmpty(importQuery)) {

--- a/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
+++ b/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
@@ -59,7 +59,7 @@ import javax.management.ReflectionException;
 public final class DBUtils {
   private static final Logger LOG = LoggerFactory.getLogger(DBUtils.class);
 
-  private static final Calendar PURE_GREGORIAN_CALENDAR = createPureGregorianCalender();
+  public static final Calendar PURE_GREGORIAN_CALENDAR = createPureGregorianCalender();
 
   // Java by default uses October 15, 1582 as a Gregorian cut over date.
   // Any timestamp created with time less than this cut over date is treated as Julian date.

--- a/database-commons/src/test/java/io/cdap/plugin/db/DBRecordUnitTest.java
+++ b/database-commons/src/test/java/io/cdap/plugin/db/DBRecordUnitTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.db;
+
+import com.mockrunner.mock.jdbc.MockConnection;
+import com.mockrunner.mock.jdbc.MockPreparedStatement;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tests for the DBRecord class
+ */
+public class DBRecordUnitTest {
+
+    @Test
+    public void validateTimeStampWriteOperation() throws SQLException {
+        String instantStr1 = "0001-01-01T01:00:00Z";
+        String instantStr2 = "2023-01-01T01:00:00Z";
+
+        ZonedDateTime tStamp1 = Instant.parse(instantStr1).atZone(ZoneId.of("UTC"));
+        ZonedDateTime tStamp2 = Instant.parse(instantStr2).atZone(ZoneId.of("UTC"));
+
+        StructuredRecord record = Mockito.mock(StructuredRecord.class);
+        Mockito.when(record.get(Mockito.eq("COL1"))).thenReturn(tStamp1);
+        Mockito.when(record.getTimestamp(Mockito.eq("COL1"))).thenReturn(tStamp1);
+        Mockito.when(record.get(Mockito.eq("COL2"))).thenReturn(tStamp2);
+        Mockito.when(record.getTimestamp(Mockito.eq("COL2"))).thenReturn(tStamp2);
+
+        List<ColumnType> columnTypes = new ArrayList<ColumnType>();
+        columnTypes.add(new ColumnType("COL1", "timestamp", Types.TIMESTAMP));
+        columnTypes.add(new ColumnType("COL2", "timestamp", Types.TIMESTAMP));
+
+        MockPreparedStatement preparedStatement = new MockPreparedStatement(new MockConnection(), "sql");
+
+        Schema schema = Schema.of(Schema.LogicalType.TIMESTAMP_MICROS);
+        Schema.Field field1 = Schema.Field.of("COL1", schema);
+        Schema.Field field2 = Schema.Field.of("COL2", schema);
+
+        DBRecord dbRecord = new DBRecord(record, columnTypes);
+        dbRecord.writeToDB(preparedStatement, field1, 0);
+        dbRecord.writeToDB(preparedStatement, field2, 1);
+
+        Assert.assertTrue(Timestamp.valueOf(tStamp1.toLocalDateTime()).equals(preparedStatement.getParameter(1)));
+        Assert.assertTrue(Timestamp.valueOf(tStamp2.toLocalDateTime()).equals(preparedStatement.getParameter(2)));
+    }
+}

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresDBRecord.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresDBRecord.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.plugin.db.ColumnType;
 import io.cdap.plugin.db.DBRecord;
 import io.cdap.plugin.db.SchemaReader;
+import io.cdap.plugin.util.DBUtils;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -28,6 +29,11 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 /**
@@ -49,11 +55,40 @@ public class PostgresDBRecord extends DBRecord {
   @Override
   protected void handleField(ResultSet resultSet, StructuredRecord.Builder recordBuilder, Schema.Field field,
                              int columnIndex, int sqlType, int sqlPrecision, int sqlScale) throws SQLException {
+    String columnTypeName = resultSet.getMetaData().getColumnTypeName(columnIndex);
     if (isUseSchema(resultSet.getMetaData(), columnIndex)) {
       setFieldAccordingToSchema(resultSet, recordBuilder, field, columnIndex);
+    } else if (sqlType == Types.TIMESTAMP && columnTypeName.equalsIgnoreCase("timestamp")) {
+      Timestamp timestamp = resultSet.getTimestamp(columnIndex, DBUtils.PURE_GREGORIAN_CALENDAR);
+      if (timestamp != null) {
+        ZonedDateTime zonedDateTime = OffsetDateTime.of(timestamp.toLocalDateTime(), OffsetDateTime.now().getOffset())
+                .atZoneSameInstant(ZoneId.of("UTC"));
+        /*if (columnTypeName.equalsIgnoreCase("timestamptz")) {
+          recordBuilder.setTimestamp(field.getName(), zonedDateTime);
+        } else */
+        Schema nonNullableSchema = field.getSchema().isNullable() ?
+                field.getSchema().getNonNullable() : field.getSchema();
+        setZonedDateTimeBasedOnOuputSchema(recordBuilder, nonNullableSchema.getLogicalType(),
+                field.getName(), zonedDateTime);
+      } else {
+        recordBuilder.set(field.getName(), null);
+      }
     } else {
       setField(resultSet, recordBuilder, field, columnIndex, sqlType, sqlPrecision, sqlScale);
     }
+  }
+
+  private void setZonedDateTimeBasedOnOuputSchema(StructuredRecord.Builder recordBuilder,
+                                                  Schema.LogicalType logicalType,
+                                                  String fieldName,
+                                                  ZonedDateTime zonedDateTime) {
+    if (Schema.LogicalType.DATETIME.equals(logicalType)) {
+      recordBuilder.setDateTime(fieldName, zonedDateTime.toLocalDateTime());
+    } else if (Schema.LogicalType.TIMESTAMP_MICROS.equals(logicalType)) {
+      recordBuilder.setTimestamp(fieldName, zonedDateTime);
+    }
+
+    return;
   }
 
   private static boolean isUseSchema(ResultSetMetaData metadata, int columnIndex) throws SQLException {

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresDBRecord.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresDBRecord.java
@@ -73,6 +73,13 @@ public class PostgresDBRecord extends DBRecord {
       } else {
         recordBuilder.set(field.getName(), null);
       }
+    } else if (sqlType == Types.TIMESTAMP && columnTypeName.equalsIgnoreCase("timestamptz")) {
+      OffsetDateTime timestamp = resultSet.getObject(columnIndex, OffsetDateTime.class);
+      if (timestamp != null) {
+        recordBuilder.setTimestamp(field.getName(), timestamp.atZoneSameInstant(ZoneId.of("UTC")));
+      } else {
+        recordBuilder.set(field.getName(), null);
+      }
     } else {
       setField(resultSet, recordBuilder, field, columnIndex, sqlType, sqlPrecision, sqlScale);
     }

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresFieldsValidator.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresFieldsValidator.java
@@ -30,8 +30,8 @@ public class PostgresFieldsValidator extends CommonFieldsValidator {
 
   @Override
   public boolean isFieldCompatible(Schema.Field field, ResultSetMetaData metadata, int index) throws SQLException {
-    Schema.Type fieldType = field.getSchema().isNullable() ? field.getSchema().getNonNullable().getType()
-      : field.getSchema().getType();
+    Schema schema = field.getSchema().isNullable() ? field.getSchema().getNonNullable() : field.getSchema();
+    Schema.Type fieldType = schema.getType();
 
     String colTypeName = metadata.getColumnTypeName(index);
     int columnType = metadata.getColumnType(index);
@@ -44,6 +44,11 @@ public class PostgresFieldsValidator extends CommonFieldsValidator {
                     "{} type.", field.getName(), fieldType, colTypeName);
         return false;
       }
+    }
+
+    if (colTypeName.equalsIgnoreCase("timestamp")
+        && schema.getLogicalType().equals(Schema.LogicalType.DATETIME)) {
+      return true;
     }
 
     return super.isFieldCompatible(field, metadata, index);

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSchemaReader.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSchemaReader.java
@@ -58,6 +58,10 @@ public class PostgresSchemaReader extends CommonSchemaReader {
       return Schema.of(Schema.Type.STRING);
     }
 
+    if (typeName.equalsIgnoreCase("timestamp")) {
+      return Schema.of(Schema.LogicalType.DATETIME);
+    }
+
     return super.getSchema(metadata, index);
   }
 


### PR DESCRIPTION
Related JIRA : 
https://cdap.atlassian.net/browse/PLUGIN-1518
https://cdap.atlassian.net/browse/PLUGIN-1526

Postgres Timestamp type does not have a timezone information. Current handling creates an offset in the Sink plugin. Hence converting the handling of the PostgreSQL Timestamp type into Datetime type ensuring backward compatibility with the Timestamp type.
