### PR TITLE
[cherrypick][PLUGIN-1779] Add TRANSACTION_ISOLATION_LEVEL config in MySQL, PostgreSQL & SQL Server plugins to support 6.9.x release

### DIFF
--- a/.github/workflows/build-report.yml
+++ b/.github/workflows/build-report.yml
@@ -21,6 +21,11 @@ on:
     types:
     - completed
 
+permissions:
+  actions: read    # Allows reading workflow run information
+  statuses: write  # Required if the action updates commit statuses
+  checks: write    # Required if it updates GitHub Checks API
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,12 +37,12 @@ jobs:
          && (github.event.action != 'labeled' || github.event.label.name == 'build')
          )
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ github.workflow }}-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,9 +16,9 @@ name: Build e2e tests
 
 on:
   push:
-    branches: [ develop, release/* ]
+    branches: [ develop, release/** ]
   pull_request:
-      branches: [ develop, release/* ]
+      branches: [ develop, release/** ]
       types: [ opened, synchronize, reopened, labeled ]
   workflow_dispatch:
 
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       # Pinned 1.0.0 version
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: plugin
           submodules: 'recursive'
@@ -61,14 +61,14 @@ jobs:
               - '${{ matrix.module }}/**/e2e-test/**'
 
       - name: Checkout e2e test repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: cdapio/cdap-e2e-tests
           path: e2e
           ref: release/6.10
 
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ github.workflow }}-${{ hashFiles('**/pom.xml') }}
@@ -96,6 +96,12 @@ jobs:
             POSTGRESQL_USERNAME:cdapio-github-builds/POSTGRESQL_USERNAME
             POSTGRESQL_PASSWORD:cdapio-github-builds/POSTGRESQL_PASSWORD
             POSTGRESQL_PORT:cdapio-github-builds/POSTGRESQL_PORT
+            CLOUDSQL_POSTGRESQL_USERNAME:cdapio-github-builds/CLOUDSQL_POSTGRESQL_USERNAME
+            CLOUDSQL_POSTGRESQL_PASSWORD:cdapio-github-builds/CLOUDSQL_POSTGRESQL_PASSWORD
+            CLOUDSQL_POSTGRESQL_CONNECTION_NAME:cdapio-github-builds/CLOUDSQL_POSTGRESQL_CONNECTION_NAME
+            CLOUDSQL_MYSQL_USERNAME:cdapio-github-builds/CLOUDSQL_MYSQL_USERNAME
+            CLOUDSQL_MYSQL_PASSWORD:cdapio-github-builds/CLOUDSQL_MYSQL_PASSWORD
+            CLOUDSQL_MYSQL_CONNECTION_NAME:cdapio-github-builds/CLOUDSQL_MYSQL_CONNECTION_NAME
 
       - name: Run required e2e tests
         if: github.event_name != 'workflow_dispatch' && github.event_name != 'push' && steps.filter.outputs.e2e-test == 'false'
@@ -117,6 +123,12 @@ jobs:
           POSTGRESQL_USERNAME: ${{ steps.secrets.outputs.POSTGRESQL_USERNAME }}
           POSTGRESQL_PASSWORD: ${{ steps.secrets.outputs.POSTGRESQL_PASSWORD }}
           POSTGRESQL_PORT: ${{ steps.secrets.outputs.POSTGRESQL_PORT }}
+          CLOUDSQL_POSTGRESQL_USERNAME: ${{ steps.secrets.outputs.CLOUDSQL_POSTGRESQL_USERNAME }}
+          CLOUDSQL_POSTGRESQL_PASSWORD: ${{ steps.secrets.outputs.CLOUDSQL_POSTGRESQL_PASSWORD }}
+          CLOUDSQL_POSTGRESQL_CONNECTION_NAME: ${{ steps.secrets.outputs.CLOUDSQL_POSTGRESQL_CONNECTION_NAME }}
+          CLOUDSQL_MYSQL_USERNAME: ${{ steps.secrets.outputs.CLOUDSQL_MYSQL_USERNAME }}
+          CLOUDSQL_MYSQL_PASSWORD: ${{ steps.secrets.outputs.CLOUDSQL_MYSQL_PASSWORD }}
+          CLOUDSQL_MYSQL_CONNECTION_NAME: ${{ steps.secrets.outputs.CLOUDSQL_MYSQL_CONNECTION_NAME }}
 
       - name: Run all e2e tests
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || steps.filter.outputs.e2e-test == 'true'
@@ -138,25 +150,28 @@ jobs:
           POSTGRESQL_USERNAME: ${{ steps.secrets.outputs.POSTGRESQL_USERNAME }}
           POSTGRESQL_PASSWORD: ${{ steps.secrets.outputs.POSTGRESQL_PASSWORD }}
           POSTGRESQL_PORT: ${{ steps.secrets.outputs.POSTGRESQL_PORT }}
-
-      - name: Upload report
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: Cucumber report - ${{ matrix.module }}
-          path: ./**/target/cucumber-reports
+          CLOUDSQL_POSTGRESQL_USERNAME: ${{ steps.secrets.outputs.CLOUDSQL_POSTGRESQL_USERNAME }}
+          CLOUDSQL_POSTGRESQL_PASSWORD: ${{ steps.secrets.outputs.CLOUDSQL_POSTGRESQL_PASSWORD }}
+          CLOUDSQL_POSTGRESQL_CONNECTION_NAME: ${{ steps.secrets.outputs.CLOUDSQL_POSTGRESQL_CONNECTION_NAME }}
+          CLOUDSQL_MYSQL_USERNAME: ${{ steps.secrets.outputs.CLOUDSQL_MYSQL_USERNAME }}
+          CLOUDSQL_MYSQL_PASSWORD: ${{ steps.secrets.outputs.CLOUDSQL_MYSQL_PASSWORD }}
+          CLOUDSQL_MYSQL_CONNECTION_NAME: ${{ steps.secrets.outputs.CLOUDSQL_MYSQL_CONNECTION_NAME }}
 
       - name: Upload debug files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Debug files - ${{ matrix.module }}
           path: ./**/target/e2e-debug
 
       - name: Upload files to GCS
-        uses: google-github-actions/upload-cloud-storage@v0
+        uses: google-github-actions/upload-cloud-storage@v2
         if: always()
         with:
           path: ./plugin
           destination: e2e-tests-cucumber-reports/${{ github.event.repository.name }}/${{ github.ref }}
           glob: '**/target/cucumber-reports/**'
+
+      - name: Cucumber Report URL
+        if: always()
+        run: echo "https://storage.googleapis.com/e2e-tests-cucumber-reports/${{ github.event.repository.name }}/${{ github.ref }}/plugin/${{ matrix.module }}/target/cucumber-reports/advanced-reports/cucumber-html-reports/overview-features.html"

--- a/database-commons/src/main/java/io/cdap/plugin/db/ConnectionConfig.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/ConnectionConfig.java
@@ -45,6 +45,7 @@ public abstract class ConnectionConfig extends PluginConfig implements DatabaseC
   public static final String CONNECTION_ARGUMENTS = "connectionArguments";
   public static final String JDBC_PLUGIN_NAME = "jdbcPluginName";
   public static final String JDBC_PLUGIN_TYPE = "jdbc";
+  public static final String TRANSACTION_ISOLATION_LEVEL = "transactionIsolationLevel";
 
   @Name(JDBC_PLUGIN_NAME)
   @Description("Name of the JDBC driver to use. This is the value of the 'jdbcPluginName' key defined in the JSON " +

--- a/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnectorConfig.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnectorConfig.java
@@ -20,8 +20,9 @@ import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.plugin.db.ConnectionConfig;
+import io.cdap.plugin.db.TransactionIsolationLevel;
 
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -42,6 +43,12 @@ public abstract class AbstractDBSpecificConnectorConfig extends AbstractDBConnec
   @Nullable
   protected Integer port;
 
+  @Name(ConnectionConfig.TRANSACTION_ISOLATION_LEVEL)
+  @Description("The transaction isolation level for the database session.")
+  @Macro
+  @Nullable
+  protected String transactionIsolationLevel;
+
   public String getHost() {
     return host;
   }
@@ -55,4 +62,21 @@ public abstract class AbstractDBSpecificConnectorConfig extends AbstractDBConnec
   public boolean canConnect() {
     return super.canConnect() && !containsMacro(ConnectionConfig.HOST) && !containsMacro(ConnectionConfig.PORT);
   }
+
+  @Override
+  public Map<String, String> getAdditionalArguments() {
+    Map<String, String> additonalArguments = new HashMap<>();
+    if (getTransactionIsolationLevel() != null) {
+      additonalArguments.put(TransactionIsolationLevel.CONF_KEY, getTransactionIsolationLevel());
+    }
+    return additonalArguments;
+  }
+
+  public String getTransactionIsolationLevel() {
+    if (transactionIsolationLevel == null) {
+      return null;
+    }
+    return TransactionIsolationLevel.Level.valueOf(transactionIsolationLevel).name();
+  }
 }
+

--- a/mssql-plugin/docs/SQL Server-connector.md
+++ b/mssql-plugin/docs/SQL Server-connector.md
@@ -22,6 +22,14 @@ authentication. Optional for databases that do not require authentication.
 
 **Password:** Password to use to connect to the specified database.
 
+**Transaction Isolation Level** The transaction isolation level of the database connection
+- TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
+- TRANSACTION_SERIALIZABLE: No dirty reads. Non-repeatable and phantom reads are prevented.
+- TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
+- TRANSACTION_READ_UNCOMMITTED: Allows dirty reads (reading uncommitted changes from other transactions). Non-repeatable reads and phantom reads are possible.
+
+For more details on the Transaction Isolation Levels supported in SQL Server, refer to the [SQL Server documentation](https://learn.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver16)
+
 **Authentication Type:** Indicates which authentication method will be used for the connection. Use 'SQL Login'. to
 connect to a SQL Server using username and password properties. Use 'Active Directory Password' to connect to an Azure
 SQL Database/Data Warehouse using an Azure AD principal name and password.

--- a/mssql-plugin/docs/SqlServer-batchsink.md
+++ b/mssql-plugin/docs/SqlServer-batchsink.md
@@ -46,6 +46,14 @@ an Azure SQL Database/Data Warehouse using an Azure AD principal name and passwo
 
 **Password:** Password to use to connect to the specified database.
 
+**Transaction Isolation Level** The transaction isolation level of the database connection
+- TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
+- TRANSACTION_SERIALIZABLE: No dirty reads. Non-repeatable and phantom reads are prevented.
+- TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
+- TRANSACTION_READ_UNCOMMITTED: Allows dirty reads (reading uncommitted changes from other transactions). Non-repeatable reads and phantom reads are possible.
+
+For more details on the Transaction Isolation Levels supported in SQL Server, refer to the [SQL Server documentation](https://learn.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver16)
+
 **Instance Name:** SQL Server instance name to connect to. When it is not specified, a
 connection is made to the default instance. For the case where both the instanceName and port are specified,
 see the notes for port. If you specify a Virtual Network Name in the Server connection property, you cannot

--- a/mssql-plugin/docs/SqlServer-batchsource.md
+++ b/mssql-plugin/docs/SqlServer-batchsource.md
@@ -56,6 +56,14 @@ an Azure SQL Database/Data Warehouse using an Azure AD principal name and passwo
 
 **Password:** Password to use to connect to the specified database.
 
+**Transaction Isolation Level** The transaction isolation level of the database connection
+- TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
+- TRANSACTION_SERIALIZABLE: No dirty reads. Non-repeatable and phantom reads are prevented.
+- TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
+- TRANSACTION_READ_UNCOMMITTED: Allows dirty reads (reading uncommitted changes from other transactions). Non-repeatable reads and phantom reads are possible.
+
+For more details on the Transaction Isolation Levels supported in SQL Server, refer to the [SQL Server documentation](https://learn.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver16)
+
 **Instance Name:** SQL Server instance name to connect to. When it is not specified, a
 connection is made to the default instance. For the case where both the instanceName and port are specified,
 see the notes for port. If you specify a Virtual Network Name in the Server connection property, you cannot

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerSink.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerSink.java
@@ -168,6 +168,11 @@ public class SqlServerSink extends AbstractDBSink<SqlServerSink.SqlServerSinkCon
     }
 
     @Override
+    public String getTransactionIsolationLevel() {
+      return connection.getTransactionIsolationLevel();
+    }
+
+    @Override
     public String getConnectionString() {
       return String.format(SqlServerConstants.SQL_SERVER_CONNECTION_STRING_FORMAT,
                            connection.getHost(), connection.getPort(), database);

--- a/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerSource.java
+++ b/mssql-plugin/src/main/java/io/cdap/plugin/mssql/SqlServerSource.java
@@ -189,6 +189,11 @@ public class SqlServerSource extends AbstractDBSource<SqlServerSource.SqlServerS
     }
 
     @Override
+    public String getTransactionIsolationLevel() {
+      return connection.getTransactionIsolationLevel();
+    }
+
+    @Override
     public void validate(FailureCollector collector) {
       ConfigUtil.validateConnection(this, useConnection, connection, collector);
       super.validate(collector);

--- a/mssql-plugin/widgets/SQL Server-connector.json
+++ b/mssql-plugin/widgets/SQL Server-connector.json
@@ -64,6 +64,20 @@
           "widget-type": "password",
           "label": "Password",
           "name": "password"
+        },
+        {
+          "widget-type": "select",
+          "label": "Transaction Isolation Level",
+          "name": "transactionIsolationLevel",
+          "widget-attributes": {
+            "values": [
+              "TRANSACTION_READ_UNCOMMITTED",
+              "TRANSACTION_READ_COMMITTED",
+              "TRANSACTION_REPEATABLE_READ",
+              "TRANSACTION_SERIALIZABLE"
+            ],
+            "default": "TRANSACTION_SERIALIZABLE"
+          }
         }
       ]
     },

--- a/mssql-plugin/widgets/SqlServer-batchsink.json
+++ b/mssql-plugin/widgets/SqlServer-batchsink.json
@@ -85,6 +85,20 @@
           "name": "password"
         },
         {
+          "widget-type": "select",
+          "label": "Transaction Isolation Level",
+          "name": "transactionIsolationLevel",
+          "widget-attributes": {
+            "values": [
+              "TRANSACTION_READ_UNCOMMITTED",
+              "TRANSACTION_READ_COMMITTED",
+              "TRANSACTION_REPEATABLE_READ",
+              "TRANSACTION_SERIALIZABLE"
+            ],
+            "default": "TRANSACTION_SERIALIZABLE"
+          }
+        },
+        {
           "widget-type": "keyvalue",
           "label": "Connection Arguments",
           "name": "connectionArguments",
@@ -267,6 +281,10 @@
         {
           "type": "property",
           "name": "connectionArguments"
+        },
+        {
+          "type": "property",
+          "name": "transactionIsolationLevel"
         }
       ]
     },

--- a/mssql-plugin/widgets/SqlServer-batchsource.json
+++ b/mssql-plugin/widgets/SqlServer-batchsource.json
@@ -85,6 +85,20 @@
           "name": "password"
         },
         {
+          "widget-type": "select",
+          "label": "Transaction Isolation Level",
+          "name": "transactionIsolationLevel",
+          "widget-attributes": {
+            "values": [
+              "TRANSACTION_READ_UNCOMMITTED",
+              "TRANSACTION_READ_COMMITTED",
+              "TRANSACTION_REPEATABLE_READ",
+              "TRANSACTION_SERIALIZABLE"
+            ],
+            "default": "TRANSACTION_SERIALIZABLE"
+          }
+        },
+        {
           "widget-type": "keyvalue",
           "label": "Connection Arguments",
           "name": "connectionArguments",
@@ -316,6 +330,10 @@
         {
           "type": "property",
           "name": "connectionArguments"
+        },
+        {
+          "type": "property",
+          "name": "transactionIsolationLevel"
         }
       ]
     },

--- a/mysql-plugin/docs/MySQL-connector.md
+++ b/mysql-plugin/docs/MySQL-connector.md
@@ -22,6 +22,14 @@ authentication. Optional for databases that do not require authentication.
 
 **Password:** Password to use to connect to the specified database.
 
+**Transaction Isolation Level** The transaction isolation level of the databse connection
+- TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
+- TRANSACTION_SERIALIZABLE: No dirty reads. Non-repeatable and phantom reads are prevented.
+- TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
+- TRANSACTION_READ_UNCOMMITTED: Allows dirty reads (reading uncommitted changes from other transactions). Non-repeatable reads and phantom reads are possible.
+
+For more details on the Transaction Isolation Levels supported in MySQL, refer to the  [MySQL documentation](https://dev.mysql.com/doc/refman/8.4/en/innodb-transaction-isolation-levels.html)
+
 **Connection Arguments:** A list of arbitrary string tag/value pairs as connection arguments. These arguments
 will be passed to the JDBC driver, as connection arguments, for JDBC drivers that may need additional configurations.
 This is a semicolon-separated list of key-value pairs, where each pair is separated by a equals '=' and specifies

--- a/mysql-plugin/docs/Mysql-batchsink.md
+++ b/mysql-plugin/docs/Mysql-batchsink.md
@@ -39,6 +39,14 @@ You also can use the macro function ${conn(connection-name)}.
 
 **Password:** Password to use to connect to the specified database.
 
+**Transaction Isolation Level** The transaction isolation level of the databse connection
+- TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
+- TRANSACTION_SERIALIZABLE: No dirty reads. Non-repeatable and phantom reads are prevented.
+- TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
+- TRANSACTION_READ_UNCOMMITTED: Allows dirty reads (reading uncommitted changes from other transactions). Non-repeatable reads and phantom reads are possible.
+
+For more details on the Transaction Isolation Levels supported in MySQL, refer to the  [MySQL documentation](https://dev.mysql.com/doc/refman/8.4/en/innodb-transaction-isolation-levels.html)
+
 **Connection Arguments:** A list of arbitrary string key/value pairs as connection arguments. These arguments
 will be passed to the JDBC driver as connection arguments for JDBC drivers that may need additional configurations.
 

--- a/mysql-plugin/docs/Mysql-batchsource.md
+++ b/mysql-plugin/docs/Mysql-batchsource.md
@@ -49,6 +49,14 @@ For example, 'SELECT MIN(id),MAX(id) FROM table'. Not required if numSplits is s
 
 **Password:** Password to use to connect to the specified database.
 
+**Transaction Isolation Level** The transaction isolation level of the database connection
+- TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
+- TRANSACTION_SERIALIZABLE: No dirty reads. Non-repeatable and phantom reads are prevented.
+- TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
+- TRANSACTION_READ_UNCOMMITTED: Allows dirty reads (reading uncommitted changes from other transactions). Non-repeatable reads and phantom reads are possible.
+
+For more details on the Transaction Isolation Levels supported in MySQL, refer to the  [MySQL documentation](https://dev.mysql.com/doc/refman/8.4/en/innodb-transaction-isolation-levels.html)
+
 **Connection Arguments:** A list of arbitrary string key/value pairs as connection arguments. These arguments
 will be passed to the JDBC driver as connection arguments for JDBC drivers that may need additional configurations.
 

--- a/mysql-plugin/src/e2e-test/java/io/cdap/plugin/MysqlClient.java
+++ b/mysql-plugin/src/e2e-test/java/io/cdap/plugin/MysqlClient.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin;
 
+import com.google.common.base.Strings;
 import io.cdap.e2e.utils.PluginPropertyUtils;
 import org.junit.Assert;
 
@@ -162,9 +163,13 @@ public class MysqlClient {
       statement.executeUpdate(createSourceTableQuery);
 
       // Insert dummy data.
-      String datatypesValues = PluginPropertyUtils.pluginProp("datatypesValues");
-      String datatypesColumnsList = PluginPropertyUtils.pluginProp("datatypesColumnsList");
-      statement.executeUpdate("INSERT INTO " + sourceTable + " " + datatypesColumnsList + " " + datatypesValues);
+      int rowCount = 1;
+      while (!Strings.isNullOrEmpty(PluginPropertyUtils.pluginProp("datatypesValue" + rowCount))) {
+        String datatypesValues = PluginPropertyUtils.pluginProp("datatypesValue" + rowCount);
+        String datatypesColumnsList = PluginPropertyUtils.pluginProp("datatypesColumnsList");
+        statement.executeUpdate("INSERT INTO " + sourceTable + " " + datatypesColumnsList + " " + datatypesValues);
+        rowCount++;
+      }
     }
   }
 

--- a/mysql-plugin/src/e2e-test/resources/pluginParameters.properties
+++ b/mysql-plugin/src/e2e-test/resources/pluginParameters.properties
@@ -13,25 +13,40 @@ datatypesColumns=(ID varchar(100) PRIMARY KEY, COL1 bigint(20), COL2 bigint(20) 
   COL12 enum('A','B','C'), COL13 float, COL14 int(11), COL15 int(10) unsigned, COL16 mediumblob, COL17 mediumtext, \
   COL18 longblob, COL19 longtext, COL20 mediumint(9), COL21 mediumint(8) unsigned, COL22 set('X','y','Z'), \
   COL23 smallint(6), COL24 smallint(5) unsigned, COL25 text, COL26 time, COL27 timestamp, COL28 tinyblob, \
-  COL29 tinyint(4), COL30 tinyint(3) unsigned, COL31 tinytext, COL32 varbinary(100), COL33 json)
+  COL29 tinyint(4), COL30 tinyint(3) unsigned, COL31 tinytext, COL32 varbinary(100), COL33 json, COL34 year)
 datatypesColumnsList=(ID,COL1,COL2,COL3,COL4,COL5,COL6,COL7,COL8,COL9,COL10,COL11,COL12,COL13,COL14,COL15,COL16,COL17,\
-  COL18,COL19,COL20,COL21,COL22,COL23,COL24,COL25,COL26,COL27,COL28,COL29,COL30,COL31,COL32,COL33)
-datatypesValues=VALUES ('User1',1000000000000000000,1000000000000000000,1,1,\
-  HEX('27486920546869732069732061206C6F6E6720746578742E27'),1,'A','2023-01-01','2023-01-01 00:00:00',1234,\
-  1234.5678,'A',22.0,-1234,1234,HEX('27486920546869732069732061206C6F6E6720746578742E27'),\
+  COL18,COL19,COL20,COL21,COL22,COL23,COL24,COL25,COL26,COL27,COL28,COL29,COL30,COL31,COL32,COL33,COL34)
+datatypesValue1=VALUES ('User1',-9223372036854775808,null,1,1,\
+  HEX('27486920546869732069732061206C6F6E6720746578742E27'),-1,'A','2023-01-01','2023-01-01 00:00:00',1234,\
+  1234.5678,'A',22.0,-2147483648,0,HEX('27486920546869732069732061206C6F6E6720746578742E27'),\
   'This is a test message',HEX('27486920546869732069732061206C6F6E6720746578742E27'),\
-  'This is a test message\n\n',-1234,1234,'X',-1234,1234,'This is a test message','00:00:00','2023-01-01 00:00:00',\
-  HEX('27486920546869732069732061206C6F6E6720746578742E27'),-100,100,'This is a test message',1,\
-  '{"key1": "value1", "key2": "value2"}')
+  'This is a test message\n\n',null,0,'X',-32768,0,'This is a test message','00:00:00','2023-01-01 00:00:00',\
+  HEX('27486920546869732069732061206C6F6E6720746578742E27'),-128,0,'This is a test message',1,\
+  '{"key1": "value1", "key2": "value2"}',2023)
+datatypesValue2=VALUES ('User2',9223372036854775807,18446744073709551615,1,1,\
+  HEX('27486920546869732069732061206C6F6E6720746578742E27'),127,'A','2023-01-01','2023-01-01 00:00:00',1234,\
+  1234.5678,'A',22.0,2147483647,4294967295,HEX('27486920546869732069732061206C6F6E6720746578742E27'),\
+  'This is a test message',HEX('27486920546869732069732061206C6F6E6720746578742E27'),\
+  'This is a test message\n\n',8388607,16777215,'X',32767,65535,'This is a test message','00:00:00','2023-01-01 00:00:00',\
+  HEX('27486920546869732069732061206C6F6E6720746578742E27'),127,255,'This is a test message',1,\
+  '{"key1": "value1", "key2": "value2"}',0)
+datatypesValue3=VALUES ('User3',null,0,1,1,\
+  HEX('27486920546869732069732061206C6F6E6720746578742E27'),null,'A','2023-01-01','2023-01-01 00:00:00',1234,\
+  1234.5678,'A',22.0,null,null,HEX('27486920546869732069732061206C6F6E6720746578742E27'),\
+  'This is a test message',HEX('27486920546869732069732061206C6F6E6720746578742E27'),\
+  'This is a test message\n\n',-8388608,null,'X',null,null,'This is a test message','00:00:00','2023-01-01 00:00:00',\
+  HEX('27486920546869732069732061206C6F6E6720746578742E27'),null,null,'This is a test message',1,\
+  '{"key1": "value1", "key2": "value2"}',null)
 datatypesSchema=[{"key":"ID","value":"string"},{"key":"COL1","value":"long"},{"key":"COL2","value":"decimal"},\
   {"key":"COL3","value":"bytes"},{"key":"COL4","value":"boolean"},{"key":"COL5","value":"bytes"},\
-  {"key":"COL6","value":"boolean"},{"key":"COL7","value":"string"},{"key":"COL8","value":"date"},\
+  {"key":"COL6","value":"int"},{"key":"COL7","value":"string"},{"key":"COL8","value":"date"},\
   {"key":"COL9","value":"timestamp"},{"key":"COL10","value":"decimal"},{"key":"COL11","value":"double"},\
   {"key":"COL12","value":"string"},{"key":"COL13","value":"float"},{"key":"COL14","value":"int"},\
   {"key":"COL15","value":"long"},{"key":"COL16","value":"bytes"},{"key":"COL17","value":"string"},\
   {"key":"COL18","value":"bytes"},{"key":"COL19","value":"string"},{"key":"COL20","value":"int"},\
-  {"key":"COL21","value":"long"},{"key":"COL22","value":"string"},{"key":"COL23","value":"int"},\
+  {"key":"COL21","value":"int"},{"key":"COL22","value":"string"},{"key":"COL23","value":"int"},\
   {"key":"COL24","value":"int"},{"key":"COL25","value":"string"},{"key":"COL26","value":"time"},\
   {"key":"COL27","value":"timestamp"},{"key":"COL28","value":"bytes"},{"key":"COL29","value":"int"},\
   {"key":"COL30","value":"int"},{"key":"COL31","value":"string"},{"key":"COL32","value":"bytes"},\
-  {"key":"COL33","value":"string"}]
+  {"key":"COL33","value":"string"},{"key":"COL34","value":"int"}]
+{"key":"COL33","value":"string"}]

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlSink.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlSink.java
@@ -149,6 +149,11 @@ public class MysqlSink extends AbstractDBSink<MysqlSink.MysqlSinkConfig> {
     }
 
     @Override
+    public String getTransactionIsolationLevel() {
+      return connection.getTransactionIsolationLevel();
+    }
+
+    @Override
     public MysqlConnectorConfig getConnection() {
       return connection;
     }

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlSource.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlSource.java
@@ -181,6 +181,11 @@ public class MysqlSource extends AbstractDBSource<MysqlSource.MysqlSourceConfig>
     }
 
     @Override
+    public String getTransactionIsolationLevel() {
+      return connection.getTransactionIsolationLevel();
+    }
+
+    @Override
     public void validate(FailureCollector collector) {
       ConfigUtil.validateConnection(this, useConnection, connection, collector);
       super.validate(collector);

--- a/mysql-plugin/widgets/MySQL-connector.json
+++ b/mysql-plugin/widgets/MySQL-connector.json
@@ -30,6 +30,20 @@
           "widget-attributes": {
             "default": "3306"
           }
+        },
+        {
+          "widget-type": "select",
+          "label": "Transaction Isolation Level",
+          "name": "transactionIsolationLevel",
+          "widget-attributes": {
+            "values": [
+              "TRANSACTION_READ_UNCOMMITTED",
+              "TRANSACTION_READ_COMMITTED",
+              "TRANSACTION_REPEATABLE_READ",
+              "TRANSACTION_SERIALIZABLE"
+            ],
+            "default": "TRANSACTION_SERIALIZABLE"
+          }
         }
       ]
     },

--- a/mysql-plugin/widgets/Mysql-batchsink.json
+++ b/mysql-plugin/widgets/Mysql-batchsink.json
@@ -66,6 +66,20 @@
           "name": "password"
         },
         {
+          "widget-type": "select",
+          "label": "Transaction Isolation Level",
+          "name": "transactionIsolationLevel",
+          "widget-attributes": {
+            "values": [
+              "TRANSACTION_READ_UNCOMMITTED",
+              "TRANSACTION_READ_COMMITTED",
+              "TRANSACTION_REPEATABLE_READ",
+              "TRANSACTION_SERIALIZABLE"
+            ],
+            "default": "TRANSACTION_SERIALIZABLE"
+          }
+        },
+        {
           "widget-type": "keyvalue",
           "label": "Connection Arguments",
           "name": "connectionArguments",
@@ -211,6 +225,10 @@
         {
           "type": "property",
           "name": "password"
+        },
+        {
+          "type": "property",
+          "name": "transactionIsolationLevel"
         },
         {
           "type": "property",

--- a/mysql-plugin/widgets/Mysql-batchsource.json
+++ b/mysql-plugin/widgets/Mysql-batchsource.json
@@ -66,6 +66,20 @@
           "name": "password"
         },
         {
+          "widget-type": "select",
+          "label": "Transaction Isolation Level",
+          "name": "transactionIsolationLevel",
+          "widget-attributes": {
+            "values": [
+              "TRANSACTION_READ_UNCOMMITTED",
+              "TRANSACTION_READ_COMMITTED",
+              "TRANSACTION_REPEATABLE_READ",
+              "TRANSACTION_SERIALIZABLE"
+            ],
+            "default": "TRANSACTION_SERIALIZABLE"
+          }
+        },
+        {
           "widget-type": "keyvalue",
           "label": "Connection Arguments",
           "name": "connectionArguments",
@@ -276,6 +290,10 @@
         {
           "type": "property",
           "name": "password"
+        },
+        {
+          "type": "property",
+          "name": "transactionIsolationLevel"
         },
         {
           "type": "property",

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnectorConfig.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnectorConfig.java
@@ -78,12 +78,6 @@ public class OracleConnectorConfig extends AbstractDBSpecificConnectorConfig {
   @Macro
   private String database;
 
-  @Name(OracleConstants.TRANSACTION_ISOLATION_LEVEL)
-  @Description("The transaction isolation level for the database session.")
-  @Macro
-  @Nullable
-  private String transactionIsolationLevel;
-
   @Override
   protected int getDefaultPort() {
     return 1521;
@@ -111,6 +105,7 @@ public class OracleConnectorConfig extends AbstractDBSpecificConnectorConfig {
     return prop;
   }
 
+  @Override
   public String getTransactionIsolationLevel() {
     //if null default to the highest isolation level possible
     if (transactionIsolationLevel == null) {
@@ -120,16 +115,7 @@ public class OracleConnectorConfig extends AbstractDBSpecificConnectorConfig {
     //This ensures that the role is mapped to the right serialization level, even w/ incorrect user input
     //if role is SYSDBA or SYSOP it will map to read_committed. else serialized
     return (!getRole().equals(ROLE_NORMAL)) ? TransactionIsolationLevel.Level.TRANSACTION_READ_COMMITTED.name() :
-            TransactionIsolationLevel.Level.valueOf(transactionIsolationLevel).name();
-  }
-
-  @Override
-  public Map<String, String> getAdditionalArguments() {
-    Map<String, String> additonalArguments = new HashMap<>();
-    if (getTransactionIsolationLevel() != null) {
-      additonalArguments.put(TransactionIsolationLevel.CONF_KEY, getTransactionIsolationLevel());
-    }
-    return additonalArguments;
+      TransactionIsolationLevel.Level.valueOf(transactionIsolationLevel).name();
   }
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -716,7 +716,14 @@
         <dependency>
           <groupId>io.cdap.tests.e2e</groupId>
           <artifactId>cdap-e2e-framework</artifactId>
-          <version>0.2.3</version>
+          <version>0.3.0</version>
+          <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/io.netty/netty-all -->
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-all</artifactId>
+          <version>4.1.92.Final</version>
           <scope>test</scope>
         </dependency>
         <dependency>

--- a/postgresql-plugin/docs/PostgreSQL-connector.md
+++ b/postgresql-plugin/docs/PostgreSQL-connector.md
@@ -22,6 +22,14 @@ authentication. Optional for databases that do not require authentication.
 
 **Password:** Password to use to connect to the specified database.
 
+**Transaction Isolation Level** The transaction isolation level of the databse connection
+- TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
+- TRANSACTION_SERIALIZABLE: No dirty reads. Non-repeatable and phantom reads are prevented.
+- TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
+- Note: PostgreSQL does not implement `TRANSACTION_READ_UNCOMMITTED` as a distinct isolation level. Instead, this mode behaves identically to`TRANSACTION_READ_COMMITTED`, which is why it is not exposed as a separate option.
+
+For more details on the Transaction Isolation Levels supported in PostgreSQL, refer to the [PostgreSQL documentation](https://www.postgresql.org/docs/current/transaction-iso.html#TRANSACTION-ISO)
+
 **Database:** The name of the database to connect to.
 
 **Connection Arguments:** A list of arbitrary string tag/value pairs as connection arguments. These arguments

--- a/postgresql-plugin/docs/Postgres-batchsink.md
+++ b/postgresql-plugin/docs/Postgres-batchsink.md
@@ -39,6 +39,14 @@ You also can use the macro function ${conn(connection-name)}.
 
 **Password:** Password to use to connect to the specified database.
 
+**Transaction Isolation Level** The transaction isolation level of the databse connection
+- TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
+- TRANSACTION_SERIALIZABLE: No dirty reads. Non-repeatable and phantom reads are prevented.
+- TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
+- Note: PostgreSQL does not implement `TRANSACTION_READ_UNCOMMITTED` as a distinct isolation level. Instead, this mode behaves identically to`TRANSACTION_READ_COMMITTED`, which is why it is not exposed as a separate option.
+
+For more details on the Transaction Isolation Levels supported in PostgreSQL, refer to the [PostgreSQL documentation](https://www.postgresql.org/docs/current/transaction-iso.html#TRANSACTION-ISO)
+
 **Connection Arguments:** A list of arbitrary string key/value pairs as connection arguments. These arguments
 will be passed to the JDBC driver as connection arguments for JDBC drivers that may need additional configurations.
 

--- a/postgresql-plugin/docs/Postgres-batchsource.md
+++ b/postgresql-plugin/docs/Postgres-batchsource.md
@@ -49,6 +49,14 @@ For example, 'SELECT MIN(id),MAX(id) FROM table'. Not required if numSplits is s
 
 **Password:** Password to use to connect to the specified database.
 
+**Transaction Isolation Level** The transaction isolation level of the databse connection
+- TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
+- TRANSACTION_SERIALIZABLE: No dirty reads. Non-repeatable and phantom reads are prevented.
+- TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
+- Note: PostgreSQL does not implement `TRANSACTION_READ_UNCOMMITTED` as a distinct isolation level. Instead, this mode behaves identically to`TRANSACTION_READ_COMMITTED`, which is why it is not exposed as a separate option. 
+
+For more details on the Transaction Isolation Levels supported in PostgreSQL, refer to the [PostgreSQL documentation](https://www.postgresql.org/docs/current/transaction-iso.html#TRANSACTION-ISO)
+
 **Connection Arguments:** A list of arbitrary string key/value pairs as connection arguments. These arguments
 will be passed to the JDBC driver as connection arguments for JDBC drivers that may need additional configurations.
 

--- a/postgresql-plugin/src/e2e-test/resources/pluginParameters.properties
+++ b/postgresql-plugin/src/e2e-test/resources/pluginParameters.properties
@@ -14,13 +14,13 @@ datatypesColumns=( id varchar(100) primary key, col1 bpchar, col2 bpchar(10), co
   col32 box, col33 path, col34 polygon, col35 circle, col36 cidr, col37 inet, col38 macaddr, col39 macaddr8, \
   col40 bit(2), col41 varbit(5), col42 json, col43 jsonb, col44 _pg_lsn, col45 pg_snapshot, col46 tsquery, \
   col47 tsvector, col48 txid_snapshot, col49 uuid, col50 xml, col51 int4range, col52 int8range, col53 numrange, \
-  col54 tsrange, col55 tstzrange, col56 daterange, col57 pg_lsn, col58 int4, col59 int2, col60 int8 )
-
+  col54 tsrange, col55 tstzrange, col56 daterange, col57 pg_lsn, col58 int4, col59 int2, col60 int8, col61 real, \
+  col62 smallint, col63 serial, col64 smallserial, col65 double precision, col66 bigint, col67 bigserial, col68 boolean)
 datatypesColumnsList=( id, col1, col2, col3, col4, col5, col6 , col7 , col8 , col10, col11, col12, col13, col14, \
   col15, col16, col17, col18, col22, col23, col24, col25, col26, col27, col28, col29, col30, col31, col32, col33, \
   col34, col35, col36, col37, col38, col39, col40, col41, col42, col43, col44, col45, col46, col47, col48, col49, \
-  col50, col51, col52, col53, col54, col55, col56, col57, col58, col59, col60 )
-
+  col50, col51, col52, col53, col54, col55, col56, col57, col58, col59, col60, col61, col62, col63, col64, col65,\
+  col66, col67, col68 )
 datatypesValues=VALUES ('User5', 'M', 'ABC...1234', 'B', 'ABC', decode('48656C6C6F20576F726C6421','hex'), 123, 123, \
   123456, 123.4567, 123456789, 123.456, 123.456, 100.26, 'Hello World!', 'User 5', 123.456, 100, \
   '2023-01-01 07:30:00.000', '2023-01-01 15:30:00.000', '02:00:00', '6 mons 02:30:00'::interval, \
@@ -34,15 +34,15 @@ datatypesValues=VALUES ('User5', 'M', 'ABC...1234', 'B', 'ABC', decode('48656C6C
   'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'::uuid, 'xml ''<foo>bar</foo>''', '[3,7)'::int4range, '[3,7)'::int8range, \
   '(1.0,14.0)'::numrange, '["2010-01-01 14:30:00","2010-01-01 15:30:00")'::tsrange, \
   '["2010-01-01 20:00:00+05:30","2010-01-01 21:00:00+05:30")'::tstzrange, '[1992-03-21,1994-06-26)'::daterange, \
-  '16/B374D848'::pg_lsn, 2, 2, 2);
-
+  '16/B374D848'::pg_lsn, 2, 2, 2, '1234.5679', '600', DEFAULT, DEFAULT, '61.823765812', '2500000000000', \
+  DEFAULT, false);
 datatypesSchema=[{"key":"id","value":"string"},{"key":"col1","value":"string"},{"key":"col2","value":"string"},\
   {"key":"col3","value":"string"},{"key":"col4","value":"string"},{"key":"col5","value":"bytes"},\
   {"key":"col6","value":"int"},{"key":"col7","value":"int"},{"key":"col8","value":"long"},\
   {"key":"col10","value":"decimal"},{"key":"col11","value":"decimal"},{"key":"col12","value":"float"},\
   {"key":"col13","value":"double"},{"key":"col14","value":"string"},{"key":"col15","value":"string"},\
   {"key":"col16","value":"string"},{"key":"col17","value":"double"},{"key":"col18","value":"decimal"},\
-  {"key":"col22","value":"timestamp"},{"key":"col23","value":"timestamp"},{"key":"col24","value":"time"},\
+  {"key":"col22","value":"datetime"},{"key":"col23","value":"timestamp"},{"key":"col24","value":"time"},\
   {"key":"col25","value":"string"},{"key":"col26","value":"string"},{"key":"col27","value":"date"},\
   {"key":"col28","value":"string"},{"key":"col29","value":"string"},{"key":"col30","value":"string"},\
   {"key":"col31","value":"string"},{"key":"col32","value":"string"},{"key":"col33","value":"string"},\
@@ -54,4 +54,7 @@ datatypesSchema=[{"key":"id","value":"string"},{"key":"col1","value":"string"},{
   {"key":"col49","value":"string"},{"key":"col50","value":"string"},{"key":"col51","value":"string"},\
   {"key":"col52","value":"string"},{"key":"col53","value":"string"},{"key":"col54","value":"string"},\
   {"key":"col55","value":"string"},{"key":"col56","value":"string"},{"key":"col57","value":"string"},\
-  {"key":"col58","value":"int"},{"key":"col59","value":"int"},{"key":"col60","value":"long"}]
+  {"key":"col58","value":"int"},{"key":"col59","value":"int"},{"key":"col60","value":"long"}, \
+  {"key":"col61","value":"float"},{"key":"col62","value":"int"},{"key":"col63","value":"int"},\
+  {"key":"col64","value":"int"},{"key":"col65","value":"double"},{"key":"col66","value":"long"},\
+  {"key":"col67","value":"long"},{"key":"col68","value":"boolean"}]

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSink.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSink.java
@@ -147,6 +147,11 @@ public class PostgresSink extends AbstractDBSink<PostgresSink.PostgresSinkConfig
     }
 
     @Override
+    public String getTransactionIsolationLevel() {
+      return connection.getTransactionIsolationLevel();
+    }
+
+    @Override
     protected PostgresConnectorConfig getConnection() {
       return connection;
     }

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSource.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSource.java
@@ -134,6 +134,11 @@ public class PostgresSource extends AbstractDBSource<PostgresSource.PostgresSour
     }
 
     @Override
+    public String getTransactionIsolationLevel() {
+      return connection.getTransactionIsolationLevel();
+    }
+
+    @Override
     public void validate(FailureCollector collector) {
       ConfigUtil.validateConnection(this, useConnection, connection, collector);
       super.validate(collector);

--- a/postgresql-plugin/widgets/PostgreSQL-connector.json
+++ b/postgresql-plugin/widgets/PostgreSQL-connector.json
@@ -32,6 +32,19 @@
           }
         },
         {
+          "widget-type": "select",
+          "label": "Transaction Isolation Level",
+          "name": "transactionIsolationLevel",
+          "widget-attributes": {
+            "values": [
+              "TRANSACTION_READ_COMMITTED",
+              "TRANSACTION_REPEATABLE_READ",
+              "TRANSACTION_SERIALIZABLE"
+            ],
+            "default": "TRANSACTION_SERIALIZABLE"
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Database",
           "name": "database"

--- a/postgresql-plugin/widgets/Postgres-batchsink.json
+++ b/postgresql-plugin/widgets/Postgres-batchsink.json
@@ -66,6 +66,19 @@
           "name": "password"
         },
         {
+          "widget-type": "select",
+          "label": "Transaction Isolation Level",
+          "name": "transactionIsolationLevel",
+          "widget-attributes": {
+            "values": [
+              "TRANSACTION_READ_COMMITTED",
+              "TRANSACTION_REPEATABLE_READ",
+              "TRANSACTION_SERIALIZABLE"
+            ],
+            "default": "TRANSACTION_SERIALIZABLE"
+          }
+        },
+        {
           "widget-type": "keyvalue",
           "label": "Connection Arguments",
           "name": "connectionArguments",
@@ -156,6 +169,10 @@
         {
           "type": "property",
           "name": "port"
+        },
+        {
+          "type": "property",
+          "name": "transactionIsolationLevel"
         },
         {
           "type": "property",

--- a/postgresql-plugin/widgets/Postgres-batchsource.json
+++ b/postgresql-plugin/widgets/Postgres-batchsource.json
@@ -66,6 +66,19 @@
           "name": "password"
         },
         {
+          "widget-type": "select",
+          "label": "Transaction Isolation Level",
+          "name": "transactionIsolationLevel",
+          "widget-attributes": {
+            "values": [
+              "TRANSACTION_READ_COMMITTED",
+              "TRANSACTION_REPEATABLE_READ",
+              "TRANSACTION_SERIALIZABLE"
+            ],
+            "default": "TRANSACTION_SERIALIZABLE"
+          }
+        },
+        {
           "widget-type": "keyvalue",
           "label": "Connection Arguments",
           "name": "connectionArguments",
@@ -205,6 +218,10 @@
         {
           "type": "property",
           "name": "port"
+        },
+        {
+          "type": "property",
+          "name": "transactionIsolationLevel"
         },
         {
           "type": "property",


### PR DESCRIPTION
[PLUGIN-1779](https://cdap.atlassian.net/browse/PLUGIN-1779) Set TRANSACTION_ISOLATION_LEVEL config in **MySQL**, **PostgreSQL** & **MSSQL** plugins

[PLUGIN-1779]: https://cdap.atlassian.net/browse/PLUGIN-1779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ