### PR TITLE
PLUGIN-1640: add support for using different ports in cloud sql proxy VM

### DIFF
--- a/cloudsql-mysql-plugin/docs/CloudSQLMySQL-action.md
+++ b/cloudsql-mysql-plugin/docs/CloudSQLMySQL-action.md
@@ -23,6 +23,8 @@ Properties
 **Connection Name:** The CloudSQL instance to connect to in the format <PROJECT_ID>:\<REGION>:<INSTANCE_NAME>. 
 Can be found in the instance overview page.
 
+**Port:** Port that MySQL is running on.
+
 **CloudSQL Instance Type:** Whether the CloudSQL instance to connect to is private or public. Defaults to 'Public'.
 
 **Username:** User identity for connecting to the specified database.

--- a/cloudsql-mysql-plugin/docs/CloudSQLMySQL-batchsink.md
+++ b/cloudsql-mysql-plugin/docs/CloudSQLMySQL-batchsink.md
@@ -32,6 +32,8 @@ You also can use the macro function ${conn(connection-name)}.
 **Connection Name:** The CloudSQL instance to connect to in the format <PROJECT_ID>:\<REGION>:<INSTANCE_NAME>. 
 Can be found in the instance overview page.
 
+**Port:** Port that MySQL is running on.
+
 **CloudSQL Instance Type:** Whether the CloudSQL instance to connect to is private or public. Defaults to 'Public'.
 
 **Table Name:** Name of the table to export to. Table must exist prior to running the pipeline.

--- a/cloudsql-mysql-plugin/docs/CloudSQLMySQL-batchsource.md
+++ b/cloudsql-mysql-plugin/docs/CloudSQLMySQL-batchsource.md
@@ -31,6 +31,8 @@ You also can use the macro function ${conn(connection-name)}.
 **Connection Name:** The CloudSQL instance to connect to in the format <PROJECT_ID>:\<REGION>:<INSTANCE_NAME>.
 Can be found in the instance overview page.
 
+**Port:** Port that MySQL is running on.
+
 **CloudSQL Instance Type:** Whether the CloudSQL instance to connect to is private or public. Defaults to 'Public'.
 
 **Import Query:** The SELECT query to use to import data from the specified table.

--- a/cloudsql-mysql-plugin/docs/CloudSQLMySQL-connector.md
+++ b/cloudsql-mysql-plugin/docs/CloudSQLMySQL-connector.md
@@ -18,6 +18,8 @@ Properties
 **Connection Name:** The CloudSQL instance to connect to in the format <PROJECT_ID>:\<REGION>:<INSTANCE_NAME>.
 Can be found in the instance overview page.
 
+**Port:** Port that MySQL is running on.
+
 **Database:** MySQL database name.
 
 **Username:** User identity for connecting to the specified database. Required for databases that need

--- a/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLAction.java
+++ b/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLAction.java
@@ -18,11 +18,13 @@ package io.cdap.plugin.cloudsql.mysql;
 
 import com.google.common.collect.ImmutableMap;
 import io.cdap.cdap.api.annotation.Description;
+import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.action.Action;
+import io.cdap.plugin.db.ConnectionConfig;
 import io.cdap.plugin.db.action.AbstractDBAction;
 import io.cdap.plugin.db.action.QueryConfig;
 import io.cdap.plugin.util.CloudSQLUtil;
@@ -48,11 +50,13 @@ public class CloudSQLMySQLAction extends AbstractDBAction {
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     FailureCollector failureCollector = pipelineConfigurer.getStageConfigurer().getFailureCollector();
-    
-    CloudSQLUtil.checkConnectionName(
-        failureCollector,
-        cloudsqlMysqlActionConfig.instanceType,
-        cloudsqlMysqlActionConfig.connectionName);
+
+    if (cloudsqlMysqlActionConfig.canConnect()) {
+      CloudSQLUtil.checkConnectionName(
+          failureCollector,
+          cloudsqlMysqlActionConfig.instanceType,
+          cloudsqlMysqlActionConfig.connectionName);
+    }
     
     super.configurePipeline(pipelineConfigurer);
   }
@@ -69,10 +73,18 @@ public class CloudSQLMySQLAction extends AbstractDBAction {
         "The CloudSQL instance to connect to. For a public instance, the connection string should be in the format "
             + "<PROJECT_ID>:<REGION>:<INSTANCE_NAME> which can be found in the instance overview page. For a private "
             + "instance, enter the internal IP address of the Compute Engine VM cloudsql proxy is running on.")
+    @Macro
     public String connectionName;
+
+    @Name(ConnectionConfig.PORT)
+    @Description("Database port number")
+    @Macro
+    @Nullable
+    private Integer port;
 
     @Name(DATABASE)
     @Description("Database name to connect to")
+    @Macro
     public String database;
 
     @Name(CloudSQLMySQLConstants.CONNECTION_TIMEOUT)
@@ -94,6 +106,7 @@ public class CloudSQLMySQLAction extends AbstractDBAction {
         return String.format(
             CloudSQLMySQLConstants.PRIVATE_CLOUDSQL_MYSQL_CONNECTION_STRING_FORMAT,
             connectionName,
+            getPort(),
             database);
       }
       
@@ -103,10 +116,19 @@ public class CloudSQLMySQLAction extends AbstractDBAction {
           connectionName);
     }
 
+    public int getPort() {
+      return port == null ? 3306 : port;
+    }
+
     @Override
     public Map<String, String> getDBSpecificArguments() {
       return ImmutableMap.of(
           CloudSQLMySQLConstants.CONNECTION_TIMEOUT, String.valueOf(connectionTimeout));
+    }
+
+    public boolean canConnect() {
+      return !containsMacro(CloudSQLUtil.CONNECTION_NAME) && !containsMacro(ConnectionConfig.PORT) &&
+          !containsMacro(DATABASE);
     }
   }
 }

--- a/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLConstants.java
+++ b/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLConstants.java
@@ -26,5 +26,5 @@ public final class CloudSQLMySQLConstants {
   public static final String CONNECTION_TIMEOUT = "connectionTimeout";
   public static final String PUBLIC_CLOUDSQL_MYSQL_CONNECTION_STRING_FORMAT =
       "jdbc:mysql:///%s?cloudSqlInstance=%s&socketFactory=com.google.cloud.sql.mysql.SocketFactory";
-  public static final String PRIVATE_CLOUDSQL_MYSQL_CONNECTION_STRING_FORMAT = "jdbc:mysql://%s/%s";
+  public static final String PRIVATE_CLOUDSQL_MYSQL_CONNECTION_STRING_FORMAT = "jdbc:mysql://%s:%s/%s";
 }

--- a/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLSink.java
+++ b/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLSink.java
@@ -91,7 +91,8 @@ public class CloudSQLMySQLSink extends AbstractDBSink<CloudSQLMySQLSink.CloudSQL
       host = connectionParams[2];
       location = connectionParams[1];
     }
-    String fqn = DBUtils.constructFQN("mysql", host, 3306,
+    String fqn = DBUtils.constructFQN("mysql", host,
+                                      cloudsqlMysqlSinkConfig.getConnection().getPort(),
                                       cloudsqlMysqlSinkConfig.getConnection().getDatabase(),
                                       cloudsqlMysqlSinkConfig.getReferenceName());
     Asset.Builder assetBuilder = Asset.builder(cloudsqlMysqlSinkConfig.getReferenceName()).setFqn(fqn);

--- a/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLSource.java
+++ b/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLSource.java
@@ -86,6 +86,7 @@ public class CloudSQLMySQLSource extends AbstractDBSource<CloudSQLMySQLSource.Cl
       return String.format(
           CloudSQLMySQLConstants.PRIVATE_CLOUDSQL_MYSQL_CONNECTION_STRING_FORMAT,
           cloudsqlMysqlSourceConfig.connection.getConnectionName(),
+          cloudsqlMysqlSourceConfig.connection.getPort(),
           cloudsqlMysqlSourceConfig.connection.getDatabase());
     }
 
@@ -108,7 +109,8 @@ public class CloudSQLMySQLSource extends AbstractDBSource<CloudSQLMySQLSource.Cl
       host = connectionParams[2];
       location = connectionParams[1];
     }
-    String fqn = DBUtils.constructFQN("mysql", host, 3306,
+    String fqn = DBUtils.constructFQN("mysql", host,
+                                      cloudsqlMysqlSourceConfig.getConnection().getPort(),
                                       cloudsqlMysqlSourceConfig.getConnection().getDatabase(),
                                       cloudsqlMysqlSourceConfig.getReferenceName());
     Asset.Builder assetBuilder = Asset.builder(cloudsqlMysqlSourceConfig.getReferenceName()).setFqn(fqn);

--- a/cloudsql-mysql-plugin/src/test/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLConnectorTest.java
+++ b/cloudsql-mysql-plugin/src/test/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLConnectorTest.java
@@ -54,7 +54,7 @@ public class CloudSQLMySQLConnectorTest extends DBSpecificConnectorBaseTest {
     test(
       new CloudSQLMySQLConnector(
         new CloudSQLMySQLConnectorConfig(username, password, JDBC_PLUGIN_NAME, connectionArguments, instanceType,
-                                         connectionName, database)
+                                         connectionName, database, null)
       ),
       JDBC_DRIVER_CLASS_NAME,
       CloudSQLMySQLConstants.PLUGIN_NAME

--- a/cloudsql-mysql-plugin/widgets/CloudSQLMySQL-action.json
+++ b/cloudsql-mysql-plugin/widgets/CloudSQLMySQL-action.json
@@ -74,11 +74,11 @@
           }
         },
         {
-          "widget-type": "textbox",
-          "label": "Instance Name",
-          "name": "instanceName",
+          "widget-type": "number",
+          "label": "Port",
+          "name": "port",
           "widget-attributes": {
-            "placeholder": "CloudSQL instance connection name"
+            "default": "3306"
           }
         },
         {
@@ -110,6 +110,20 @@
             "kv-delimiter": "=",
             "delimiter": ";"
           }
+        }
+      ]
+    }
+  ],
+  "filters": [
+    {
+      "name": "showPrivateInstanceProperties ",
+      "condition": {
+        "expression": "instanceType == 'private'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "port"
         }
       ]
     }

--- a/cloudsql-mysql-plugin/widgets/CloudSQLMySQL-batchsink.json
+++ b/cloudsql-mysql-plugin/widgets/CloudSQLMySQL-batchsink.json
@@ -67,6 +67,14 @@
           }
         },
         {
+          "widget-type": "number",
+          "label": "Port",
+          "name": "port",
+          "widget-attributes": {
+            "default": "3306"
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Username",
           "name": "user"
@@ -212,6 +220,18 @@
         {
           "type": "property",
           "name": "connection"
+        }
+      ]
+    },
+    {
+      "name": "showPrivateInstanceProperties ",
+      "condition": {
+        "expression": "instanceType == 'private'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "port"
         }
       ]
     }

--- a/cloudsql-mysql-plugin/widgets/CloudSQLMySQL-batchsource.json
+++ b/cloudsql-mysql-plugin/widgets/CloudSQLMySQL-batchsource.json
@@ -67,6 +67,14 @@
           }
         },
         {
+          "widget-type": "number",
+          "label": "Port",
+          "name": "port",
+          "widget-attributes": {
+            "default": "3306"
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Username",
           "name": "user"
@@ -229,6 +237,18 @@
         {
           "type": "property",
           "name": "connection"
+        }
+      ]
+    },
+    {
+      "name": "showPrivateInstanceProperties ",
+      "condition": {
+        "expression": "instanceType == 'private'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "port"
         }
       ]
     }

--- a/cloudsql-mysql-plugin/widgets/CloudSQLMySQL-connector.json
+++ b/cloudsql-mysql-plugin/widgets/CloudSQLMySQL-connector.json
@@ -46,6 +46,14 @@
           "widget-attributes": {
             "placeholder": "CloudSQL instance connection name"
           }
+        },
+        {
+          "widget-type": "number",
+          "label": "Port",
+          "name": "port",
+          "widget-attributes": {
+            "default": "3306"
+          }
         }
       ]
     },
@@ -88,5 +96,19 @@
       ]
     }
   ],
-  "outputs": []
+  "outputs": [],
+  "filters": [
+    {
+      "name": "showPrivateInstanceProperties ",
+      "condition": {
+        "expression": "instanceType == 'private'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "port"
+        }
+      ]
+    }
+  ]
 }

--- a/cloudsql-postgresql-plugin/docs/CloudSQLPostgreSQL-action.md
+++ b/cloudsql-postgresql-plugin/docs/CloudSQLPostgreSQL-action.md
@@ -23,6 +23,8 @@ Properties
 **Connection Name:** The CloudSQL instance to connect to in the format <PROJECT_ID>:\<REGION>:<INSTANCE_NAME>. 
 Can be found in the instance overview page.
 
+**Port:** Port that PostgreSQL is running on.
+
 **CloudSQL Instance Type:** Whether the CloudSQL instance to connect to is private or public. Defaults to 'Public'.
 
 **Username:** User identity for connecting to the specified database.

--- a/cloudsql-postgresql-plugin/docs/CloudSQLPostgreSQL-batchsink.md
+++ b/cloudsql-postgresql-plugin/docs/CloudSQLPostgreSQL-batchsink.md
@@ -32,6 +32,8 @@ You also can use the macro function ${conn(connection-name)}.
 **Connection Name:** The CloudSQL instance to connect to in the format <PROJECT_ID>:\<REGION>:<INSTANCE_NAME>.
 Can be found in the instance overview page.
 
+**Port:** Port that PostgreSQL is running on.
+
 **CloudSQL Instance Type:** Whether the CloudSQL instance to connect to is private or public. Defaults to 'Public'.
 
 **Table Name:** Name of the table to export to.

--- a/cloudsql-postgresql-plugin/docs/CloudSQLPostgreSQL-batchsource.md
+++ b/cloudsql-postgresql-plugin/docs/CloudSQLPostgreSQL-batchsource.md
@@ -31,6 +31,8 @@ You also can use the macro function ${conn(connection-name)}.
 **Connection Name:** The CloudSQL instance to connect to in the format <PROJECT_ID>:\<REGION>:<INSTANCE_NAME>.
 Can be found in the instance overview page.
 
+**Port:** Port that PostgreSQL is running on.
+
 **CloudSQL Instance Type:** Whether the CloudSQL instance to connect to is private or public. Defaults to 'Public'.
 
 **Import Query:** The SELECT query to use to import data from the specified table.

--- a/cloudsql-postgresql-plugin/docs/CloudSQLPostgreSQL-connector.md
+++ b/cloudsql-postgresql-plugin/docs/CloudSQLPostgreSQL-connector.md
@@ -18,6 +18,8 @@ Properties
 **Connection Name:** The CloudSQL instance to connect to in the format <PROJECT_ID>:\<REGION>:<INSTANCE_NAME>.
 Can be found in the instance overview page.
 
+**Port:** Port that PostgreSQL is running on.
+
 **Database:** CloudSQL PostgreSQL database name.
 
 **Username:** User identity for connecting to the specified database. Required for databases that need

--- a/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLConstants.java
+++ b/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLConstants.java
@@ -26,5 +26,5 @@ public final class CloudSQLPostgreSQLConstants {
   public static final String CONNECTION_TIMEOUT = "connectionTimeout";
   public static final String PUBLIC_CLOUDSQL_POSTGRES_CONNECTION_STRING_FORMAT =
       "jdbc:postgresql:///%s?cloudSqlInstance=%s&socketFactory=com.google.cloud.sql.postgres.SocketFactory";
-  public static final String PRIVATE_CLOUDSQL_POSTGRES_CONNECTION_STRING_FORMAT = "jdbc:postgresql://%s/%s";
+  public static final String PRIVATE_CLOUDSQL_POSTGRES_CONNECTION_STRING_FORMAT = "jdbc:postgresql://%s:%s/%s";
 }

--- a/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLSink.java
+++ b/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLSink.java
@@ -136,7 +136,8 @@ public class CloudSQLPostgreSQLSink extends AbstractDBSink<CloudSQLPostgreSQLSin
       host = connectionParams[2];
       location = connectionParams[1];
     }
-    String fqn = DBUtils.constructFQN("postgres", host, 5432,
+    String fqn = DBUtils.constructFQN("postgres", host,
+                                      cloudsqlPostgresqlSinkConfig.getConnection().getPort(),
                                       cloudsqlPostgresqlSinkConfig.getConnection().getDatabase(),
                                       cloudsqlPostgresqlSinkConfig.getReferenceName());
     Asset.Builder assetBuilder = Asset.builder(cloudsqlPostgresqlSinkConfig.getReferenceName()).setFqn(fqn);

--- a/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLSource.java
+++ b/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLSource.java
@@ -93,6 +93,7 @@ public class CloudSQLPostgreSQLSource
       return String.format(
           CloudSQLPostgreSQLConstants.PRIVATE_CLOUDSQL_POSTGRES_CONNECTION_STRING_FORMAT,
           cloudsqlPostgresqlSourceConfig.connection.getConnectionName(),
+          cloudsqlPostgresqlSourceConfig.connection.getPort(),
           cloudsqlPostgresqlSourceConfig.connection.getDatabase());
     }
 
@@ -116,7 +117,8 @@ public class CloudSQLPostgreSQLSource
       host = connectionParams[2];
       location = connectionParams[1];
     }
-    String fqn = DBUtils.constructFQN("postgres", host, 5432,
+    String fqn = DBUtils.constructFQN("postgres", host,
+                                      cloudsqlPostgresqlSourceConfig.getConnection().getPort(),
                                       cloudsqlPostgresqlSourceConfig.getConnection().getDatabase(),
                                       cloudsqlPostgresqlSourceConfig.getReferenceName());
     Asset.Builder assetBuilder = Asset.builder(cloudsqlPostgresqlSourceConfig.getReferenceName()).setFqn(fqn);

--- a/cloudsql-postgresql-plugin/src/test/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLConnectorTest.java
+++ b/cloudsql-postgresql-plugin/src/test/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLConnectorTest.java
@@ -54,7 +54,7 @@ public class CloudSQLPostgreSQLConnectorTest extends DBSpecificConnectorBaseTest
     test(
       new CloudSQLPostgreSQLConnector(
         new CloudSQLPostgreSQLConnectorConfig(username, password, JDBC_PLUGIN_NAME, connectionArguments, instanceType,
-                                              connectionName, database)
+                                              connectionName, database, null)
       ),
       JDBC_DRIVER_CLASS_NAME,
       CloudSQLPostgreSQLConstants.PLUGIN_NAME

--- a/cloudsql-postgresql-plugin/widgets/CloudSQLPostgreSQL-action.json
+++ b/cloudsql-postgresql-plugin/widgets/CloudSQLPostgreSQL-action.json
@@ -74,6 +74,14 @@
           }
         },
         {
+          "widget-type": "number",
+          "label": "Port",
+          "name": "port",
+          "widget-attributes": {
+            "default": "5432"
+          }
+        },
+        {
           "widget-type": "textarea",
           "label": "Database Command",
           "name": "query"
@@ -102,6 +110,20 @@
             "kv-delimiter": "=",
             "delimiter": ";"
           }
+        }
+      ]
+    }
+  ],
+  "filters": [
+    {
+      "name": "showPrivateInstanceProperties ",
+      "condition": {
+        "expression": "instanceType == 'private'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "port"
         }
       ]
     }

--- a/cloudsql-postgresql-plugin/widgets/CloudSQLPostgreSQL-batchsink.json
+++ b/cloudsql-postgresql-plugin/widgets/CloudSQLPostgreSQL-batchsink.json
@@ -67,6 +67,14 @@
           }
         },
         {
+          "widget-type": "number",
+          "label": "Port",
+          "name": "port",
+          "widget-attributes": {
+            "default": "5432"
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Username",
           "name": "user"
@@ -233,6 +241,18 @@
         {
           "type": "property",
           "name": "connection"
+        }
+      ]
+    },
+    {
+      "name": "showPrivateInstanceProperties ",
+      "condition": {
+        "expression": "instanceType == 'private'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "port"
         }
       ]
     }

--- a/cloudsql-postgresql-plugin/widgets/CloudSQLPostgreSQL-batchsource.json
+++ b/cloudsql-postgresql-plugin/widgets/CloudSQLPostgreSQL-batchsource.json
@@ -67,6 +67,14 @@
           }
         },
         {
+          "widget-type": "number",
+          "label": "Port",
+          "name": "port",
+          "widget-attributes": {
+            "default": "5432"
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Username",
           "name": "user"
@@ -233,6 +241,18 @@
         {
           "type": "property",
           "name": "connection"
+        }
+      ]
+    },
+    {
+      "name": "showPrivateInstanceProperties ",
+      "condition": {
+        "expression": "instanceType == 'private'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "port"
         }
       ]
     }

--- a/cloudsql-postgresql-plugin/widgets/CloudSQLPostgreSQL-connector.json
+++ b/cloudsql-postgresql-plugin/widgets/CloudSQLPostgreSQL-connector.json
@@ -46,6 +46,14 @@
           "widget-attributes": {
             "placeholder": "CloudSQL instance connection name"
           }
+        },
+        {
+          "widget-type": "number",
+          "label": "Port",
+          "name": "port",
+          "widget-attributes": {
+            "default": "5432"
+          }
         }
       ]
     },
@@ -88,5 +96,19 @@
       ]
     }
   ],
-  "outputs": []
+  "outputs": [],
+  "filters": [
+    {
+      "name": "showPrivateInstanceProperties ",
+      "condition": {
+        "expression": "instanceType == 'private'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "port"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Why:
- The Cloud SQL Auth Proxy can listen on different ports except the default port when using private IP to connect to the Cloud SQL instance.

Tested in CDAP Sandbox.