### PR TITLE
PLUGIN-1654

### DIFF
--- a/database-commons/src/main/java/io/cdap/plugin/db/sink/ETLDBOutputFormat.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/sink/ETLDBOutputFormat.java
@@ -97,8 +97,8 @@ public class ETLDBOutputFormat<K extends DBWritable, V> extends DBOutputFormat<K
           try {
             if (!emptyData) {
               getStatement().executeBatch();
-              getConnection().commit();
             }
+            getConnection().commit();
           } catch (SQLException e) {
             try {
               getConnection().rollback();
@@ -135,6 +135,7 @@ public class ETLDBOutputFormat<K extends DBWritable, V> extends DBOutputFormat<K
             // This is done to reduce memory usage in the worker, as processed records can now be GC'd.
             if (batchSize > 0 && numWrittenRecords % batchSize == 0) {
               getStatement().executeBatch();
+              emptyData = true;
             }
           } catch (SQLException e) {
             throw new IOException(e);


### PR DESCRIPTION
**BugFix**
Issue summary: Customer has a pipeline that is trying to load a table from bigquery into a netezza database that is failing.
This pipeline has exactly 52000 records and will not load, nor will it provide any usable error message.
1. When customer loads half the table first, then the second half later, it works.
2. When customer loads 51999 records, it works.
3. When customer loads 52001 (added a null record), it works.
4. But the load for 52000 does not work.
CDAP : https://cdap.atlassian.net/browse/PLUGIN-1654

Solution: 
Added proper handling for empty data flag. In case of empty data, batch will not be executed in close method.