### PR TITLE
[🍒][PLUGIN-1873] Error Management AbstractDBAction

### DIFF
--- a/database-commons/src/main/java/io/cdap/plugin/db/action/AbstractDBAction.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/action/AbstractDBAction.java
@@ -16,12 +16,15 @@
 
 package io.cdap.plugin.db.action;
 
+import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.action.Action;
 import io.cdap.cdap.etl.api.action.ActionContext;
+import io.cdap.plugin.common.db.DBErrorDetailsProvider;
 import io.cdap.plugin.util.DBUtils;
 
 import java.sql.Driver;
+import java.sql.SQLException;
 
 /**
  * Action that runs a db command.
@@ -40,7 +43,18 @@ public abstract class AbstractDBAction extends Action {
   public void run(ActionContext context) throws Exception {
     Class<? extends Driver> driverClass = context.loadPluginClass(JDBC_PLUGIN_ID);
     DBRun executeQuery = new DBRun(config, driverClass, enableAutoCommit);
-    executeQuery.run();
+    try {
+      executeQuery.run();
+    } catch (Exception e) {
+      if (e instanceof SQLException) {
+        DBErrorDetailsProvider dbe = new DBErrorDetailsProvider();
+        throw dbe.getProgramFailureException((SQLException) e, null);
+      }
+      FailureCollector collector = context.getFailureCollector();
+      collector.addFailure("Failed to execute query with message: " + e.getMessage(), null)
+          .withStacktrace(e.getStackTrace());
+      collector.getOrThrowException();
+    }
   }
 
   @Override


### PR DESCRIPTION
🍒 [cherrypick]

### Commits :
 - 9b368503054ab587861f65909f0c9c71a5793912 

### PR:
 -  #568 [ Reviewer @itsankit-google ]
 
 ---
 
 https://cdap.atlassian.net/browse/PLUGIN-1873

Ref: https://github.com/cdapio/hydrator-plugins/pull/1956

```java
    try {
      executeQuery.run();
    } catch (Exception e) {
      if (e instanceof SQLException) {
        DBErrorDetailsProvider dbe = new DBErrorDetailsProvider();
        throw dbe.getProgramFailureException((SQLException) e, null);
      }
      FailureCollector collector = context.getFailureCollector();
      collector.addFailure("Failed to execute query with message: " + e.getMessage(), null)
          .withStacktrace(e.getStackTrace());
      collector.getOrThrowException();
    }
```

![image](https://github.com/user-attachments/assets/d3b41574-5c25-4bc9-935c-d9af46ec8782)

```json
[
  {
    "stageName": "SQL Server Execute",
    "errorCategory": "Plugin-'SQL Server Execute'",
    "errorReason": "SQL Exception occurred: [Message='String or binary data would be truncated in table 'master.dbo.usernames', column 'name'. Truncated value: 'TEST1'.', SQLState='S0001', ErrorCode='2628']. For more details, see https://en.wikipedia.org/wiki/SQLSTATE",
    "errorMessage": "SQL Error occurred, sqlState: 'S0001', errorCode: '2628', errorMessage: SQL Exception occurred: [Message='String or binary data would be truncated in table 'master.dbo.usernames', column 'name'. Truncated value: 'TEST1'.', SQLState='S0001', ErrorCode='2628'].",
    "errorType": "UNKNOWN",
    "dependency": "true",
    "errorCodeType": "SQLSTATE",
    "errorCode": "S0001",
    "supportedDocumentationUrl": "https://en.wikipedia.org/wiki/SQLSTATE"
  }
]
```

