### PR TITLE
Added documentation for unsupported datatypes in SQL Server

### DIFF
--- a/mssql-plugin/docs/SqlServer-batchsource.md
+++ b/mssql-plugin/docs/SqlServer-batchsource.md
@@ -144,6 +144,10 @@ Data Types Mapping
     | SQLVARIANT       | string                 |                                                                |
     | GEOMETRY         | bytes                  |                                                                |
     | GEOGRAPHY        | bytes                  |                                                                |
+    | CURSOR           | unsupported            |                                                                |
+    | ROWVERSION       | unsupported            |                                                                |
+    | SQL_VARIANT      | unsupported            |                                                                |
+    | TABLE            | unsupported            |                                                                |
 
 
 Example


### PR DESCRIPTION
Added documentation for datatypes not supported by SQL server: cursor, rowversion, sql_variant, table