### PR TITLE
Fixed smalldatetime and datetimeoffset datatypes handling

### DIFF
--- a/mssql-plugin/src/e2e-test/java/io.cdap.plugin/MssqlClient.java
+++ b/mssql-plugin/src/e2e-test/java/io.cdap.plugin/MssqlClient.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin;
 
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.e2e.utils.PluginPropertyUtils;
 import org.junit.Assert;
 
@@ -29,6 +30,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -227,7 +229,7 @@ public class MssqlClient {
                 String columnTypeName = mdSource.getColumnTypeName(currentColumnCount);
                 int columnType = mdSource.getColumnType(currentColumnCount);
                 String columnName = mdSource.getColumnName(currentColumnCount);
-                if (columnType == Types.TIMESTAMP) {
+                if (columnType == Types.TIMESTAMP || columnTypeName.equalsIgnoreCase("datetimeoffset")) {
                     GregorianCalendar gc = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
                     gc.setGregorianChange(new Date(Long.MIN_VALUE));
                     Timestamp sourceTS = rsSource.getTimestamp(currentColumnCount, gc);

--- a/mssql-plugin/src/e2e-test/resources/pluginParameters.properties
+++ b/mssql-plugin/src/e2e-test/resources/pluginParameters.properties
@@ -1,5 +1,5 @@
 driverName=sqlserver
-databaseName=temp1
+databaseName=cdftest
 sourceRef=source
 targetRef=target
 host=MSSQL_HOST
@@ -40,8 +40,9 @@ uniqueIdentifierColumnsList=(ID, COL1)
 uniqueIdentifierValues=VALUES ('User1', '6F9619FF-8B86-D011-B42D-00C04FC964FF')
 outputDatatypesSchema3=[{"key":"ID","value":"string"},{"key":"COL1","value":"string"}]
 
-dateTimeColumns=(ID VARCHAR(100) PRIMARY KEY, COL1 DATETIME, COL2 DATETIME2(0))
-dateTimeColumnsList=(ID, COL1, COL2)
-dateTimeValues=VALUES ('User1', '2023-01-01 01:00:00.000', '2023-01-01 01:00:00.000')
+dateTimeColumns=(ID VARCHAR(100) PRIMARY KEY, COL1 DATETIME, COL2 DATETIME2(0), COL3 SMALLDATETIME, COL4 DATETIMEOFFSET)
+dateTimeColumnsList=(ID, COL1, COL2, COL3, COL4)
+dateTimeValues=VALUES ('User1', '2023-01-01 01:00:00.000', '2023-01-01 01:00:00.000', '2023-01-01 01:00:00.000', \
+  '2025-12-10 12:32:10.000 +01:00')
 outputDatatypesSchema4=[{"key":"ID","value":"string"},{"key":"COL1","value":"datetime"},\
-  {"key":"COL2","value":"datetime"}]
+  {"key":"COL2","value":"datetime"},{"key":"COL3","value":"datetime"}, {"key":"COL4","value":"timestamp"}]

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlFieldsValidator.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlFieldsValidator.java
@@ -41,11 +41,17 @@ public class SqlFieldsValidator extends CommonFieldsValidator {
     // Handles datetime datatypes
     // Case when Timestamp maps to datetime
     // Case when Datetime2 maps to datetime
-    // Case when DatetimeOffset maps to datetime
     if ((sqlType == Types.TIMESTAMP || sqlType == SqlServerSourceSchemaReader.DATETIME_OFFSET_TYPE)
-            && fieldLogicalType.equals(Schema.LogicalType.DATETIME)) {
+      && fieldLogicalType.equals(Schema.LogicalType.DATETIME)) {
       return true;
     }
+
+    // Case when datetimeoffset maps to timestamp
+    if (sqlType == SqlServerSourceSchemaReader.DATETIME_OFFSET_TYPE &&
+      fieldLogicalType.equals(Schema.LogicalType.TIMESTAMP_MICROS)) {
+      return true;
+    }
+
     // Handle logical types first
     if (fieldLogicalType != null) {
       return super.isFieldCompatible(fieldType, fieldLogicalType, sqlType, precision, isSigned);
@@ -57,7 +63,8 @@ public class SqlFieldsValidator extends CommonFieldsValidator {
           || sqlType == SqlServerSinkSchemaReader.GEOMETRY_TYPE
           || super.isFieldCompatible(field, metadata, index);
       case STRING:
-        return sqlType == SqlServerSinkSchemaReader.DATETIME_OFFSET_TYPE
+        return
+          sqlType == SqlServerSinkSchemaReader.DATETIME_OFFSET_TYPE
           // Value of GEOMETRY and GEOGRAPHY type can be set as Well Known Text string such as "POINT(3 40 5 6)"
           || sqlType == SqlServerSinkSchemaReader.GEOGRAPHY_TYPE
           || sqlType == SqlServerSinkSchemaReader.GEOMETRY_TYPE

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerConnector.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerConnector.java
@@ -149,16 +149,4 @@ public class SqlServerConnector extends AbstractDBSpecificConnector<SqlServerSou
                          limit, sessionID, limit, strata);
   }
 
-  @Override
-  protected Schema getSchema(int sqlType, String typeName, int scale, int precision, String columnName,
-                             boolean isSigned, boolean handleAsDecimal) throws SQLException {
-    if (SqlServerSourceSchemaReader.shouldConvertToDatetime(typeName)) {
-      return Schema.of(Schema.LogicalType.DATETIME);
-    }
-
-    if (SqlServerSourceSchemaReader.GEOMETRY_TYPE == sqlType || SqlServerSourceSchemaReader.GEOGRAPHY_TYPE == sqlType) {
-      return Schema.of(Schema.Type.BYTES);
-    }
-    return super.getSchema(sqlType, typeName, scale, precision, columnName, isSigned, handleAsDecimal);
-  }
 }


### PR DESCRIPTION
- Current handling incorrectly maps SmallDateTime datatype to timestamp in the sink side as it does not have any time zone information. Fixed it to map to datetime.
- DateTimeOffset was incorrectly mapped to datetime in the sink side. Fixed it to map to timestamp. Example: A DateTimeOffset value of '2025-12-10 12:32:10 +01:00' is transferred as '2025-12-10 11:32:10 +00:00' to the sink side.