### PR TITLE
 [PLUGIN-1680] numeric_precision_fix

### DIFF
--- a/database-commons/src/main/java/io/cdap/plugin/db/DBRecord.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/DBRecord.java
@@ -218,7 +218,7 @@ public class DBRecord implements Writable, DBWritable, Configurable {
     }
   }
 
-  private Schema getNonNullableSchema(Schema.Field field) {
+  protected Schema getNonNullableSchema(Schema.Field field) {
     Schema schema = field.getSchema();
     if (field.getSchema().isNullable()) {
       schema = field.getSchema().getNonNullable();

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresDBRecord.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresDBRecord.java
@@ -106,6 +106,7 @@ public class PostgresDBRecord extends DBRecord {
   protected void writeToDB(PreparedStatement stmt, Schema.Field field, int fieldIndex) throws SQLException {
     int sqlIndex = fieldIndex + 1;
     ColumnType columnType = columnTypes.get(fieldIndex);
+    Schema fieldSchema = getNonNullableSchema(field);
     if (PostgresSchemaReader.STRING_MAPPED_POSTGRES_TYPES_NAMES.contains(columnType.getTypeName()) ||
       PostgresSchemaReader.STRING_MAPPED_POSTGRES_TYPES.contains(columnType.getType())) {
       stmt.setObject(sqlIndex, createPGobject(columnType.getTypeName(),
@@ -114,7 +115,7 @@ public class PostgresDBRecord extends DBRecord {
       return;
     }
     if (columnType.getType() == Types.NUMERIC && record.get(field.getName()) != null &&
-      field.getSchema().getType() == Schema.Type.STRING) {
+      fieldSchema.getType() == Schema.Type.STRING) {
       stmt.setBigDecimal(sqlIndex, new BigDecimal((String) record.get(field.getName())));
       return;
     }


### PR DESCRIPTION
The mapping of source to sink should happen in case of numeric data type in which it is being converted to string in case of 0 precision. Previously it was fetching nullable schema and schema type was getting as Union in place of string. Now it is fetching nonNullable schema with the expected data type and schema is mapped from source to sink.
https://cdap.atlassian.net/browse/PLUGIN-1680