### PR TITLE
[🍒][PLUGIN-1813] CloudSQLMySQL Escape column names

### DIFF
--- a/cloudsql-mysql-plugin/src/test/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLSinkTest.java
+++ b/cloudsql-mysql-plugin/src/test/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLSinkTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.cloudsql.mysql;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CloudSQLMySQLSinkTest {
+   @Test
+    public void testSetColumnsInfo() {
+     Schema outputSchema = Schema.recordOf("output",
+        Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+        Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+        Schema.Field.of("insert", Schema.of(Schema.Type.STRING)));
+        CloudSQLMySQLSink cloudSQLMySQLSink = new CloudSQLMySQLSink(new CloudSQLMySQLSink.CloudSQLMySQLSinkConfig());
+        Assert.assertNotNull(outputSchema.getFields());
+        cloudSQLMySQLSink.setColumnsInfo(outputSchema.getFields());
+        Assert.assertEquals("`id`,`name`,`insert`", cloudSQLMySQLSink.getDbColumns());
+    }
+}

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlDBRecord.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlDBRecord.java
@@ -93,4 +93,13 @@ public class MysqlDBRecord extends DBRecord {
 
     super.writeNonNullToDB(stmt, fieldSchema, fieldName, fieldIndex);
   }
+
+  @Override
+  protected void insertOperation(PreparedStatement stmt) throws SQLException {
+    for (int fieldIndex = 0; fieldIndex < columnTypes.size(); fieldIndex++) {
+      ColumnType columnType = columnTypes.get(fieldIndex);
+      Schema.Field field = record.getSchema().getField(columnType.getName(), true);
+      writeToDB(stmt, field, fieldIndex);
+    }
+  }
 }

--- a/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlSinkTest.java
+++ b/mysql-plugin/src/test/java/io/cdap/plugin/mysql/MysqlSinkTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.mysql;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MysqlSinkTest {
+  @Test
+  public void testSetColumnsInfo() {
+    Schema outputSchema = Schema.recordOf("output",
+      Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("insert", Schema.of(Schema.Type.STRING)));
+    MysqlSink mySQLSink = new MysqlSink(new MysqlSink.MysqlSinkConfig());
+    Assert.assertNotNull(outputSchema.getFields());
+    mySQLSink.setColumnsInfo(outputSchema.getFields());
+    Assert.assertEquals("`id`,`name`,`insert`", mySQLSink.getDbColumns());
+  }
+}


### PR DESCRIPTION
🍒 [cherrypick]

### Commits :
 - 7be2c445f1a01f40f35ec5962952e612c33a3897

### PR:
 - #514 [ Reviewer @itsankit-google ]
 
---


## CloudSQLMySQL Escape column names

Jira : [PLUGIN-1813](https://cdap.atlassian.net/browse/PLUGIN-1813)

### Description

If column name is a MySQL reserved keyword say `insert` the query will fail due to incorrect sql syntax.
This PR fixes this issue by escaping the column names using back ticks.

Similar column escapes is used in other plugins. Ref [CloudSQLPostgreSQLSink](https://github.com/data-integrations/database-plugins/blob/a83eaac204fdff5f9a81fbacc938114d040dd844/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLSink.java#L107-L118) 


### Code change

- Modified `CloudSQLMySQLSink.java`
- Modified `MysqlSink.java`

### Unit Tests

- Added `CloudSQLMySQLSinkTest.java`
- ![image](https://github.com/user-attachments/assets/9b8fe4bc-e7a4-4dae-be2f-0f58ea4b664e)
- Added `MysqlSinkTest.java`
- <img width="503" alt="image" src="https://github.com/user-attachments/assets/7c8495b6-5b93-4699-8382-630e4bc402e3">







[PLUGIN-1813]: https://cdap.atlassian.net/browse/PLUGIN-1813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ