### PR TITLE
e2e tests pipeline preview error fix

### DIFF
--- a/cloudsql-mysql-plugin/src/e2e-test/resources/errorMessage.properties
+++ b/cloudsql-mysql-plugin/src/e2e-test/resources/errorMessage.properties
@@ -15,7 +15,9 @@ errorMessageInvalidTableName=Table 'Invalidtable' does not exist. Ensure table '
 errorMessageConnectionName=Connection Name must be in the format <PROJECT_ID>:<REGION>:<INSTANCE_NAME> to connect to a public CloudSQL MySQL instance.
 validationSuccessMessage=No errors found.
 validationErrorMessage=COUNT ERROR found
-errorLogsMessageInvalidTableName=Spark program 'phase-1' failed with error: Errors were encountered during validation. \
-  Table 
-errorLogsMessageInvalidCredentials =Spark program 'phase-1' failed with error: Errors were encountered during validation.
-errorLogsMessageInvalidBoundingQuery=Spark program 'phase-1' failed with error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'table' at line 1. Please check the system logs for more details.
+errorLogsMessageInvalidTableName=Spark program 'phase-1' failed with error: Stage 'CloudSQL MySQL' encountered : io.cdap.cdap.etl.api.validation.ValidationException: Errors were encountered during validation. \
+  Table 'Table123' does not exist.. Please check the system logs for more details.
+errorLogsMessageInvalidCredentials =Spark program 'phase-1' failed with error: Stage 'CloudSQL MySQL' encountered : io.cdap.cdap.etl.api.validation.ValidationException: Errors were encountered during validation. \
+  Exception while trying to validate schema of database table 
+errorLogsMessageInvalidBoundingQuery=Spark program 'phase-1' failed with error: Stage 'CloudSQL MySQL' encountered : java.io.IOException: You have an error in your SQL syntax; \
+  check the manual that corresponds to your MySQL server version for the right syntax to use near 'table' at line 1. Please check the system logs for more details.

--- a/mssql-plugin/src/e2e-test/resources/errorMessage.properties
+++ b/mssql-plugin/src/e2e-test/resources/errorMessage.properties
@@ -13,11 +13,11 @@ errorMessagenumofSplit=Split-By Field Name must be specified if Number of Splits
 errorMessageInvalidSinkDatabase=Exception while trying to validate schema of database table
 errorMessageInvalidSinkTableName=Table 'Table123@' does not exist.
 errormessageBlankHost=Exception while trying to validate schema of database table
-errorMessageInvalidTableName=Spark program 'phase-1' failed with error: Errors were encountered during validation. \
-  Table 'Table123@' does not exist.. Please check the system logs for more details.
+errorMessageInvalidTableName=Spark program 'phase-1' failed with error: Stage 'SQL Server2' encountered : io.cdap.cdap.etl.api.validation.ValidationException: \
+  Errors were encountered during validation. Table 'Table123@' does not exist.. Please check the system logs for more details.
 errorMessageInvalidCredentials=Spark program 'phase-1' failed with error: Unable to create config for batchsink SqlServer \
   'connection' is invalid: Failed to assign value
-errorMessageInvalidsourcetable=Spark program 'phase-1' failed with error: Incorrect syntax near the keyword 'table'.. \
-  Please check the system logs for more details.
-errorMessageInvalidCredentialSource=Spark program 'phase-1' failed with error: Plugin with id SQL \
-  Server:source.jdbc.sqlserver does not exist in program phase-1 of application
+errorMessageInvalidsourcetable=Spark program 'phase-1' failed with error: Stage 'SQL Server' encountered : io.cdap.cdap.api.exception.ProgramFailureException: \
+  Error occurred while trying to get schema from database.Error message: 'Incorrect syntax near the keyword 'table'.'. 
+errorMessageInvalidCredentialSource=Spark program 'phase-1' failed with error: Stage 'SQL Server' encountered : java.lang.IllegalArgumentException: \
+  Plugin with id SQL Server:source.jdbc.sqlserver does not exist in program phase-1 of application 

--- a/mysql-plugin/src/e2e-test/features/mysqlsource/RunTime.feature
+++ b/mysql-plugin/src/e2e-test/features/mysqlsource/RunTime.feature
@@ -142,7 +142,7 @@ Feature: MySQL Source - Run time scenarios
     Then Close the Plugin Properties page
     Then Save the pipeline
     Then Preview and run the pipeline
-    Then Wait till pipeline preview is in running state
+    Then Wait till pipeline preview is in running state and check if any error occurs
     Then Open and capture pipeline preview logs
     Then Verify the preview run status of pipeline in the logs is "failed"
 

--- a/oracle-plugin/src/e2e-test/features/source/OracleRunTime.feature
+++ b/oracle-plugin/src/e2e-test/features/source/OracleRunTime.feature
@@ -296,7 +296,7 @@ Feature: Oracle - Verify data transfer from Oracle source to BigQuery sink
     Then Close the Plugin Properties page
     Then Save the pipeline
     Then Preview and run the pipeline
-    Then Wait till pipeline preview is in running state
+    Then Wait till pipeline preview is in running state and check if any error occurs
     Then Verify the preview run status of pipeline in the logs is "failed"
 
   @ORACLE_SOURCE_TEST @BQ_SINK_TEST

--- a/oracle-plugin/src/e2e-test/resources/errorMessage.properties
+++ b/oracle-plugin/src/e2e-test/resources/errorMessage.properties
@@ -15,7 +15,7 @@ errorMessageBlankUsername=Username is required when password is given.
 errorMessageInvalidTableName=Exception while trying to validate schema of database table '"table"' for connection
 errorMessageInvalidSinkDatabase=Exception while trying to validate schema of database table '"TARGETTABLE_
 errorMessageInvalidHost=Exception while trying to validate schema of database table '"table"' for connection
-errorLogsMessageInvalidBoundingQuery=Spark program 'phase-1' failed with error: ORA-00936: missing expression . \
-  Please check the system logs for more details.
+errorLogsMessageInvalidBoundingQuery=Spark program 'phase-1' failed with error: Stage 'Oracle' encountered : \
+  java.io.IOException: ORA-00936: missing expression . Please check the system logs for more details.
 blank.database.message=Required property 'database' has no value.
 blank.connection.message=Exception while trying to validate schema of database table 

--- a/postgresql-plugin/src/e2e-test/resources/errorMessage.properties
+++ b/postgresql-plugin/src/e2e-test/resources/errorMessage.properties
@@ -18,5 +18,5 @@ errorMessageInvalidSourceHost=SQL error while getting query schema: The connecti
 errorMessageInvalidTableName=Table 'table' does not exist. Ensure table '"table"' is set correctly and that the
 errorMessageInvalidSinkDatabase=Exception while trying to validate schema of database table '"targettable_
 errorMessageInvalidHost=Exception while trying to validate schema of database table '"table"' for connection 
-errorLogsMessageInvalidBoundingQuery=Spark program 'phase-1' failed with error: The column index is out of range: 1, \
-  number of columns: 0.. Please check the system logs for more details.
+errorLogsMessageInvalidBoundingQuery=Spark program 'phase-1' failed with error: Stage 'PostgreSQL' encountered : \
+  java.io.IOException: The column index is out of range: 1, number of columns: 0.. Please check the system logs for more details.


### PR DESCRIPTION
Added new step in scenarios when pipeline preview fails with error details. Fix for MySQL and Oracle e2e tests build failures along with the changes in error messages.