### PR TITLE
[PLUGIN-1845] Return null for ErrorDetailsProvider by default

### DIFF
--- a/database-commons/src/main/java/io/cdap/plugin/db/sink/AbstractDBSink.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/sink/AbstractDBSink.java
@@ -172,7 +172,7 @@ public abstract class AbstractDBSink<T extends PluginConfig & DatabaseSinkConfig
    * @return ErrorDetailsProvider class name
    */
   protected String getErrorDetailsProviderClassName() {
-    return DBErrorDetailsProvider.class.getName();
+    return null;
   }
 
   @Override
@@ -240,7 +240,9 @@ public abstract class AbstractDBSink<T extends PluginConfig & DatabaseSinkConfig
                         context.getArguments().get(ETLDBOutputFormat.COMMIT_BATCH_SIZE));
     }
     // set error details provider
-    context.setErrorDetailsProvider(new ErrorDetailsProviderSpec(getErrorDetailsProviderClassName()));
+    if (!Strings.isNullOrEmpty(getErrorDetailsProviderClassName())) {
+      context.setErrorDetailsProvider(new ErrorDetailsProviderSpec(getErrorDetailsProviderClassName()));
+    }
     addOutputContext(context);
   }
   protected void addOutputContext(BatchSinkContext context) {

--- a/database-commons/src/main/java/io/cdap/plugin/db/source/AbstractDBSource.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/source/AbstractDBSource.java
@@ -239,7 +239,7 @@ public abstract class AbstractDBSource<T extends PluginConfig & DatabaseSourceCo
    * @return ErrorDetailsProvider class name
    */
   protected String getErrorDetailsProviderClassName() {
-    return DBErrorDetailsProvider.class.getName();
+    return null;
   }
 
   private DriverCleanup loadPluginClassAndGetDriver(Class<? extends Driver> driverClass)
@@ -299,7 +299,9 @@ public abstract class AbstractDBSource<T extends PluginConfig & DatabaseSourceCo
                                  schema.getFields().stream().map(Schema.Field::getName).collect(Collectors.toList()));
     }
     // set error details provider
-    context.setErrorDetailsProvider(new ErrorDetailsProviderSpec(getErrorDetailsProviderClassName()));
+    if (!Strings.isNullOrEmpty(getErrorDetailsProviderClassName())) {
+      context.setErrorDetailsProvider(new ErrorDetailsProviderSpec(getErrorDetailsProviderClassName()));
+    }
     context.setInput(Input.of(sourceConfig.getReferenceName(), new SourceInputFormatProvider(
       DataDrivenETLDBInputFormat.class, connectionConfigAccessor.getConfiguration())));
   }


### PR DESCRIPTION
## Return Null for ErrorDetailsProvider by default to fix DBErrorDetailsProvider export issue

Jira : [PLUGIN-1845](https://cdap.atlassian.net/browse/PLUGIN-1845)

### Description

Return `null` for error details provider by default, this is for plugins which have not yet implemented the error details provider.

### Code change

- Modified `AbstractDBSource.java`

[PLUGIN-1845]: https://cdap.atlassian.net/browse/PLUGIN-1845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ