### PR TITLE
[🍒][PLUGIN-1835] Add OracleErrorDetailsProvider

### DIFF
--- a/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
+++ b/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
@@ -64,6 +64,7 @@ public final class DBUtils {
   public static final String CLOUDSQLMYSQL_SUPPORTED_DOC_URL = "https://cloud.google.com/sql/docs/mysql/error-messages";
   public static final String POSTGRES_SUPPORTED_DOC_URL =
     "https://www.postgresql.org/docs/current/errcodes-appendix.html";
+  public static final String ORACLE_SUPPORTED_DOC_URL = "https://docs.oracle.com/en/error-help/db/ora-index.html";
   public static final String CLOUDSQLPOSTGRES_SUPPORTED_DOC_URL =
     "https://cloud.google.com/sql/docs/postgres/error-messages";
 

--- a/oracle-plugin/src/e2e-test/features/source/OracleRunTime.feature
+++ b/oracle-plugin/src/e2e-test/features/source/OracleRunTime.feature
@@ -338,7 +338,9 @@ Feature: Oracle - Verify data transfer from Oracle source to BigQuery sink
     And Save and Deploy Pipeline
     And Run the Pipeline in Runtime
     And Wait till pipeline is in running state
+    And Open and capture logs
     And Verify the pipeline status is "Failed"
+    And Close the pipeline logs
     Then Open Pipeline logs and verify Log entries having below listed Level and Message:
       | Level | Message                                  |
       | ERROR | errorLogsMessageInvalidBoundingQuery     |

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleErrorDetailsProvider.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleErrorDetailsProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.oracle;
+
+import io.cdap.plugin.common.db.DBErrorDetailsProvider;
+import io.cdap.plugin.util.DBUtils;
+
+/**
+ * A custom ErrorDetailsProvider for Oracle plugin.
+ */
+public class OracleErrorDetailsProvider extends DBErrorDetailsProvider {
+
+  @Override
+  protected String getExternalDocumentationLink() {
+    return DBUtils.ORACLE_SUPPORTED_DOC_URL;
+  }
+}

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSink.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSink.java
@@ -82,6 +82,15 @@ public class OracleSink extends AbstractDBSink<OracleSink.OracleSinkConfig> {
     return new LineageRecorder(context, asset);
   }
 
+  @Override
+  protected String getErrorDetailsProviderClassName() {
+    return OracleErrorDetailsProvider.class.getName();
+  }
+
+  @Override
+  protected String getExternalDocumentationLink() {
+    return DBUtils.ORACLE_SUPPORTED_DOC_URL;
+  }
 
   /**
    * Oracle action configuration.

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSource.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSource.java
@@ -72,6 +72,16 @@ public class OracleSource extends AbstractDBSource<OracleSource.OracleSourceConf
   }
 
   @Override
+  protected String getExternalDocumentationLink() {
+    return DBUtils.ORACLE_SUPPORTED_DOC_URL;
+  }
+
+  @Override
+  protected String getErrorDetailsProviderClassName() {
+    return OracleErrorDetailsProvider.class.getName();
+  }
+
+  @Override
   protected LineageRecorder getLineageRecorder(BatchSourceContext context) {
     String fqn = DBUtils.constructFQN("oracle",
                                       oracleSourceConfig.getConnection().getHost(),


### PR DESCRIPTION
🍒 [cherrypick]

### Commits :
 - 96702fdee831722ff326a316af5441f08489c2b3

### PR:
 - #532 [ Reviewer @itsankit-google ]
 
---

## ErrorDetailsProvider - Oracle DB [Source|Sink] plugin

Jira : [PLUGIN-1835](https://cdap.atlassian.net/browse/PLUGIN-1835)

### Description

Implement Program Failure Exception Handling in Oracle DB Source/Sink plugin to catch known errors

### Code change

- Added `OracleErrorDetailsProvider.java`
- Modified `DBUtils.java`
- Modified `OracleSink.java`
- Modified `OracleSource.java`


### E2E Changes

- Adding `Open and capture logs` step when pipeline is expected to fail.

###  Tests

 - Test Case (Violate check constrain)
  
<details>
  <summary>Raw Logs</summary>

  ```   

2025-01-29 04:09:03,101 - ERROR [Executor task launch worker for task 0.0 in stage 0.0 (TID 0):o.a.s.u.Utils@98] - Aborting task
io.cdap.cdap.api.exception.WrappedStageException: Stage 'Oracle2' encountered : io.cdap.cdap.api.exception.ProgramFailureException: Error occurred in the phase: 'Writing' with sqlState: '23000', errorCode: '1', errorMessage: ORA-00001: unique constraint (C##BUILDUSER.PK_AGE) violated

https://docs.oracle.com/error-help/db/ora-00001/
	at io.cdap.cdap.etl.common.ErrorDetails.handleException(ErrorDetails.java:77)
	at io.cdap.cdap.etl.spark.io.StageTrackingRecordWriter.close(StageTrackingRecordWriter.java:67)
	at org.apache.spark.internal.io.HadoopMapReduceWriteConfigUtil.closeWriter(SparkHadoopWriter.scala:373)
	at org.apache.spark.internal.io.SparkHadoopWriter$.$anonfun$executeTask$1(SparkHadoopWriter.scala:145)
	at org.apache.spark.util.Utils$.tryWithSafeFinallyAndFailureCallbacks(Utils.scala:1539)
	at org.apache.spark.internal.io.SparkHadoopWriter$.executeTask(SparkHadoopWriter.scala:135)
	at org.apache.spark.internal.io.SparkHadoopWriter$.$anonfun$write$1(SparkHadoopWriter.scala:88)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:136)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:548)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1505)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:551)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.lang.Thread.run(Thread.java:829)
Caused by: io.cdap.cdap.api.exception.ProgramFailureException: Error occurred in the phase: 'Writing' with sqlState: '23000', errorCode: '1', errorMessage: ORA-00001: unique constraint (C##BUILDUSER.PK_AGE) violated

https://docs.oracle.com/error-help/db/ora-00001/
	at io.cdap.cdap.api.exception.ProgramFailureException$Builder.build(ProgramFailureException.java:229)
	at io.cdap.cdap.api.exception.ErrorUtils.getProgramFailureException(ErrorUtils.java:198)
	at io.cdap.plugin.common.db.DBErrorDetailsProvider.getProgramFailureException(DBErrorDetailsProvider.java:196)
	at io.cdap.plugin.common.db.DBErrorDetailsProvider.getExceptionDetails(DBErrorDetailsProvider.java:170)
	at io.cdap.cdap.etl.common.ErrorDetails.handleException(ErrorDetails.java:75)
	... 14 common frames omitted
Caused by: java.sql.BatchUpdateException: ORA-00001: unique constraint (C##BUILDUSER.PK_AGE) violated

https://docs.oracle.com/error-help/db/ora-00001/
	at oracle.jdbc.driver.OraclePreparedStatement.generateBatchUpdateException(OraclePreparedStatement.java:10528)
	at oracle.jdbc.driver.OraclePreparedStatement.executeBatchWithoutQueue(OraclePreparedStatement.java:10171)
	at oracle.jdbc.driver.OraclePreparedStatement.executeLargeBatch(OraclePreparedStatement.java:10044)
	at oracle.jdbc.driver.OracleStatement.executeBatch(OracleStatement.java:5208)
	at oracle.jdbc.driver.OracleStatementWrapper.executeBatch(OracleStatementWrapper.java:288)
	at io.cdap.plugin.db.sink.ETLDBOutputFormat$1.close(ETLDBOutputFormat.java:99)
	at io.cdap.cdap.etl.spark.io.TrackingRecordWriter.close(TrackingRecordWriter.java:46)
	at io.cdap.cdap.etl.spark.io.StageTrackingRecordWriter.close(StageTrackingRecordWriter.java:65)
	... 13 common frames omitted
2025-01-29 04:09:03,114 - WARN  [Executor task launch worker for task 0.0 in stage 0.0 (TID 0):i.c.p.d.s.ETLDBOutputFormat@106] - java.sql.SQLRecoverableException: ORA-17008: Closed connection
https://docs.oracle.com/error-help/db/ora-17008/
	at oracle.jdbc.driver.PhysicalConnection.requireOpenConnection(PhysicalConnection.java:12507)
	at oracle.jdbc.driver.PhysicalConnection.getAutoCommit(PhysicalConnection.java:2640)
	at oracle.jdbc.driver.PhysicalConnection.rollback(PhysicalConnection.java:2768)
	at io.cdap.plugin.db.sink.ETLDBOutputFormat$1.close(ETLDBOutputFormat.java:104)
	at io.cdap.cdap.etl.spark.io.TrackingRecordWriter.close(TrackingRecordWriter.java:46)
	at io.cdap.cdap.etl.spark.io.StageTrackingRecordWriter.close(StageTrackingRecordWriter.java:65)
	at org.apache.spark.internal.io.HadoopMapReduceWriteConfigUtil.closeWriter(SparkHadoopWriter.scala:373)
	at org.apache.spark.internal.io.SparkHadoopWriter$.$anonfun$executeTask$2(SparkHadoopWriter.scala:150)
	at org.apache.spark.util.Utils$.tryWithSafeFinallyAndFailureCallbacks(Utils.scala:1550)
	at org.apache.spark.internal.io.SparkHadoopWriter$.executeTask(SparkHadoopWriter.scala:135)
	at org.apache.spark.internal.io.SparkHadoopWriter$.$anonfun$write$1(SparkHadoopWriter.scala:88)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:136)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:548)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1505)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:551)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)


  ```
</details>

<details>
  <summary>POST v3/namespaces/{namespace-id}/apps/{app-id}/workflows/DataPipelineWorkflow/runs/{run-id}/classify</summary>

  ```json
  [
    {
        "stageName": "Oracle2",
        "errorCategory": "Plugin-\u0027DB Integrity Constraint Violation\u0027-\u0027Oracle2\u0027",
        "errorReason": "ORA-00001: unique constraint (C##BUILDUSER.PK_AGE) violated\n\nhttps://docs.oracle.com/error-help/db/ora-00001/. For more details, see https://docs.oracle.com/en/error-help/db/ora-index.html",
        "errorMessage": "Error occurred in the phase: \u0027Writing\u0027 with sqlState: \u002723000\u0027, errorCode: \u00271\u0027, errorMessage: ORA-00001: unique constraint (C##BUILDUSER.PK_AGE) violated\n\nhttps://docs.oracle.com/error-help/db/ora-00001/",
        "errorType": "USER",
        "dependency": "true",
        "errorCodeType": "SQLSTATE",
        "errorCode": "23000",
        "supportedDocumentationUrl": "https://docs.oracle.com/en/error-help/db/ora-index.html"
    }
]
  ```
</details>

<img width="1164" alt="image" src="https://github.com/user-attachments/assets/74e0a3a3-ad6e-4eb4-b7c5-3ce832f147ed" />


[PLUGIN-1835]: https://cdap.atlassian.net/browse/PLUGIN-1835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ