### PR TITLE
pom changes for postgres as build was failing due to version mismatch

### DIFF
--- a/cloudsql-postgresql-plugin/pom.xml
+++ b/cloudsql-postgresql-plugin/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>io.cdap.plugin</groupId>
       <artifactId>postgresql-plugin</artifactId>
-      <version>1.7.0</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>


### PR DESCRIPTION
pom changes for postgres as build was failing due to version mismatch.
Version was given as 1.7.0 while it should be current project version