### PR TITLE
[PLUGIN-1831] Add CloudSQLPostgreSQLErrorDetailsProvider

### DIFF
--- a/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLErrorDetailsProvider.java
+++ b/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLErrorDetailsProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.cloudsql.postgres;
+
+import io.cdap.plugin.postgres.PostgresErrorDetailsProvider;
+import io.cdap.plugin.util.DBUtils;
+
+/**
+ * A custom ErrorDetailsProvider for CloudSQL PostgreSQL plugin.
+ */
+public class CloudSQLPostgreSQLErrorDetailsProvider extends PostgresErrorDetailsProvider {
+  @Override
+  protected String getExternalDocumentationLink() {
+    return DBUtils.CLOUDSQLPOSTGRES_SUPPORTED_DOC_URL;
+  }
+}

--- a/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLSink.java
+++ b/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLSink.java
@@ -147,6 +147,11 @@ public class CloudSQLPostgreSQLSink extends AbstractDBSink<CloudSQLPostgreSQLSin
     return new LineageRecorder(context, assetBuilder.build());
   }
 
+  @Override
+  protected String getErrorDetailsProviderClassName() {
+    return CloudSQLPostgreSQLErrorDetailsProvider.class.getName();
+  }
+
   /** CloudSQL PostgreSQL sink config. */
   public static class CloudSQLPostgreSQLSinkConfig extends AbstractDBSpecificSinkConfig {
 

--- a/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLSource.java
+++ b/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLSource.java
@@ -87,6 +87,16 @@ public class CloudSQLPostgreSQLSource
   }
 
   @Override
+  protected String getExternalDocumentationLink() {
+    return DBUtils.CLOUDSQLPOSTGRES_SUPPORTED_DOC_URL;
+  }
+
+  @Override
+  protected String getErrorDetailsProviderClassName() {
+    return CloudSQLPostgreSQLErrorDetailsProvider.class.getName();
+  }
+
+  @Override
   protected String createConnectionString() {
     if (CloudSQLUtil.PRIVATE_INSTANCE.equalsIgnoreCase(
         cloudsqlPostgresqlSourceConfig.connection.getInstanceType())) {

--- a/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
+++ b/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
@@ -64,6 +64,8 @@ public final class DBUtils {
   public static final String CLOUDSQLMYSQL_SUPPORTED_DOC_URL = "https://cloud.google.com/sql/docs/mysql/error-messages";
   public static final String POSTGRES_SUPPORTED_DOC_URL =
     "https://www.postgresql.org/docs/current/errcodes-appendix.html";
+  public static final String CLOUDSQLPOSTGRES_SUPPORTED_DOC_URL =
+    "https://cloud.google.com/sql/docs/postgres/error-messages";
 
   // Java by default uses October 15, 1582 as a Gregorian cut over date.
   // Any timestamp created with time less than this cut over date is treated as Julian date.


### PR DESCRIPTION
## ErrorDetailsProvider - CloudSQLPostgreSQL [Source|Sink] plugin

Jira : [PLUGIN-1831](https://cdap.atlassian.net/browse/PLUGIN-1831)

### Description

Implement Program Failure Exception Handling in CloudSQLPostgreSQL Source/Sink plugin to catch known errors

### Code change

- Added `CloudSQLPostgreSQLErrorDetailsProvider.java`
- Modified `CloudSQLPostgreSQLSink.java`
- Modified `CloudSQLPostgreSQLSource.java`

### E2E Changes

- Adding `Open and capture logs` step when pipeline is expected to fail.

[PLUGIN-1831]: https://cdap.atlassian.net/browse/PLUGIN-1831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ