### PR TITLE
[PLUGIN-1518][PLUGIN-1526] Fixed the timestamp handling to DateTime

### DIFF
--- a/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
+++ b/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
@@ -59,7 +59,7 @@ import javax.management.ReflectionException;
 public final class DBUtils {
   private static final Logger LOG = LoggerFactory.getLogger(DBUtils.class);
 
-  private static final Calendar PURE_GREGORIAN_CALENDAR = createPureGregorianCalender();
+  public static final Calendar PURE_GREGORIAN_CALENDAR = createPureGregorianCalender();
 
   // Java by default uses October 15, 1582 as a Gregorian cut over date.
   // Any timestamp created with time less than this cut over date is treated as Julian date.

--- a/postgresql-plugin/src/e2e-test/resources/pluginParameters.properties
+++ b/postgresql-plugin/src/e2e-test/resources/pluginParameters.properties
@@ -42,7 +42,7 @@ datatypesSchema=[{"key":"id","value":"string"},{"key":"col1","value":"string"},{
   {"key":"col10","value":"decimal"},{"key":"col11","value":"decimal"},{"key":"col12","value":"float"},\
   {"key":"col13","value":"double"},{"key":"col14","value":"string"},{"key":"col15","value":"string"},\
   {"key":"col16","value":"string"},{"key":"col17","value":"double"},{"key":"col18","value":"decimal"},\
-  {"key":"col22","value":"timestamp"},{"key":"col23","value":"timestamp"},{"key":"col24","value":"time"},\
+  {"key":"col22","value":"datetime"},{"key":"col23","value":"timestamp"},{"key":"col24","value":"time"},\
   {"key":"col25","value":"string"},{"key":"col26","value":"string"},{"key":"col27","value":"date"},\
   {"key":"col28","value":"string"},{"key":"col29","value":"string"},{"key":"col30","value":"string"},\
   {"key":"col31","value":"string"},{"key":"col32","value":"string"},{"key":"col33","value":"string"},\

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresFieldsValidator.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresFieldsValidator.java
@@ -30,8 +30,8 @@ public class PostgresFieldsValidator extends CommonFieldsValidator {
 
   @Override
   public boolean isFieldCompatible(Schema.Field field, ResultSetMetaData metadata, int index) throws SQLException {
-    Schema.Type fieldType = field.getSchema().isNullable() ? field.getSchema().getNonNullable().getType()
-      : field.getSchema().getType();
+    Schema schema = field.getSchema().isNullable() ? field.getSchema().getNonNullable() : field.getSchema();
+    Schema.Type fieldType = schema.getType();
 
     String colTypeName = metadata.getColumnTypeName(index);
     int columnType = metadata.getColumnType(index);
@@ -44,6 +44,11 @@ public class PostgresFieldsValidator extends CommonFieldsValidator {
                     "{} type.", field.getName(), fieldType, colTypeName);
         return false;
       }
+    }
+
+    if (colTypeName.equalsIgnoreCase("timestamp")
+        && schema.getLogicalType().equals(Schema.LogicalType.DATETIME)) {
+      return true;
     }
 
     return super.isFieldCompatible(field, metadata, index);

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSchemaReader.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSchemaReader.java
@@ -58,6 +58,10 @@ public class PostgresSchemaReader extends CommonSchemaReader {
       return Schema.of(Schema.Type.STRING);
     }
 
+    if (typeName.equalsIgnoreCase("timestamp")) {
+      return Schema.of(Schema.LogicalType.DATETIME);
+    }
+
     return super.getSchema(metadata, index);
   }
 

--- a/postgresql-plugin/src/test/java/io/cdap/plugin/postgres/PostgresDBRecordUnitTest.java
+++ b/postgresql-plugin/src/test/java/io/cdap/plugin/postgres/PostgresDBRecordUnitTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.postgres;
+
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.plugin.util.DBUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit Test class for the PostgresDBRecord
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PostgresDBRecordUnitTest {
+    @Test
+    public void validateTimestampType() throws SQLException {
+        OffsetDateTime offsetDateTime = OffsetDateTime.of(2023, 1, 1, 1, 0, 0, 0, ZoneOffset.UTC);
+        ResultSetMetaData metaData = Mockito.mock(ResultSetMetaData.class);
+        when(metaData.getColumnTypeName(eq(0))).thenReturn("timestamp");
+
+        ResultSet resultSet = Mockito.mock(ResultSet.class);
+        when(resultSet.getMetaData()).thenReturn(metaData);
+        when(resultSet.getTimestamp(eq(0), eq(DBUtils.PURE_GREGORIAN_CALENDAR)))
+                .thenReturn(Timestamp.from(offsetDateTime.toInstant()));
+
+        Schema.Field field1 = Schema.Field.of("field1", Schema.of(Schema.LogicalType.DATETIME));
+        Schema schema = Schema.recordOf(
+                "dbRecord",
+                field1
+        );
+        StructuredRecord.Builder builder = StructuredRecord.builder(schema);
+
+        PostgresDBRecord dbRecord = new PostgresDBRecord(null, null, null, null);
+        dbRecord.handleField(resultSet, builder, field1, 0, Types.TIMESTAMP, 0, 0);
+        StructuredRecord record = builder.build();
+        Assert.assertNotNull(record);
+        Assert.assertNotNull(record.getDateTime("field1"));
+        Assert.assertEquals(record.getDateTime("field1").toInstant(ZoneOffset.UTC), offsetDateTime.toInstant());
+
+        // Validate backward compatibility
+
+        field1 = Schema.Field.of("field1", Schema.of(Schema.LogicalType.TIMESTAMP_MICROS));
+        schema = Schema.recordOf(
+            "dbRecord",
+            field1
+        );
+        builder = StructuredRecord.builder(schema);
+        dbRecord.handleField(resultSet, builder, field1, 0, Types.TIMESTAMP, 0, 0);
+        record = builder.build();
+        Assert.assertNotNull(record);
+        Assert.assertNotNull(record.getTimestamp("field1"));
+        Assert.assertEquals(record.getTimestamp("field1").toInstant(), offsetDateTime.toInstant());
+    }
+
+    @Test
+    public void validateTimestampTZType() throws SQLException {
+        OffsetDateTime offsetDateTime = OffsetDateTime.of(2023, 1, 1, 1, 0, 0, 0, ZoneOffset.UTC);
+        ResultSetMetaData metaData = Mockito.mock(ResultSetMetaData.class);
+        when(metaData.getColumnTypeName(eq(0))).thenReturn("timestamptz");
+
+        ResultSet resultSet = Mockito.mock(ResultSet.class);
+        when(resultSet.getMetaData()).thenReturn(metaData);
+        when(resultSet.getObject(eq(0), eq(OffsetDateTime.class))).thenReturn(offsetDateTime);
+
+        Schema.Field field1 = Schema.Field.of("field1", Schema.of(Schema.LogicalType.TIMESTAMP_MICROS));
+        Schema schema = Schema.recordOf(
+                "dbRecord",
+                field1
+        );
+        StructuredRecord.Builder builder = StructuredRecord.builder(schema);
+
+        PostgresDBRecord dbRecord = new PostgresDBRecord(null, null, null, null);
+        dbRecord.handleField(resultSet, builder, field1, 0, Types.TIMESTAMP, 0, 0);
+        StructuredRecord record = builder.build();
+        Assert.assertNotNull(record);
+        Assert.assertNotNull(record.getTimestamp("field1", ZoneId.of("UTC")));
+        Assert.assertEquals(record.getTimestamp("field1", ZoneId.of("UTC")).toInstant(), offsetDateTime.toInstant());
+    }
+}


### PR DESCRIPTION
Related JIRA :
https://cdap.atlassian.net/browse/PLUGIN-1518
https://cdap.atlassian.net/browse/PLUGIN-1526

Postgres Timestamp type does not have a timezone information. Current handling creates an offset in the Sink plugin. Hence converting the handling of the PostgreSQL Timestamp type into Datetime type ensuring backward compatibility with the Timestamp type.