### PR TITLE
[PLUGIN-1829] Add CloudSQLMySQLErrorDetailsProvider

### DIFF
--- a/cloudsql-mysql-plugin/src/e2e-test/features/sink/CloudMySqlRunTimeMacro.feature
+++ b/cloudsql-mysql-plugin/src/e2e-test/features/sink/CloudMySqlRunTimeMacro.feature
@@ -142,7 +142,9 @@ Feature: CloudMySql Sink - Run time scenarios (macro)
     Then Enter runtime argument value "invalidTablename" for key "invalidTablename"
     Then Run the Pipeline in Runtime with runtime arguments
     Then Wait till pipeline is in running state
+    And Open and capture logs
     And Verify the pipeline status is "Failed"
+    And Close the pipeline logs
     Then Open Pipeline logs and verify Log entries having below listed Level and Message:
       | Level | Message                                  |
       | ERROR | errorLogsMessageInvalidTableName         |
@@ -181,7 +183,9 @@ Feature: CloudMySql Sink - Run time scenarios (macro)
     Then Enter runtime argument value "invalidPassword" for key "Password"
     Then Run the Pipeline in Runtime with runtime arguments
     Then Wait till pipeline is in running state
+    And Open and capture logs
     And Verify the pipeline status is "Failed"
+    And Close the pipeline logs
     Then Open Pipeline logs and verify Log entries having below listed Level and Message:
       | Level | Message                                  |
       | ERROR | errorLogsMessageInvalidCredentials       |

--- a/cloudsql-mysql-plugin/src/e2e-test/features/source/CloudMySqlRunTime.feature
+++ b/cloudsql-mysql-plugin/src/e2e-test/features/source/CloudMySqlRunTime.feature
@@ -224,7 +224,9 @@ Feature: CloudMySql Source - Run time scenarios
     Then Deploy the pipeline
     Then Run the Pipeline in Runtime
     Then Wait till pipeline is in running state
+    And Open and capture logs
     And Verify the pipeline status is "Failed"
+    And Close the pipeline logs
     Then Open Pipeline logs and verify Log entries having below listed Level and Message:
       | Level | Message                                  |
       | ERROR | errorLogsMessageInvalidBoundingQuery     |

--- a/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLErrorDetailsProvider.java
+++ b/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLErrorDetailsProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.cloudsql.mysql;
+
+
+import io.cdap.plugin.mysql.MysqlErrorDetailsProvider;
+
+/**
+ * A custom ErrorDetailsProvider for CloudSQL MySQL plugins.
+ */
+public class CloudSQLMySQLErrorDetailsProvider extends MysqlErrorDetailsProvider {
+
+  @Override
+  protected String getExternalDocumentationLink() {
+    return "https://cloud.google.com/sql/docs/mysql/error-messages";
+  }
+}

--- a/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLSink.java
+++ b/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLSink.java
@@ -104,6 +104,11 @@ public class CloudSQLMySQLSink extends AbstractDBSink<CloudSQLMySQLSink.CloudSQL
   }
 
   @Override
+  protected String getErrorDetailsProviderClassName() {
+    return CloudSQLMySQLErrorDetailsProvider.class.getName();
+  }
+
+  @Override
   protected LineageRecorder getLineageRecorder(BatchSinkContext context) {
     String host;
     String location = "";

--- a/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLSource.java
+++ b/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLSource.java
@@ -127,6 +127,11 @@ public class CloudSQLMySQLSource extends AbstractDBSource<CloudSQLMySQLSource.Cl
     return new MysqlSchemaReader(null, cloudsqlMysqlSourceConfig.getConnectionArguments());
   }
 
+  @Override
+  protected String getErrorDetailsProviderClassName() {
+    return CloudSQLMySQLErrorDetailsProvider.class.getName();
+  }
+
   /** CloudSQL MySQL source config. */
   public static class CloudSQLMySQLSourceConfig extends AbstractDBSpecificSourceConfig {
 


### PR DESCRIPTION
## ErrorDetailsProvider - CloudSQLMySQL [Source|Sink] plugin

Jira : [PLUGIN-1829](https://cdap.atlassian.net/browse/PLUGIN-1829)

### Description

Implement Program Failure Exception Handling in CloudSQLMySQL Source/Sink plugin to catch known errors

### Code change

- Added `CloudSQLMySQLErrorDetailsProvider.java`
- Modified `CloudSQLMySQLSink.java`
- Modified `CloudSQLMySQLSource.java`

### E2E Changes

- Adding `Open and capture logs` step when pipeline is expected to fail.



[PLUGIN-1829]: https://cdap.atlassian.net/browse/PLUGIN-1829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ