### PR TITLE
[🍒][CDAP-21093] Add ExternalDocumentationLink in abstract sink

### DIFF
--- a/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLSink.java
+++ b/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLSink.java
@@ -109,6 +109,11 @@ public class CloudSQLMySQLSink extends AbstractDBSink<CloudSQLMySQLSink.CloudSQL
   }
 
   @Override
+  protected String getExternalDocumentationLink() {
+    return DBUtils.CLOUDSQLMYSQL_SUPPORTED_DOC_URL;
+  }
+
+  @Override
   protected LineageRecorder getLineageRecorder(BatchSinkContext context) {
     String host;
     String location = "";

--- a/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLSink.java
+++ b/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLSink.java
@@ -152,6 +152,11 @@ public class CloudSQLPostgreSQLSink extends AbstractDBSink<CloudSQLPostgreSQLSin
     return CloudSQLPostgreSQLErrorDetailsProvider.class.getName();
   }
 
+  @Override
+  protected String getExternalDocumentationLink() {
+    return DBUtils.CLOUDSQLPOSTGRES_SUPPORTED_DOC_URL;
+  }
+
   /** CloudSQL PostgreSQL sink config. */
   public static class CloudSQLPostgreSQLSinkConfig extends AbstractDBSpecificSinkConfig {
 

--- a/database-commons/src/main/java/io/cdap/plugin/db/sink/AbstractDBSink.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/sink/AbstractDBSink.java
@@ -25,6 +25,10 @@ import io.cdap.cdap.api.data.batch.Output;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.lib.KeyValue;
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorCodeType;
+import io.cdap.cdap.api.exception.ErrorType;
+import io.cdap.cdap.api.exception.ErrorUtils;
 import io.cdap.cdap.api.plugin.PluginConfig;
 import io.cdap.cdap.etl.api.Emitter;
 import io.cdap.cdap.etl.api.FailureCollector;
@@ -175,6 +179,16 @@ public abstract class AbstractDBSink<T extends PluginConfig & DatabaseSinkConfig
     return DBErrorDetailsProvider.class.getName();
   }
 
+  /**
+   * Returns the external documentation link.
+   * Override this method to provide a custom external documentation link.
+   *
+   * @return external documentation link
+   */
+  protected String getExternalDocumentationLink() {
+    return null;
+  }
+
   @Override
   public void prepareRun(BatchSinkContext context) {
     String connectionString = dbSinkConfig.getConnectionString();
@@ -296,8 +310,21 @@ public abstract class AbstractDBSink<T extends PluginConfig & DatabaseSinkConfig
           inferredFields.addAll(getSchemaReader().getSchemaFields(rs));
         }
       } catch (SQLException e) {
-        throw new InvalidStageException("Error while reading table metadata", e);
-
+        // wrap exception to ensure SQLException-child instances not exposed to contexts w/o jdbc driver in classpath
+        String errorMessageWithDetails = String.format("Error while reading table metadata." +
+          "Error message: '%s'. Error code: '%s'. SQLState: '%s'", e.getMessage(), e.getErrorCode(), e.getSQLState());
+        String externalDocumentationLink = getExternalDocumentationLink();
+        if (!Strings.isNullOrEmpty(externalDocumentationLink)) {
+          if (!errorMessageWithDetails.endsWith(".")) {
+            errorMessageWithDetails = errorMessageWithDetails + ".";
+          }
+          errorMessageWithDetails = String.format("%s For more details, see %s", errorMessageWithDetails,
+            externalDocumentationLink);
+        }
+        throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN),
+          e.getMessage(), errorMessageWithDetails, ErrorType.USER, false, ErrorCodeType.SQLSTATE,
+          e.getSQLState(), externalDocumentationLink, new SQLException(e.getMessage(),
+            e.getSQLState(), e.getErrorCode()));
       }
     } catch (IllegalAccessException | InstantiationException | SQLException e) {
       throw new InvalidStageException("JDBC Driver unavailable: " + dbSinkConfig.getJdbcPluginName(), e);

--- a/database-commons/src/main/java/io/cdap/plugin/db/source/AbstractDBSource.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/source/AbstractDBSource.java
@@ -373,6 +373,12 @@ public abstract class AbstractDBSource<T extends PluginConfig & DatabaseSourceCo
     return DBRecord.class;
   }
 
+  /**
+   * Returns the external documentation link.
+   * Override this method to provide a custom external documentation link.
+   *
+   * @return external documentation link
+   */
   protected String getExternalDocumentationLink() {
     return null;
   }

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlSink.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlSink.java
@@ -114,6 +114,11 @@ public class MysqlSink extends AbstractDBSink<MysqlSink.MysqlSinkConfig> {
     return MysqlErrorDetailsProvider.class.getName();
   }
 
+  @Override
+  protected String getExternalDocumentationLink() {
+    return DBUtils.MYSQL_SUPPORTED_DOC_URL;
+  }
+
   /**
    * MySQL action configuration.
    */

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSink.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSink.java
@@ -121,6 +121,11 @@ public class PostgresSink extends AbstractDBSink<PostgresSink.PostgresSinkConfig
     return PostgresErrorDetailsProvider.class.getName();
   }
 
+  @Override
+  protected String getExternalDocumentationLink() {
+    return DBUtils.POSTGRES_SUPPORTED_DOC_URL;
+  }
+
   /**
    * PostgreSQL action configuration.
    */


### PR DESCRIPTION
🍒 [cherrypick]

### Commits :
 - 5952ef738031950e35e8dc195d3cd9e2f8dd4b91

### PR:
 - #533 [ Reviewer @itsankit-google ]
 
---

## Add ExternalDocumentationLink in abstract sink

Jira : [CDAP-21093](https://cdap.atlassian.net/browse/CDAP-21093)

### Description

The [AbstractDBSink](https://github.com/data-integrations/database-plugins/blob/5af79a6bbf623899a7f0467db3ab41dda982901c/database-commons/src/main/java/io/cdap/plugin/db/sink/AbstractDBSink.java#L298-L299) class also throw SQLException, we also need to make the changes similar to [AbstractDBSource](https://github.com/data-integrations/database-plugins/blob/5af79a6bbf623899a7f0467db3ab41dda982901c/database-commons/src/main/java/io/cdap/plugin/db/source/AbstractDBSource.java#L202-L221) there as well.

Ref: #530

### Code change

- Modified `CloudSQLMySQLSink.java`
- Modified `CloudSQLPostgreSQLSink.java`
- Modified `AbstractDBSink.java`
- Modified `AbstractDBSource.java`
- Modified `MysqlSink.java`
- Modified `PostgresSink.java`


[CDAP-21093]: https://cdap.atlassian.net/browse/CDAP-21093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ