### PR TITLE
[CDAP-21093] Add errorCodeType, errorCode & supportedDocURL in exception (MySQL/CloudSQLMySQLErrorDetailsProvider)

### DIFF
--- a/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLErrorDetailsProvider.java
+++ b/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLErrorDetailsProvider.java
@@ -18,6 +18,7 @@ package io.cdap.plugin.cloudsql.mysql;
 
 
 import io.cdap.plugin.mysql.MysqlErrorDetailsProvider;
+import io.cdap.plugin.util.DBUtils;
 
 /**
  * A custom ErrorDetailsProvider for CloudSQL MySQL plugins.
@@ -26,6 +27,6 @@ public class CloudSQLMySQLErrorDetailsProvider extends MysqlErrorDetailsProvider
 
   @Override
   protected String getExternalDocumentationLink() {
-    return "https://cloud.google.com/sql/docs/mysql/error-messages";
+    return DBUtils.CLOUDSQLMYSQL_SUPPORTED_DOC_URL;
   }
 }

--- a/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLSource.java
+++ b/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLSource.java
@@ -82,6 +82,11 @@ public class CloudSQLMySQLSource extends AbstractDBSource<CloudSQLMySQLSource.Cl
   }
 
   @Override
+  protected String getExternalDocumentationLink() {
+    return DBUtils.CLOUDSQLMYSQL_SUPPORTED_DOC_URL;
+  }
+
+  @Override
   protected String createConnectionString() {
     if (CloudSQLUtil.PRIVATE_INSTANCE.equalsIgnoreCase(
         cloudsqlMysqlSourceConfig.connection.getInstanceType())) {

--- a/database-commons/src/main/java/io/cdap/plugin/db/DBErrorDetailsProvider.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/DBErrorDetailsProvider.java
@@ -19,11 +19,13 @@ package io.cdap.plugin.db;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorCodeType;
 import io.cdap.cdap.api.exception.ErrorType;
 import io.cdap.cdap.api.exception.ErrorUtils;
 import io.cdap.cdap.api.exception.ProgramFailureException;
 import io.cdap.cdap.etl.api.exception.ErrorContext;
 import io.cdap.cdap.etl.api.exception.ErrorDetailsProvider;
+import io.cdap.plugin.util.DBUtils;
 
 import java.sql.SQLException;
 import java.util.List;
@@ -76,7 +78,8 @@ public class DBErrorDetailsProvider implements ErrorDetailsProvider {
         externalDocumentationLink);
     }
     return ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN),
-      errorMessage, errorMessageWithDetails, getErrorTypeFromErrorCode(errorCode), false, e);
+      errorMessage, errorMessageWithDetails, getErrorTypeFromErrorCode(errorCode), false, ErrorCodeType.SQLSTATE,
+      sqlState, externalDocumentationLink, e);
   }
 
   /**

--- a/database-commons/src/main/java/io/cdap/plugin/db/DBRecord.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/DBRecord.java
@@ -17,7 +17,6 @@
 package io.cdap.plugin.db;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;

--- a/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
+++ b/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
@@ -60,6 +60,8 @@ public final class DBUtils {
   private static final Logger LOG = LoggerFactory.getLogger(DBUtils.class);
 
   public static final Calendar PURE_GREGORIAN_CALENDAR = createPureGregorianCalender();
+  public static final String MYSQL_SUPPORTED_DOC_URL = "https://dev.mysql.com/doc/mysql-errors/9.0/en/";
+  public static final String CLOUDSQLMYSQL_SUPPORTED_DOC_URL = "https://cloud.google.com/sql/docs/mysql/error-messages";
 
   // Java by default uses October 15, 1582 as a Gregorian cut over date.
   // Any timestamp created with time less than this cut over date is treated as Julian date.

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlErrorDetailsProvider.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlErrorDetailsProvider.java
@@ -18,6 +18,7 @@ package io.cdap.plugin.mysql;
 
 import io.cdap.cdap.api.exception.ErrorType;
 import io.cdap.plugin.db.DBErrorDetailsProvider;
+import io.cdap.plugin.util.DBUtils;
 
 /**
  * A custom ErrorDetailsProvider for MySQL plugins.
@@ -26,7 +27,7 @@ public class MysqlErrorDetailsProvider extends DBErrorDetailsProvider {
 
   @Override
   protected String getExternalDocumentationLink() {
-    return "https://dev.mysql.com/doc/mysql-errors/9.0/en/";
+    return DBUtils.MYSQL_SUPPORTED_DOC_URL;
   }
 
   @Override

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlSource.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlSource.java
@@ -69,6 +69,11 @@ public class MysqlSource extends AbstractDBSource<MysqlSource.MysqlSourceConfig>
     return MysqlDBRecord.class;
   }
 
+ @Override
+ protected String getExternalDocumentationLink() {
+    return DBUtils.MYSQL_SUPPORTED_DOC_URL;
+ }
+
   @Override
   protected LineageRecorder getLineageRecorder(BatchSourceContext context) {
     String fqn = DBUtils.constructFQN("mysql",


### PR DESCRIPTION
## Add errorCodeType, errorCode & supportedDocURL in exception

Jira : [CDAP-21093](https://cdap.atlassian.net/browse/CDAP-21093)

### Description

Adding  errorCodeType, errorCode & supportedDocURL in exception for mysql, and command `DBErrorDetailsProvider` class

### Code change

- Modified `DBErrorDetailsProvider.java`
- Modified `DBRecord.java`
- Modified `DBUtils.java`
- Modified `MysqlErrorDetailsProvider.java`

## Test

![image](https://github.com/user-attachments/assets/bd86e46a-21bd-46a4-be9c-d649a3afe817)
![image](https://github.com/user-attachments/assets/11d1e520-fb44-4fb5-83e7-3493a87cc298)

![image](https://github.com/user-attachments/assets/9d2131e9-9486-4b0c-8ce0-21a1d3dae32e)




[CDAP-21093]: https://cdap.atlassian.net/browse/CDAP-21093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ