### PR TITLE
Bump 1.12.1-SNAPSHOT

### DIFF
--- a/amazon-redshift-plugin/pom.xml
+++ b/amazon-redshift-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.0</version>
+    <version>1.12.1-SNAPSHOT</version>
   </parent>
 
   <name>Amazon Redshift plugin</name>

--- a/aurora-mysql-plugin/pom.xml
+++ b/aurora-mysql-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.0</version>
+    <version>1.12.1-SNAPSHOT</version>
   </parent>
 
   <name>Aurora DB MySQL plugin</name>

--- a/aurora-postgresql-plugin/pom.xml
+++ b/aurora-postgresql-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.0</version>
+    <version>1.12.1-SNAPSHOT</version>
   </parent>
 
   <name>Aurora DB PostgreSQL plugin</name>

--- a/cloudsql-mysql-plugin/pom.xml
+++ b/cloudsql-mysql-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.0</version>
+    <version>1.12.1-SNAPSHOT</version>
   </parent>
 
   <name>CloudSQL MySQL plugin</name>
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>io.cdap.plugin</groupId>
       <artifactId>mysql-plugin</artifactId>
-      <version>1.12.0</version>
+      <version>${project.version}</version>
     </dependency>
 
     <!-- test dependencies -->

--- a/cloudsql-postgresql-plugin/pom.xml
+++ b/cloudsql-postgresql-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.0</version>
+    <version>1.12.1-SNAPSHOT</version>
   </parent>
 
   <name>CloudSQL PostgreSQL plugin</name>

--- a/database-commons/pom.xml
+++ b/database-commons/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.0</version>
+    <version>1.12.1-SNAPSHOT</version>
   </parent>
 
   <name>Database Commons</name>

--- a/db2-plugin/pom.xml
+++ b/db2-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.0</version>
+    <version>1.12.1-SNAPSHOT</version>
   </parent>
 
   <name>IBM DB2 plugin</name>

--- a/generic-database-plugin/pom.xml
+++ b/generic-database-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.0</version>
+    <version>1.12.1-SNAPSHOT</version>
   </parent>
 
   <name>Generic database plugin</name>

--- a/generic-db-argument-setter/pom.xml
+++ b/generic-db-argument-setter/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.0</version>
+    <version>1.12.1-SNAPSHOT</version>
   </parent>
 
   <name>Generic database argument setter plugin</name>

--- a/mariadb-plugin/pom.xml
+++ b/mariadb-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>database-plugins-parent</artifactId>
         <groupId>io.cdap.plugin</groupId>
-        <version>1.12.0</version>
+        <version>1.12.1-SNAPSHOT</version>
     </parent>
 
     <name>Maria DB plugin</name>

--- a/memsql-plugin/pom.xml
+++ b/memsql-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.0</version>
+    <version>1.12.1-SNAPSHOT</version>
   </parent>
 
   <name>Memsql plugin</name>

--- a/mssql-plugin/pom.xml
+++ b/mssql-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.0</version>
+    <version>1.12.1-SNAPSHOT</version>
   </parent>
 
   <name>Microsoft SQL Server plugin</name>

--- a/mysql-plugin/pom.xml
+++ b/mysql-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.0</version>
+    <version>1.12.1-SNAPSHOT</version>
   </parent>
 
   <name>Mysql plugin</name>

--- a/netezza-plugin/pom.xml
+++ b/netezza-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.0</version>
+    <version>1.12.1-SNAPSHOT</version>
   </parent>
 
   <name>Netezza plugin</name>

--- a/oracle-plugin/pom.xml
+++ b/oracle-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.0</version>
+    <version>1.12.1-SNAPSHOT</version>
   </parent>
 
   <name>Oracle plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>database-plugins-parent</artifactId>
-  <version>1.12.0</version>
+  <version>1.12.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Database Plugins</name>
   <description>Collection of database plugins</description>

--- a/postgresql-plugin/pom.xml
+++ b/postgresql-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.0</version>
+    <version>1.12.1-SNAPSHOT</version>
   </parent>
 
   <name>PostgreSQL plugin</name>

--- a/saphana-plugin/pom.xml
+++ b/saphana-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.0</version>
+    <version>1.12.1-SNAPSHOT</version>
   </parent>
 
   <name>SAP HANA plugin</name>

--- a/teradata-plugin/pom.xml
+++ b/teradata-plugin/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.0</version>
+    <version>1.12.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>teradata-plugin</artifactId>


### PR DESCRIPTION
Bump 1.12.1-SNAPSHOT

---

In `cloudsql-mysql-plugin/pom.xml` change hard coded dependency (mysql-plugin) version to `${project.version}`
