### PR TITLE
Enable TLS Support (DTS - Specific)

### DIFF
--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleAction.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleAction.java
@@ -57,7 +57,7 @@ public class OracleAction extends AbstractDBAction {
 
     @Override
     public String getConnectionString() {
-      return OracleConstants.getConnectionString(this.connectionType, host, port, database);
+      return OracleConstants.getConnectionString(this.connectionType, host, port, database, null);
     }
 
     @Override

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
@@ -126,7 +126,7 @@ public class OracleConnector extends AbstractDBSpecificConnector<OracleSourceDBR
       return config.getConnectionString();
     }
     return OracleConstants.getConnectionString(config.getConnectionType(),
-        config.getHost(), config.getPort(), database);
+        config.getHost(), config.getPort(), database, config.getSSlMode());
   }
 
   @Override

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnectorConfig.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnectorConfig.java
@@ -43,12 +43,12 @@ public class OracleConnectorConfig extends AbstractDBSpecificConnectorConfig {
 
   public OracleConnectorConfig(String host, int port, String user, String password, String jdbcPluginName,
                                String connectionArguments, String connectionType, String database) {
-    this(host, port, user, password, jdbcPluginName, connectionArguments, connectionType, database, null);
+    this(host, port, user, password, jdbcPluginName, connectionArguments, connectionType, database, null, null);
   }
 
   public OracleConnectorConfig(String host, int port, String user, String password, String jdbcPluginName,
                                String connectionArguments, String connectionType, String database,
-                               String role) {
+                               String role, Boolean useSSL) {
 
     this.host = host;
     this.port = port;
@@ -59,11 +59,12 @@ public class OracleConnectorConfig extends AbstractDBSpecificConnectorConfig {
     this.connectionType = connectionType;
     this.database = database;
     this.role = role;
+    this.useSSL = useSSL;
   }
 
   @Override
   public String getConnectionString() {
-    return OracleConstants.getConnectionString(connectionType, host, getPort(), database);
+    return OracleConstants.getConnectionString(connectionType, host, getPort(), database, useSSL);
   }
 
   @Name(OracleConstants.CONNECTION_TYPE)
@@ -86,6 +87,11 @@ public class OracleConnectorConfig extends AbstractDBSpecificConnectorConfig {
   @Nullable
   private String transactionIsolationLevel;
 
+  @Name(OracleConstants.USE_SSL)
+  @Description("Turns on SSL encryption. Connection will fail if SSL is not available")
+  @Nullable
+  public Boolean useSSL;
+
   @Override
   protected int getDefaultPort() {
     return 1521;
@@ -101,6 +107,11 @@ public class OracleConnectorConfig extends AbstractDBSpecificConnectorConfig {
 
   public String getDatabase() {
     return database;
+  }
+
+  public Boolean getSSlMode() {
+    // return false if useSSL is null, otherwise return its value
+    return useSSL != null && useSSL;
   }
 
   @Override

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConstants.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConstants.java
@@ -29,6 +29,10 @@ public final class OracleConstants {
   public static final String PLUGIN_NAME = "Oracle";
   public static final String ORACLE_CONNECTION_STRING_SID_FORMAT = "jdbc:oracle:thin:@%s:%s:%s";
   public static final String ORACLE_CONNECTION_STRING_SERVICE_NAME_FORMAT = "jdbc:oracle:thin:@//%s:%s/%s";
+  // Connection formats to accept protocol (e.g., jdbc:oracle:thin:@<protocol>://<host>:<port>/<SID>)
+  public static final String ORACLE_CONNECTION_STRING_SID_FORMAT_WITH_PROTOCOL = "jdbc:oracle:thin:@%s:%s:%s/%s";
+  public static final String ORACLE_CONNECTION_STRING_SERVICE_NAME_FORMAT_WITH_PROTOCOL =
+      "jdbc:oracle:thin:@%s://%s:%s/%s";
   public static final String ORACLE_CONNECTION_STRING_TNS_FORMAT = "jdbc:oracle:thin:@%s";
   public static final String DEFAULT_BATCH_VALUE = "defaultBatchValue";
   public static final String DEFAULT_ROW_PREFETCH = "defaultRowPrefetch";
@@ -36,28 +40,92 @@ public final class OracleConstants {
   public static final String CONNECTION_TYPE = "connectionType";
   public static final String ROLE = "role";
   public static final String NAME_DATABASE = "database";
-  public static final String TNS_CONNECTION_TYPE = "TNS";
+  public static final String TNS_CONNECTION_TYPE = "tns";
   public static final String TRANSACTION_ISOLATION_LEVEL = "transactionIsolationLevel";
+  public static final String USE_SSL = "useSSL";
 
   /**
-   * Returns the Connection String for the given ConnectionType.
+   * Constructs the Oracle connection string based on the provided connection type, host, port, and database.
+   * If SSL is enabled, the connection protocol will be "tcps" instead of "tcp".
    *
    * @param connectionType TNS/Service/SID
    * @param host Host name of the oracle server
    * @param port Port of the oracle server
    * @param database Database to connect to
-   * @return Connection String based on the given ConnectionType
+   * @param useSSL Whether SSL/TLS is required(YES/NO)
+   * @return Connection String based on the given parameters and connection type.
    */
   public static String getConnectionString(String connectionType,
                                            @Nullable String host,
                                            @Nullable int port,
-                                           String database) {
-    if (OracleConstants.TNS_CONNECTION_TYPE.equalsIgnoreCase(connectionType)) {
-      return String.format(OracleConstants.ORACLE_CONNECTION_STRING_TNS_FORMAT, database);
+                                           String database,
+                                           @Nullable Boolean useSSL) {
+    // Use protocol as "tcps" when SSL is requested or else use "tcp".
+    String connectionProtocol;
+    boolean isSSLEnabled = false;
+    if (useSSL != null && useSSL) {
+      connectionProtocol = "tcps";
+      isSSLEnabled = true;
+    } else {
+      connectionProtocol = "tcp";
     }
-    if (OracleConstants.SERVICE_CONNECTION_TYPE.equalsIgnoreCase(connectionType)) {
-      return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SERVICE_NAME_FORMAT,
-          host, port, database);
+
+    switch (connectionType.toLowerCase()) {
+      case OracleConstants.TNS_CONNECTION_TYPE:
+        // TNS connection doesn't require protocol
+        return String.format(OracleConstants.ORACLE_CONNECTION_STRING_TNS_FORMAT, database);
+      case OracleConstants.SERVICE_CONNECTION_TYPE:
+        // Create connection string for SERVICE type.
+        return getConnectionStringWithService(host, port, database, connectionProtocol, isSSLEnabled);
+      default:
+        // Default to SID format if no matching case is found.
+        return getConnectionStringWithSID(host, port, database, connectionProtocol, isSSLEnabled);
+    }
+  }
+
+  /**
+   * Constructs the connection string for a SERVICE connection type.
+   *
+   * @param host Host name of the Oracle server.
+   * @param port Port of the Oracle server.
+   * @param database Database name to connect to.
+   * @param connectionProtocol Protocol to use for the connection ("tcp" or "tcps").
+   * @param isSSLEnabled Indicates if SSL is enabled.
+   * @return Formatted connection string for a SERVICE connection.
+   */
+  private static String getConnectionStringWithService(@Nullable String host,
+                                                       @Nullable int port,
+                                                       String database,
+                                                       String connectionProtocol,
+                                                       boolean isSSLEnabled) {
+    // Choose the appropriate format based on whether SSL is enabled.
+    if (isSSLEnabled) {
+      return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SERVICE_NAME_FORMAT_WITH_PROTOCOL,
+          connectionProtocol, host, port, database);
+    }
+    return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SERVICE_NAME_FORMAT,
+        host, port, database);
+  }
+
+  /**
+   * Constructs the connection string for a SID connection type.
+   *
+   * @param host Host name of the Oracle server.
+   * @param port Port of the Oracle server.
+   * @param database Database name to connect to.
+   * @param connectionProtocol Protocol to use for the connection ("tcp" or "tcps").
+   * @param isSSLEnabled Indicates if SSL is enabled.
+   * @return Formatted connection string for a SID connection.
+   */
+  private static String getConnectionStringWithSID(@Nullable String host,
+                                                   @Nullable int port,
+                                                   String database,
+                                                   String connectionProtocol,
+                                                   boolean isSSLEnabled) {
+    // Choose the appropriate format based on whether SSL is enabled.
+    if (isSSLEnabled) {
+      return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SID_FORMAT_WITH_PROTOCOL,
+          connectionProtocol, host, port, database);
     }
     return String.format(OracleConstants.ORACLE_CONNECTION_STRING_SID_FORMAT,
         host, port, database);

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OraclePostAction.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OraclePostAction.java
@@ -57,7 +57,7 @@ public class OraclePostAction extends AbstractQueryAction {
 
     @Override
     public String getConnectionString() {
-      return OracleConstants.getConnectionString(this.connectionType, host, port, database);
+      return OracleConstants.getConnectionString(this.connectionType, host, port, database, null);
     }
 
     @Override

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSource.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSource.java
@@ -117,9 +117,9 @@ public class OracleSource extends AbstractDBSource<OracleSource.OracleSourceConf
                               String connectionArguments, String connectionType, String database, String role,
                               int defaultBatchValue, int defaultRowPrefetch,
                               String importQuery, Integer numSplits, int fetchSize,
-                              String boundingQuery, String splitBy) {
+                              String boundingQuery, String splitBy, Boolean useSSL) {
       this.connection = new OracleConnectorConfig(host, port, user, password, jdbcPluginName, connectionArguments,
-                                                  connectionType, database, role);
+                                                  connectionType, database, role, useSSL);
       this.defaultBatchValue = defaultBatchValue;
       this.defaultRowPrefetch = defaultRowPrefetch;
       this.fetchSize = fetchSize;
@@ -132,7 +132,7 @@ public class OracleSource extends AbstractDBSource<OracleSource.OracleSourceConf
     @Override
     public String getConnectionString() {
       return OracleConstants.getConnectionString(connection.getConnectionType(), connection.getHost(),
-          connection.getPort(), connection.getDatabase());
+          connection.getPort(), connection.getDatabase(), connection.getSSlMode());
     }
 
     @Override

--- a/oracle-plugin/src/test/java/io/cdap/plugin/oracle/OracleFailedConnectionTest.java
+++ b/oracle-plugin/src/test/java/io/cdap/plugin/oracle/OracleFailedConnectionTest.java
@@ -28,7 +28,8 @@ public class OracleFailedConnectionTest extends DBSpecificFailedConnectionTest {
   public void test() throws ClassNotFoundException, IOException {
 
     OracleConnector connector = new OracleConnector(
-      new OracleConnectorConfig("localhost", 1521, "username", "password", "jdbc", "", "database"));
+      new OracleConnectorConfig("localhost", 1521, "username", "password", "jdbc", "",
+              "SID", "database"));
 
     super.test(JDBC_DRIVER_CLASS_NAME, connector, "Failed to create connection to database via connection string:" +
                                                     " jdbc:oracle:thin:@localhost:1521:database and arguments: " +

--- a/oracle-plugin/widgets/Oracle-batchsink.json
+++ b/oracle-plugin/widgets/Oracle-batchsink.json
@@ -101,6 +101,26 @@
           }
         },
         {
+          "widget-type": "hidden",
+          "label": "TLS Encryption",
+          "name": "useSSL",
+          "description": "Enable TLS encryption (true/false)",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "false",
+            "options": [
+              {
+                "id": "true",
+                "label": "true"
+              },
+              {
+                "id": "false",
+                "label": "false"
+              }
+            ]
+          }
+        },
+        {
           "name": "connectionType",
           "label": "Connection Type",
           "widget-type": "radio-group",

--- a/oracle-plugin/widgets/Oracle-batchsource.json
+++ b/oracle-plugin/widgets/Oracle-batchsource.json
@@ -101,6 +101,26 @@
           }
         },
         {
+          "widget-type": "hidden",
+          "label": "TLS Encryption",
+          "name": "useSSL",
+          "description": "Enable TLS encryption (true/false)",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "false",
+            "options": [
+              {
+                "id": "true",
+                "label": "true"
+              },
+              {
+                "id": "false",
+                "label": "false"
+              }
+            ]
+          }
+        },
+        {
           "name": "connectionType",
           "label": "Connection Type",
           "widget-type": "radio-group",

--- a/oracle-plugin/widgets/Oracle-connector.json
+++ b/oracle-plugin/widgets/Oracle-connector.json
@@ -109,6 +109,26 @@
             ],
             "default": "TRANSACTION_SERIALIZABLE"
           }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "TLS Encryption",
+          "name": "useSSL",
+          "description": "Enable TLS encryption (true/false)",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "false",
+            "options": [
+              {
+                "id": "true",
+                "label": "true"
+              },
+              {
+                "id": "false",
+                "label": "false"
+              }
+            ]
+          }
         }
       ]
     },


### PR DESCRIPTION
***Add SSL/TLS support in Oracle Batch Source Classes***

This PR introduces a new field, ```useSSL```, to enable SSL (TLS) connections for Oracle by allowing the specification of protocol (tcp or tcps) in the connection string format.

****Key Changes****

1. New field

useSSL (Allows to specify whether SSL (TLS) should be used for  connections or not )
 - If useSSL is set to yes, the protocol in the connection string is set to tcps. Otherwise, it defaults to tcp.
 
 2. Connection String Format Updated:
 
 - For SID-based connections: ```jdbc:oracle:thin:@tcps or @tcp ://<host>:<port>/<SID>```
 - For Service Name-based connections: : ```jdbc:oracle:thin:tcps or @tcp ://<host>:<port>/<ServiceName>```
 
 
****Testing Scope****

- Validated TCP protocol connectivity:
Verified that the connection works as expected when specifying protocol as tcp explicitly in the connection string to ensure backward compatibility with existing behavior.

- Validated TCPS protocol connectivity:
Conducted internal tests with tcps to ensure secure connections (SSL/TLS) are correctly established and that the updated connection string format handles this protocol appropriately.
 

 
 