### PR TITLE
[PLUGIN-1728]Fix for connection arguments not getting updated.

### DIFF
--- a/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLConnectorConfig.java
+++ b/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLConnectorConfig.java
@@ -105,14 +105,14 @@ public class CloudSQLMySQLConnectorConfig extends AbstractDBConnectorConfig {
   @Override
   public Properties getConnectionArgumentsProperties() {
     Properties properties = super.getConnectionArgumentsProperties();
-    properties.put(JDBC_PROPERTY_CONNECT_TIMEOUT_MILLIS, "20000");
-    properties.put(JDBC_PROPERTY_SOCKET_TIMEOUT_MILLIS, "20000");
+    properties.putIfAbsent(JDBC_PROPERTY_CONNECT_TIMEOUT_MILLIS, "20000");
+    properties.putIfAbsent(JDBC_PROPERTY_SOCKET_TIMEOUT_MILLIS, "20000");
     return properties;
   }
 
   @Override
   public boolean canConnect() {
     return super.canConnect() && !containsMacro(CloudSQLUtil.CONNECTION_NAME) &&
-        !containsMacro(ConnectionConfig.PORT) && !containsMacro(ConnectionConfig.DATABASE);
+      !containsMacro(ConnectionConfig.PORT) && !containsMacro(ConnectionConfig.DATABASE);
   }
 }

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnectorConfig.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlConnectorConfig.java
@@ -57,9 +57,9 @@ public class MysqlConnectorConfig extends AbstractDBSpecificConnectorConfig {
   public Properties getConnectionArgumentsProperties() {
     Properties prop = super.getConnectionArgumentsProperties();
     // the unit below is milli-second
-    prop.put(JDBC_PROPERTY_CONNECT_TIMEOUT, "20000");
-    prop.put(JDBC_PROPERTY_SOCKET_TIMEOUT, "20000");
-    prop.put(JDBC_REWRITE_BATCHED_STATEMENTS, "true");
+    prop.putIfAbsent(JDBC_PROPERTY_CONNECT_TIMEOUT, "20000");
+    prop.putIfAbsent(JDBC_PROPERTY_SOCKET_TIMEOUT, "20000");
+    prop.putIfAbsent(JDBC_REWRITE_BATCHED_STATEMENTS, "true");
     // MySQL property to ensure that TINYINT(1) type data is not converted to MySQL Bit/Boolean type in the ResultSet.
     prop.putIfAbsent(MYSQL_TINYINT1_IS_BIT, "false");
     return prop;

--- a/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlFailedConnectionTest.java
+++ b/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlFailedConnectionTest.java
@@ -31,10 +31,26 @@ public class MysqlFailedConnectionTest extends DBSpecificFailedConnectionTest {
       new MysqlConnectorConfig("localhost", 3306, "username", "password", "jdbc", ""));
 
     super.test(JDBC_DRIVER_CLASS_NAME, connector, "Failed to create connection to database via connection string: " +
-                                                    "jdbc:mysql://localhost:3306 and arguments: {user=username, " +
-                                                    "rewriteBatchedStatements=true, "  +
-                                                    "connectTimeout=20000, tinyInt1isBit=false, " +
-                                                    "socketTimeout=20000}. Error: " +
-                                                    "ConnectException: Connection refused (Connection refused).");
+      "jdbc:mysql://localhost:3306 and arguments: {user=username, " +
+      "rewriteBatchedStatements=true, " +
+      "connectTimeout=20000, tinyInt1isBit=false, " +
+      "socketTimeout=20000}. Error: " +
+      "ConnectException: Connection refused (Connection refused).");
   }
+
+  @Test
+  public void testWithUpdatedConnectionArguments() throws ClassNotFoundException, IOException {
+
+    MysqlConnector connector = new MysqlConnector(
+      new MysqlConnectorConfig("localhost", 3306, "username", "password", "jdbc",
+                               "connectTimeout=30000;socketTimeout=30000"));
+
+    super.test(JDBC_DRIVER_CLASS_NAME, connector, "Failed to create connection to database via connection string: " +
+      "jdbc:mysql://localhost:3306 and arguments: {user=username, " +
+      "rewriteBatchedStatements=true, " +
+      "connectTimeout=30000, tinyInt1isBit=false, " +
+      "socketTimeout=30000}. Error: " +
+      "ConnectException: Connection refused (Connection refused).");
+  }
+
 }


### PR DESCRIPTION
https://cdap.atlassian.net/browse/PLUGIN-1728

Problem you have encountered:
When selecting MySQL driver and setting up a connection to DB there is no way to change connectTimeout and
socketTimeout parameters. They are stuck at 20000 ms and specifying connection arguments won't take any effect.

What you expected to happen:
Expect connection arguments to change according to user settings.

Steps to reproduce:

Add MySQL connection in Cloud Data Fusion

Fill all the fields like basic and credentials

Go to advanced part at the bottom of the page and fill connectTimeout and socketTimeout key-value pairs

Change host to not working ( localhost -> localhostt) to get the error code and see the connection string.

connectTimeout and socketTimeout should be 20000 both despite of user input.