### PR TITLE
Fix/plugin 1540 timestamptz fix

### DIFF
--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleFieldsValidator.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleFieldsValidator.java
@@ -47,8 +47,9 @@ public class OracleFieldsValidator extends CommonFieldsValidator {
                                                                    isSigned);
     }
     if (fieldLogicalType == Schema.LogicalType.TIMESTAMP_MICROS) {
-      return sqlType == OracleSinkSchemaReader.TIMESTAMP_LTZ ||
-        super.isFieldCompatible(fieldType, fieldLogicalType, sqlType, precision, isSigned);
+      return sqlType == OracleSinkSchemaReader.TIMESTAMP_LTZ
+              || sqlType == OracleSinkSchemaReader.TIMESTAMP_TZ
+          || super.isFieldCompatible(fieldType, fieldLogicalType, sqlType, precision, isSigned);
     } else if (fieldLogicalType != null) {
       return super.isFieldCompatible(fieldType, fieldLogicalType, sqlType, precision, isSigned);
     }

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSource.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSource.java
@@ -167,6 +167,14 @@ public class OracleSource extends AbstractDBSource<OracleSource.OracleSourceConf
           && actualFieldSchema.getType().equals(Schema.Type.STRING)) {
         return;
       }
+
+      // For handling TimestampTZ types allow if the expected schema is Timestamp and
+      // output schema is set to String type to ensure backward compatibility.
+      if (Schema.LogicalType.TIMESTAMP_MICROS.equals(actualFieldSchema.getLogicalType())
+          && Schema.Type.STRING.equals(expectedFieldSchema.getType())) {
+        return;
+      }
+
       super.validateField(collector, field, actualFieldSchema, expectedFieldSchema);
     }
   }

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSourceSchemaReader.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSourceSchemaReader.java
@@ -52,6 +52,7 @@ public class OracleSourceSchemaReader extends CommonSchemaReader {
   public static final Set<Integer> ORACLE_TYPES = ImmutableSet.of(
     INTERVAL_DS,
     INTERVAL_YM,
+    Types.TIMESTAMP,
     TIMESTAMP_TZ,
     TIMESTAMP_LTZ,
     BINARY_FLOAT,
@@ -80,9 +81,10 @@ public class OracleSourceSchemaReader extends CommonSchemaReader {
 
     switch (sqlType) {
       case TIMESTAMP_TZ:
-        return Schema.of(Schema.Type.STRING);
-      case TIMESTAMP_LTZ:
         return Schema.of(Schema.LogicalType.TIMESTAMP_MICROS);
+      case Types.TIMESTAMP:
+      case TIMESTAMP_LTZ:
+        return Schema.of(Schema.LogicalType.DATETIME);
       case BINARY_FLOAT:
         return Schema.of(Schema.Type.FLOAT);
       case BINARY_DOUBLE:


### PR DESCRIPTION
JIRA : https://cdap.atlassian.net/browse/PLUGIN-1540

Issue : TimestampTZ field is mapped to String type by calling resultSet.getString method which does not return a java.sql.Timestamp compatible string. Which later leads to failure in the Oracle Sink during mapping from String to TimestampTZ type.
For example : resultSet.getString returns “2023-01-01 02:00:00.000 +0530” which is not compatible with Timestamp type.

Fix: Using the resultSet.getTimestamp(columnIndex).toString method.
For example : resultSet.getTimestamp(columnIndex).toString returns "2022-12-31 20:30:00.0" which can be inserted into the Oracle Sink.