### PR TITLE
[PLUGIN-1830] Add PostgresErrorDetailsProvider

### DIFF
--- a/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
+++ b/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
@@ -62,6 +62,8 @@ public final class DBUtils {
   public static final Calendar PURE_GREGORIAN_CALENDAR = createPureGregorianCalender();
   public static final String MYSQL_SUPPORTED_DOC_URL = "https://dev.mysql.com/doc/mysql-errors/9.0/en/";
   public static final String CLOUDSQLMYSQL_SUPPORTED_DOC_URL = "https://cloud.google.com/sql/docs/mysql/error-messages";
+  public static final String POSTGRES_SUPPORTED_DOC_URL =
+    "https://www.postgresql.org/docs/current/errcodes-appendix.html";
 
   // Java by default uses October 15, 1582 as a Gregorian cut over date.
   // Any timestamp created with time less than this cut over date is treated as Julian date.

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlErrorDetailsProvider.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlErrorDetailsProvider.java
@@ -31,7 +31,7 @@ public class MysqlErrorDetailsProvider extends DBErrorDetailsProvider {
   }
 
   @Override
-  protected ErrorType getErrorTypeFromErrorCode(int errorCode) {
+  protected ErrorType getErrorTypeFromErrorCode(int errorCode, String sqlState) {
     // https://dev.mysql.com/doc/refman/9.0/en/error-message-elements.html#error-code-ranges
     if (errorCode >= 1000 && errorCode <= 5999) {
       return ErrorType.USER;

--- a/postgresql-plugin/src/e2e-test/features/postgresql/source/PostgresqlRunTime.feature
+++ b/postgresql-plugin/src/e2e-test/features/postgresql/source/PostgresqlRunTime.feature
@@ -147,7 +147,9 @@ Feature: PostgreSQL - Verify data transfer from PostgreSQL source to BigQuery si
     And Save and Deploy Pipeline
     And Run the Pipeline in Runtime
     And Wait till pipeline is in running state
+    And Open and capture logs
     And Verify the pipeline status is "Failed"
+    And Close the pipeline logs
     Then Open Pipeline logs and verify Log entries having below listed Level and Message:
     | Level | Message                                  |
     | ERROR | errorLogsMessageInvalidBoundingQuery     |

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresConstants.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresConstants.java
@@ -16,13 +16,19 @@
 
 package io.cdap.plugin.postgres;
 
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorType;
+import io.cdap.cdap.api.exception.ErrorUtils;
+
 /**
  * Postgres constants.
  */
 public final class PostgresConstants {
 
   private PostgresConstants() {
-    throw new AssertionError("Should not instantiate static utility class.");
+    String errorMessage = "Should not instantiate static utility class.";
+    throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN),
+      errorMessage, errorMessage, ErrorType.SYSTEM, false, new AssertionError(errorMessage));
   }
 
   public static final String PLUGIN_NAME = "Postgres";

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresErrorDetailsProvider.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresErrorDetailsProvider.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.postgres;
+
+import com.google.common.base.Strings;
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorType;
+import io.cdap.plugin.db.DBErrorDetailsProvider;
+import io.cdap.plugin.util.DBUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A custom ErrorDetailsProvider for Postgres plugins.
+ */
+public class PostgresErrorDetailsProvider extends DBErrorDetailsProvider {
+  // https://www.postgresql.org/docs/current/errcodes-appendix.html
+  private static final Map<String, ErrorType> ERROR_CODE_TO_ERROR_TYPE;
+  private static final Map<String, ErrorCategory> ERROR_CODE_TO_ERROR_CATEGORY;
+  static {
+    ERROR_CODE_TO_ERROR_TYPE = new HashMap<>();
+    ERROR_CODE_TO_ERROR_TYPE.put("01", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("02", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("08", ErrorType.SYSTEM);
+    ERROR_CODE_TO_ERROR_TYPE.put("0A", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("22", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("23", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("28", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("40", ErrorType.SYSTEM);
+    ERROR_CODE_TO_ERROR_TYPE.put("42", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("53", ErrorType.SYSTEM);
+    ERROR_CODE_TO_ERROR_TYPE.put("54", ErrorType.SYSTEM);
+    ERROR_CODE_TO_ERROR_TYPE.put("55", ErrorType.USER);
+    ERROR_CODE_TO_ERROR_TYPE.put("57", ErrorType.SYSTEM);
+    ERROR_CODE_TO_ERROR_TYPE.put("58", ErrorType.SYSTEM);
+    ERROR_CODE_TO_ERROR_TYPE.put("P0", ErrorType.SYSTEM);
+    ERROR_CODE_TO_ERROR_TYPE.put("XX", ErrorType.SYSTEM);
+
+    ErrorCategory.ErrorCategoryEnum plugin = ErrorCategory.ErrorCategoryEnum.PLUGIN;
+    ERROR_CODE_TO_ERROR_CATEGORY = new HashMap<>();
+    ERROR_CODE_TO_ERROR_CATEGORY.put("01", new ErrorCategory(plugin, "Warning"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("02", new ErrorCategory(plugin, "No Data"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("08", new ErrorCategory(plugin, "Postgres Server Connection Exception"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("0A", new ErrorCategory(plugin, "Postgres Server Feature Not Supported"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("22", new ErrorCategory(plugin, "Postgres Server Data Exception"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("23", new ErrorCategory(plugin, "Postgres Integrity Constraint Violation"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("28", new ErrorCategory(plugin, "Postgres Invalid Authorization Specification"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("40", new ErrorCategory(plugin, "Transaction Rollback"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("42", new ErrorCategory(plugin, "Syntax Error or Access Rule Violation"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("53", new ErrorCategory(plugin, "Postgres Server Insufficient Resources"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("54", new ErrorCategory(plugin, "Postgres Program Limit Exceeded"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("55", new ErrorCategory(plugin, "Object Not in Prerequisite State"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("57", new ErrorCategory(plugin, "Operator Intervention"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("58", new ErrorCategory(plugin, "Postgres Server System Error"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("P0", new ErrorCategory(plugin, "PL/pgSQL Error"));
+    ERROR_CODE_TO_ERROR_CATEGORY.put("XX", new ErrorCategory(plugin, "Postgres Server Internal Error"));
+  }
+
+  @Override
+  protected String getExternalDocumentationLink() {
+    return DBUtils.POSTGRES_SUPPORTED_DOC_URL;
+  }
+
+  @Override
+  protected ErrorType getErrorTypeFromErrorCode(int errorCode, String sqlState) {
+    if (!Strings.isNullOrEmpty(sqlState) && sqlState.length() >= 2 &&
+      ERROR_CODE_TO_ERROR_TYPE.containsKey(sqlState.substring(0, 2))) {
+      return ERROR_CODE_TO_ERROR_TYPE.get(sqlState.substring(0, 2));
+    }
+    return ErrorType.UNKNOWN;
+  }
+
+  @Override
+  protected ErrorCategory getErrorCategoryFromSqlState(String sqlState) {
+    if (!Strings.isNullOrEmpty(sqlState) && sqlState.length() >= 2 &&
+      ERROR_CODE_TO_ERROR_CATEGORY.containsKey(sqlState.substring(0, 2))) {
+      return ERROR_CODE_TO_ERROR_CATEGORY.get(sqlState.substring(0, 2));
+    }
+    return new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN);
+  }
+}

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSink.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSink.java
@@ -116,6 +116,11 @@ public class PostgresSink extends AbstractDBSink<PostgresSink.PostgresSinkConfig
     return new LineageRecorder(context, asset);
   }
 
+  @Override
+  protected String getErrorDetailsProviderClassName() {
+    return PostgresErrorDetailsProvider.class.getName();
+  }
+
   /**
    * PostgreSQL action configuration.
    */

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSource.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSource.java
@@ -68,8 +68,18 @@ public class PostgresSource extends AbstractDBSource<PostgresSource.PostgresSour
   }
 
   @Override
+  protected String getErrorDetailsProviderClassName() {
+    return PostgresErrorDetailsProvider.class.getName();
+  }
+
+  @Override
   protected Class<? extends DBWritable> getDBRecordType() {
     return PostgresDBRecord.class;
+  }
+
+  @Override
+  protected String getExternalDocumentationLink() {
+    return DBUtils.POSTGRES_SUPPORTED_DOC_URL;
   }
 
   @Override


### PR DESCRIPTION
## ErrorDetailsProvider - Postgresql [Source|Sink] plugin

Jira : [PLUGIN-1830](https://cdap.atlassian.net/browse/PLUGIN-1830)

### Description

Implement Program Failure Exception Handling in Postgresql Source/Sink plugin to catch known errors

### Code change

- Added `PostgresErrorDetailsProvider.java`
- Modified `DBErrorDetailsProvider.java`
- Modified `MysqlErrorDetailsProvider.java`
- Modified `PostgresConstants.java`
- Modified `PostgresSink.java`
- Modified `PostgresSource.java`

### E2E Changes

- Adding `Open and capture logs` step when pipeline is expected to fail.


[PLUGIN-1830]: https://cdap.atlassian.net/browse/PLUGIN-1830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ