### PR TITLE
Adding the conf TinyIntIsBit only if not already present

### DIFF
--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnectorConfig.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnectorConfig.java
@@ -61,7 +61,7 @@ public class MysqlConnectorConfig extends AbstractDBSpecificConnectorConfig {
     prop.put(JDBC_PROPERTY_SOCKET_TIMEOUT, "20000");
     prop.put(JDBC_REWRITE_BATCHED_STATEMENTS, "true");
     // MySQL property to ensure that TINYINT(1) type data is not converted to MySQL Bit/Boolean type in the ResultSet.
-    prop.put(MYSQL_TINYINT1_IS_BIT, "false");
+    prop.putIfAbsent(MYSQL_TINYINT1_IS_BIT, "false");
     return prop;
   }
 }


### PR DESCRIPTION
In case TinyInt(1) to int conversion causes any regression for any user, the users can simply set TinyIntIsBit=true in the Connection parameters to quickly fix any regression caused by #390 