### PR TITLE
[PLUGIN-1885] Add MariadbErrorDetailsProvider

### DIFF
--- a/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
+++ b/database-commons/src/main/java/io/cdap/plugin/util/DBUtils.java
@@ -61,6 +61,7 @@ public final class DBUtils {
 
   public static final Calendar PURE_GREGORIAN_CALENDAR = createPureGregorianCalender();
   public static final String MYSQL_SUPPORTED_DOC_URL = "https://dev.mysql.com/doc/mysql-errors/9.0/en/";
+  public static final String MARIADB_SUPPORTED_DOC_URL = "https://mariadb.com/kb/en/mariadb-error-codes/";
   public static final String MSSQL_SUPPORTED_DOC_URL =
     "https://docs.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors";
   public static final String CLOUDSQLMYSQL_SUPPORTED_DOC_URL = "https://cloud.google.com/sql/docs/mysql/error-messages";

--- a/mariadb-plugin/src/main/java/io/cdap/plugin/mariadb/MariadbErrorDetailsProvider.java
+++ b/mariadb-plugin/src/main/java/io/cdap/plugin/mariadb/MariadbErrorDetailsProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.mariadb;
+
+
+import io.cdap.plugin.mysql.MysqlErrorDetailsProvider;
+import io.cdap.plugin.util.DBUtils;
+
+/**
+ * A custom ErrorDetailsProvider for MariaDb plugins.
+ */
+public class MariadbErrorDetailsProvider extends MysqlErrorDetailsProvider {
+
+  @Override
+  protected String getExternalDocumentationLink() {
+    return DBUtils.MARIADB_SUPPORTED_DOC_URL;
+  }
+
+}

--- a/mariadb-plugin/src/main/java/io/cdap/plugin/mariadb/MariadbSink.java
+++ b/mariadb-plugin/src/main/java/io/cdap/plugin/mariadb/MariadbSink.java
@@ -25,8 +25,8 @@ import io.cdap.plugin.db.DBRecord;
 import io.cdap.plugin.db.SchemaReader;
 import io.cdap.plugin.db.config.DBSpecificSinkConfig;
 import io.cdap.plugin.db.sink.AbstractDBSink;
+import io.cdap.plugin.util.DBUtils;
 
-import io.cdap.plugin.mysql.MysqlDBRecord;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -59,6 +59,16 @@ public class MariadbSink extends AbstractDBSink<MariadbSink.MariadbSinkConfig> {
     return new MariadbSchemaReader(null);
   }
 
+
+  @Override
+  protected String getErrorDetailsProviderClassName() {
+    return MariadbErrorDetailsProvider.class.getName();
+  }
+
+  @Override
+  protected String getExternalDocumentationLink() {
+    return DBUtils.MARIADB_SUPPORTED_DOC_URL;
+  }
 
   /**
    * MariaDB Sink Config.

--- a/mariadb-plugin/src/main/java/io/cdap/plugin/mariadb/MariadbSource.java
+++ b/mariadb-plugin/src/main/java/io/cdap/plugin/mariadb/MariadbSource.java
@@ -81,6 +81,16 @@ public class MariadbSource extends AbstractDBSource<MariadbSource.MariadbSourceC
     return new MariadbSchemaReader(null, mariadbSourceConfig.getConnectionArguments());
   }
 
+  @Override
+  protected String getErrorDetailsProviderClassName() {
+    return MariadbErrorDetailsProvider.class.getName();
+  }
+
+  @Override
+  protected String getExternalDocumentationLink() {
+    return DBUtils.MARIADB_SUPPORTED_DOC_URL;
+  }
+
   /**
    * MaraiDB source mariadbSourceConfig.
    */


### PR DESCRIPTION
## ErrorDetailsProvider - Mariadb [Source|Sink] plugin

Jira : [PLUGIN-1885](https://cdap.atlassian.net/browse/PLUGIN-1885)

### Description

Implement Program Failure Exception Handling in Mariadb Source/Sink plugin to catch known errors

### Code change

- Added `MariadbErrorDetailsProvider.java`
- Modified `DBUtils.java`
- Modified `MariadbSink.java`
- Modified `MariadbSource.java`

###  Tests

- Sanity (file source to mariadb sink)

![image](https://github.com/user-attachments/assets/53f60800-a0f7-452f-9db8-7b9e42679bbb)



 - Test Case (Violate check constrain)
 
- Table Used

```sql
-- Create the users table
CREATE TABLE users (
    name VARCHAR(100) NOT NULL,
    age INT NOT NULL,
    gender ENUM('male', 'female') NOT NULL,
    CHECK (gender IN ('male', 'female'))
);

-- Insert two records into the users table
INSERT INTO users (name, age, gender) VALUES ('John Doe', 30, 'male');
INSERT INTO users (name, age, gender) VALUES ('Jane Smith', 25, 'female');
```
  
<details>
  <summary>Raw Logs</summary>

  ```   
2025-04-15 17:59:02,041 - ERROR [Executor task launch worker for task 0.0 in stage 0.0 (TID 0):o.a.s.u.Utils@98] - Aborting task
io.cdap.cdap.api.exception.WrappedStageException: Stage 'MariaDB' encountered : io.cdap.cdap.api.exception.ProgramFailureException: Error occurred in the phase: 'Writing' with sqlState: '01000', errorCode: '1265', errorMessage: SQL Exception occurred: [Message='(conn=55) Data truncated for column 'gender' at row 1', SQLState='01000', ErrorCode='1265'].
	at io.cdap.cdap.etl.common.ErrorDetails.handleException(ErrorDetails.java:77)
	at io.cdap.cdap.etl.spark.io.StageTrackingRecordWriter.close(StageTrackingRecordWriter.java:67)
	at org.apache.spark.internal.io.HadoopMapReduceWriteConfigUtil.closeWriter(SparkHadoopWriter.scala:373)
	at org.apache.spark.internal.io.SparkHadoopWriter$.$anonfun$executeTask$1(SparkHadoopWriter.scala:145)
	at org.apache.spark.util.Utils$.tryWithSafeFinallyAndFailureCallbacks(Utils.scala:1538)
	at org.apache.spark.internal.io.SparkHadoopWriter$.executeTask(SparkHadoopWriter.scala:135)
	at org.apache.spark.internal.io.SparkHadoopWriter$.$anonfun$write$1(SparkHadoopWriter.scala:88)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:136)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:548)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1504)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:551)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
Caused by: io.cdap.cdap.api.exception.ProgramFailureException: Error occurred in the phase: 'Writing' with sqlState: '01000', errorCode: '1265', errorMessage: SQL Exception occurred: [Message='(conn=55) Data truncated for column 'gender' at row 1', SQLState='01000', ErrorCode='1265'].
	at io.cdap.cdap.api.exception.ProgramFailureException$Builder.build(ProgramFailureException.java:229)
	at io.cdap.cdap.api.exception.ErrorUtils.getProgramFailureException(ErrorUtils.java:198)
	at io.cdap.plugin.common.db.DBErrorDetailsProvider.getProgramFailureException(DBErrorDetailsProvider.java:202)
	at io.cdap.plugin.common.db.DBErrorDetailsProvider.getExceptionDetails(DBErrorDetailsProvider.java:172)
	at io.cdap.cdap.etl.common.ErrorDetails.handleException(ErrorDetails.java:75)
	... 14 common frames omitted
Caused by: java.sql.BatchUpdateException: (conn=55) Data truncated for column 'gender' at row 1
	at org.mariadb.jdbc.export.ExceptionFactory.createBatchUpdate(ExceptionFactory.java:181)
	at org.mariadb.jdbc.BasePreparedStatement.executeBatchBulk(BasePreparedStatement.java:1956)
	at org.mariadb.jdbc.ClientPreparedStatement.executeInternalPreparedBatch(ClientPreparedStatement.java:137)
	at org.mariadb.jdbc.BasePreparedStatement.executeBatchInternal(BasePreparedStatement.java:1694)
	at org.mariadb.jdbc.BasePreparedStatement.executeBatch(BasePreparedStatement.java:1680)
	at io.cdap.plugin.db.sink.ETLDBOutputFormat$1.close(ETLDBOutputFormat.java:99)
	at io.cdap.cdap.etl.spark.io.TrackingRecordWriter.close(TrackingRecordWriter.java:46)
	at io.cdap.cdap.etl.spark.io.StageTrackingRecordWriter.close(StageTrackingRecordWriter.java:65)
	... 13 common frames omitted
Caused by: java.sql.BatchUpdateException: (conn=55) Data truncated for column 'gender' at row 1
	at org.mariadb.jdbc.export.ExceptionFactory.createBatchUpdate(ExceptionFactory.java:221)
	at org.mariadb.jdbc.client.impl.StandardClient.executePipeline(StandardClient.java:1129)
	at org.mariadb.jdbc.BasePreparedStatement.executeBatchBulk(BasePreparedStatement.java:1923)
	... 19 common frames omitted
Caused by: java.sql.SQLTransientConnectionException: (conn=55) Data truncated for column 'gender' at row 1
	at org.mariadb.jdbc.export.ExceptionFactory.createException(ExceptionFactory.java:309)
	at org.mariadb.jdbc.export.ExceptionFactory.create(ExceptionFactory.java:378)
	at org.mariadb.jdbc.message.ClientMessage.readPacket(ClientMessage.java:187)
	at org.mariadb.jdbc.client.impl.StandardClient.readPacket(StandardClient.java:1364)
	at org.mariadb.jdbc.client.impl.StandardClient.readResults(StandardClient.java:1303)
	at org.mariadb.jdbc.client.impl.StandardClient.readResponse(StandardClient.java:1222)
	at org.mariadb.jdbc.client.impl.StandardClient.executePipeline(StandardClient.java:1062)
	... 20 common frames omitted
2025-04-15 17:59:02,043 - WARN  [Executor task launch worker for task 0.0 in stage 0.0 (TID 0):i.c.p.d.s.ETLDBOutputFormat@106] - java.sql.SQLNonTransientConnectionException: (conn=55) Connection is closed
	at org.mariadb.jdbc.export.ExceptionFactory.createException(ExceptionFactory.java:300)
	at org.mariadb.jdbc.export.ExceptionFactory.create(ExceptionFactory.java:378)
	at org.mariadb.jdbc.Connection.checkNotClosed(Connection.java:700)
	at org.mariadb.jdbc.Connection.rollback(Connection.java:234)
	at io.cdap.plugin.db.sink.ETLDBOutputFormat$1.close(ETLDBOutputFormat.java:104)
	at io.cdap.cdap.etl.spark.io.TrackingRecordWriter.close(TrackingRecordWriter.java:46)
	at io.cdap.cdap.etl.spark.io.StageTrackingRecordWriter.close(StageTrackingRecordWriter.java:65)
	at org.apache.spark.internal.io.HadoopMapReduceWriteConfigUtil.closeWriter(SparkHadoopWriter.scala:373)
	at org.apache.spark.internal.io.SparkHadoopWriter$.$anonfun$executeTask$2(SparkHadoopWriter.scala:150)
	at org.apache.spark.util.Utils$.tryWithSafeFinallyAndFailureCallbacks(Utils.scala:1549)
	at org.apache.spark.internal.io.SparkHadoopWriter$.executeTask(SparkHadoopWriter.scala:135)
	at org.apache.spark.internal.io.SparkHadoopWriter$.$anonfun$write$1(SparkHadoopWriter.scala:88)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:136)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:548)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1504)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:551)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)

  ```
</details>

<details>
  <summary>POST v3/namespaces/{namespace-id}/apps/{app-id}/workflows/DataPipelineWorkflow/runs/{run-id}/classify</summary>

  ```json
[
  {
    "stageName": "MariaDB",
    "errorCategory": "Plugin-'DB Warning'-'MariaDB'",
    "errorReason": "SQL Exception occurred: [Message='(conn=55) Data truncated for column 'gender' at row 1', SQLState='01000', ErrorCode='1265']. For more details, see https://mariadb.com/kb/en/mariadb-error-codes/",
    "errorMessage": "Error occurred in the phase: 'Writing' with sqlState: '01000', errorCode: '1265', errorMessage: SQL Exception occurred: [Message='(conn=55) Data truncated for column 'gender' at row 1', SQLState='01000', ErrorCode='1265'].",
    "errorType": "USER",
    "dependency": "true",
    "errorCodeType": "SQLSTATE",
    "errorCode": "01000",
    "supportedDocumentationUrl": "https://mariadb.com/kb/en/mariadb-error-codes/"
  }
]
  ```
</details>


![image](https://github.com/user-attachments/assets/2e8b2f86-57e8-43d9-9147-8c875ab5dbfb)



[PLUGIN-1885]: https://cdap.atlassian.net/browse/PLUGIN-1885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ