### PR TITLE
Bump CDAP version to 6.11.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,10 +61,10 @@
     <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- version properties -->
-    <cdap.version>6.9.1</cdap.version>
+    <cdap.version>6.11.0-SNAPSHOT</cdap.version>
     <cdap.plugin.version>2.11.1</cdap.plugin.version>
     <guava.version>13.0.1</guava.version>
-    <hadoop.version>2.3.0</hadoop.version>
+    <hadoop.version>3.3.6</hadoop.version>
     <hsql.version>2.2.4</hsql.version>
     <junit.version>4.13</junit.version>
     <mockrunner.version>2.0.1</mockrunner.version>


### PR DESCRIPTION
Raising a different PR for bump up, since this breaks unit tests.

Error Logs ( when running unit teste [_GenericDatabasePluginTestBase_] )


```
Exception in thread "MapReduceRunner-phase-1" java.lang.RuntimeException: java.lang.Exception: java.lang.NoSuchMethodError: org.apache.hadoop.mapreduce.task.JobContextImpl.getCacheArchives(Lorg/apache/hadoop/conf/Configuration;)[Ljava/net/URI;
	at com.google.common.base.Throwables.propagate(Throwables.java:160)
	at com.google.common.util.concurrent.AbstractExecutionThreadService$1$1.run(AbstractExecutionThreadService.java:69)
	at io.cdap.cdap.internal.app.runtime.batch.MapReduceRuntimeService$2$1.run(MapReduceRuntimeService.java:453)
	at java.lang.Thread.run(Thread.java:750)
Caused by: java.lang.Exception: java.lang.NoSuchMethodError: org.apache.hadoop.mapreduce.task.JobContextImpl.getCacheArchives(Lorg/apache/hadoop/conf/Configuration;)[Ljava/net/URI;
	at io.cdap.cdap.internal.app.runtime.batch.MapReduceRuntimeService.startUp(MapReduceRuntimeService.java:370)
	at com.google.common.util.concurrent.AbstractExecutionThreadService$1$1.run(AbstractExecutionThreadService.java:47)
	... 2 more
Caused by: java.lang.NoSuchMethodError: org.apache.hadoop.mapreduce.task.JobContextImpl.getCacheArchives(Lorg/apache/hadoop/conf/Configuration;)[Ljava/net/URI;
	at org.apache.hadoop.mapreduce.v2.util.MRApps.setupDistributedCache(MRApps.java:487)
	at org.apache.hadoop.mapred.LocalDistributedCacheManager.setup(LocalDistributedCacheManager.java:92)
	at org.apache.hadoop.mapred.LocalJobRunner$Job.<init>(LocalJobRunner.java:172)
	at org.apache.hadoop.mapred.LocalJobRunner.submitJob(LocalJobRunner.java:794)
	at org.apache.hadoop.mapreduce.JobSubmitter.submitJobInternal(JobSubmitter.java:432)
	at org.apache.hadoop.mapreduce.Job$10.run(Job.java:1285)
	at org.apache.hadoop.mapreduce.Job$10.run(Job.java:1282)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:422)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1548)
	at org.apache.hadoop.mapreduce.Job.submit(Job.java:1282)
	at io.cdap.cdap.internal.app.runtime.batch.MapReduceRuntimeService.startUp(MapReduceRuntimeService.java:356)
	... 3 more
```