### PR TITLE
[🍒][PLUGIN-1847] Add SqlServerErrorDetailsProvider

### DIFF
--- a/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
+++ b/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
@@ -61,6 +61,8 @@ public final class DBUtils {
 
   public static final Calendar PURE_GREGORIAN_CALENDAR = createPureGregorianCalender();
   public static final String MYSQL_SUPPORTED_DOC_URL = "https://dev.mysql.com/doc/mysql-errors/9.0/en/";
+  public static final String MSSQL_SUPPORTED_DOC_URL =
+    "https://docs.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors";
   public static final String CLOUDSQLMYSQL_SUPPORTED_DOC_URL = "https://cloud.google.com/sql/docs/mysql/error-messages";
   public static final String POSTGRES_SUPPORTED_DOC_URL =
     "https://www.postgresql.org/docs/current/errcodes-appendix.html";

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerErrorDetailsProvider.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerErrorDetailsProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.mssql;
+
+import io.cdap.plugin.common.db.DBErrorDetailsProvider;
+import io.cdap.plugin.util.DBUtils;
+
+/**
+ * A custom ErrorDetailsProvider for SQL Server plugins.
+ */
+public class SqlServerErrorDetailsProvider extends DBErrorDetailsProvider {
+
+  @Override
+  protected String getExternalDocumentationLink() {
+    return DBUtils.MSSQL_SUPPORTED_DOC_URL;
+  }
+}

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerSink.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerSink.java
@@ -88,6 +88,16 @@ public class SqlServerSink extends AbstractDBSink<SqlServerSink.SqlServerSinkCon
     return new LineageRecorder(context, asset);
   }
 
+  @Override
+  protected String getErrorDetailsProviderClassName() {
+    return SqlServerErrorDetailsProvider.class.getName();
+  }
+
+  @Override
+  protected String getExternalDocumentationLink() {
+    return DBUtils.MSSQL_SUPPORTED_DOC_URL;
+  }
+
   /**
    * MSSQL action configuration.
    */

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerSource.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerSource.java
@@ -76,6 +76,11 @@ public class SqlServerSource extends AbstractDBSource<SqlServerSource.SqlServerS
   }
 
   @Override
+  protected String getErrorDetailsProviderClassName() {
+    return SqlServerErrorDetailsProvider.class.getName();
+  }
+
+  @Override
   protected LineageRecorder getLineageRecorder(BatchSourceContext context) {
     String fqn = DBUtils.constructFQN("mssql",
                                       sqlServerSourceConfig.getConnection().getHost(),
@@ -84,6 +89,11 @@ public class SqlServerSource extends AbstractDBSource<SqlServerSource.SqlServerS
     Asset asset = Asset.builder(sqlServerSourceConfig.getReferenceName()).setFqn(fqn).build();
     return new LineageRecorder(context, asset);
   }
+
+ @Override
+ protected String getExternalDocumentationLink() {
+   return DBUtils.MSSQL_SUPPORTED_DOC_URL;
+ }
 
   /**
    * MSSQL source config.


### PR DESCRIPTION
🍒 [cherrypick]

### Commits :
 - 53cfd3af30e32290c7a327947cbf56538055b212

### PR:
 - #539 [ Reviewer @itsankit-google ]
 
---

## ErrorDetailsProvider - SqlServer [Source|Sink] plugin

Jira : [PLUGIN-1847](https://cdap.atlassian.net/browse/PLUGIN-1847)

### Description

Implement Program Failure Exception Handling in SqlServer Source/Sink plugin to catch known errors

### Code change

- Added `SqlServerErrorDetailsProvider.java`
- Modified `DBUtils.java`
- Modified `SqlServerSink.java`
- Modified `SqlServerSource.java`

###  Tests

 - Test Case (Violate check constrain)
  
<details>
  <summary>Raw Logs</summary>

  ```   

2025-01-29 09:20:32,606 - ERROR [Executor task launch worker for task 0.0 in stage 0.0 (TID 0):o.a.s.u.Utils@98] - Aborting task
io.cdap.cdap.api.exception.WrappedStageException: Stage 'SQL Server4' encountered : io.cdap.cdap.api.exception.ProgramFailureException: Error occurred in the phase: 'Writing' with sqlState: '23000', errorCode: '547', errorMessage: The INSERT statement conflicted with the CHECK constraint "CHK_Gender". The conflict occurred in database "master", table "dbo.users", column 'gender'.
	at io.cdap.cdap.etl.common.ErrorDetails.handleException(ErrorDetails.java:77)
	at io.cdap.cdap.etl.spark.io.StageTrackingRecordWriter.close(StageTrackingRecordWriter.java:67)
	at org.apache.spark.internal.io.HadoopMapReduceWriteConfigUtil.closeWriter(SparkHadoopWriter.scala:373)
	at org.apache.spark.internal.io.SparkHadoopWriter$.$anonfun$executeTask$1(SparkHadoopWriter.scala:145)
	at org.apache.spark.util.Utils$.tryWithSafeFinallyAndFailureCallbacks(Utils.scala:1538)
	at org.apache.spark.internal.io.SparkHadoopWriter$.executeTask(SparkHadoopWriter.scala:135)
	at org.apache.spark.internal.io.SparkHadoopWriter$.$anonfun$write$1(SparkHadoopWriter.scala:88)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:136)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:548)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1504)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:551)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
Caused by: io.cdap.cdap.api.exception.ProgramFailureException: Error occurred in the phase: 'Writing' with sqlState: '23000', errorCode: '547', errorMessage: The INSERT statement conflicted with the CHECK constraint "CHK_Gender". The conflict occurred in database "master", table "dbo.users", column 'gender'.
	at io.cdap.cdap.api.exception.ProgramFailureException$Builder.build(ProgramFailureException.java:229)
	at io.cdap.cdap.api.exception.ErrorUtils.getProgramFailureException(ErrorUtils.java:198)
	at io.cdap.plugin.common.db.DBErrorDetailsProvider.getProgramFailureException(DBErrorDetailsProvider.java:196)
	at io.cdap.plugin.common.db.DBErrorDetailsProvider.getExceptionDetails(DBErrorDetailsProvider.java:170)
	at io.cdap.cdap.etl.common.ErrorDetails.handleException(ErrorDetails.java:75)
	... 14 common frames omitted
Caused by: java.sql.BatchUpdateException: The INSERT statement conflicted with the CHECK constraint "CHK_Gender". The conflict occurred in database "master", table "dbo.users", column 'gender'.
	at com.microsoft.sqlserver.jdbc.SQLServerPreparedStatement.executeBatch(SQLServerPreparedStatement.java:2101)
	at io.cdap.plugin.db.sink.ETLDBOutputFormat$1.close(ETLDBOutputFormat.java:99)
	at io.cdap.cdap.etl.spark.io.TrackingRecordWriter.close(TrackingRecordWriter.java:46)
	at io.cdap.cdap.etl.spark.io.StageTrackingRecordWriter.close(StageTrackingRecordWriter.java:65)
	... 13 common frames omitted
2025-01-29 09:20:32,609 - WARN  [Executor task launch worker for task 0.0 in stage 0.0 (TID 0):i.c.p.d.s.ETLDBOutputFormat@106] - com.microsoft.sqlserver.jdbc.SQLServerException: The connection is closed.
	at com.microsoft.sqlserver.jdbc.SQLServerException.makeFromDriverError(SQLServerException.java:237)
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.checkClosed(SQLServerConnection.java:1369)
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.rollback(SQLServerConnection.java:3724)
	at io.cdap.plugin.db.sink.ETLDBOutputFormat$1.close(ETLDBOutputFormat.java:104)
	at io.cdap.cdap.etl.spark.io.TrackingRecordWriter.close(TrackingRecordWriter.java:46)
	at io.cdap.cdap.etl.spark.io.StageTrackingRecordWriter.close(StageTrackingRecordWriter.java:65)
	at org.apache.spark.internal.io.HadoopMapReduceWriteConfigUtil.closeWriter(SparkHadoopWriter.scala:373)
	at org.apache.spark.internal.io.SparkHadoopWriter$.$anonfun$executeTask$2(SparkHadoopWriter.scala:150)
	at org.apache.spark.util.Utils$.tryWithSafeFinallyAndFailureCallbacks(Utils.scala:1549)
	at org.apache.spark.internal.io.SparkHadoopWriter$.executeTask(SparkHadoopWriter.scala:135)
	at org.apache.spark.internal.io.SparkHadoopWriter$.$anonfun$write$1(SparkHadoopWriter.scala:88)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:136)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:548)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1504)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:551)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
	
  ```
</details>

<details>
  <summary>POST v3/namespaces/{namespace-id}/apps/{app-id}/workflows/DataPipelineWorkflow/runs/{run-id}/classify</summary>

  ```json
  
  [
  {
    "stageName": "SQL Server4",
    "errorCategory": "Plugin-'DB Integrity Constraint Violation'-'SQL Server4'",
    "errorReason": "The INSERT statement conflicted with the CHECK constraint \"CHK_Gender\". The conflict occurred in database \"master\", table \"dbo.users\", column 'gender'. For more details, see https://docs.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors",
    "errorMessage": "Error occurred in the phase: 'Writing' with sqlState: '23000', errorCode: '547', errorMessage: The INSERT statement conflicted with the CHECK constraint \"CHK_Gender\". The conflict occurred in database \"master\", table \"dbo.users\", column 'gender'.",
    "errorType": "USER",
    "dependency": "true",
    "errorCodeType": "SQLSTATE",
    "errorCode": "23000",
    "supportedDocumentationUrl": "https://docs.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors"
  }
]
  
  ```
</details>

![image](https://github.com/user-attachments/assets/a0a82d26-505f-4406-8520-309ebb770ad2)




[PLUGIN-1847]: https://cdap.atlassian.net/browse/PLUGIN-1847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ