### PR TITLE
[🍒][PLUGIN-1888] Skip field validation for compatiblity

### DIFF
--- a/database-commons/src/main/java/io/cdap/plugin/db/source/AbstractDBSource.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/source/AbstractDBSource.java
@@ -529,7 +529,7 @@ public abstract class AbstractDBSource<T extends PluginConfig & DatabaseSourceCo
     }
 
     @VisibleForTesting
-    static void validateSchema(Schema actualSchema, Schema configSchema, FailureCollector collector) {
+    void validateSchema(Schema actualSchema, Schema configSchema, FailureCollector collector) {
       if (configSchema == null) {
         collector.addFailure("Schema should not be null or empty.", null)
           .withConfigProperty(SCHEMA);
@@ -550,14 +550,20 @@ public abstract class AbstractDBSource<T extends PluginConfig & DatabaseSourceCo
         Schema expectedFieldSchema = field.getSchema().isNullable() ?
           field.getSchema().getNonNullable() : field.getSchema();
 
-        if (actualFieldSchema.getType() != expectedFieldSchema.getType() ||
-          actualFieldSchema.getLogicalType() != expectedFieldSchema.getLogicalType()) {
-          collector.addFailure(
-            String.format("Schema field '%s' has type '%s but found '%s'.",
-                          field.getName(), expectedFieldSchema.getDisplayName(),
-                          actualFieldSchema.getDisplayName()), null)
-            .withOutputSchemaField(field.getName());
-        }
+        validateField(collector, field, actualFieldSchema, expectedFieldSchema);
+      }
+    }
+
+    protected void validateField(FailureCollector collector, Schema.Field field, Schema actualFieldSchema,
+                                 Schema expectedFieldSchema) {
+      if (actualFieldSchema.getType() != expectedFieldSchema.getType() ||
+        actualFieldSchema.getLogicalType() != expectedFieldSchema.getLogicalType()) {
+        collector.addFailure(
+            String.format("Schema field '%s' is expected to have type '%s but found '%s'.", field.getName(),
+              expectedFieldSchema.getDisplayName(), actualFieldSchema.getDisplayName()),
+            String.format("Change the data type of field %s to %s.", field.getName(),
+              actualFieldSchema.getDisplayName()))
+          .withOutputSchemaField(field.getName());
       }
     }
 

--- a/database-commons/src/test/java/io/cdap/plugin/db/source/AbstractDBSourceTest.java
+++ b/database-commons/src/test/java/io/cdap/plugin/db/source/AbstractDBSourceTest.java
@@ -43,11 +43,17 @@ public class AbstractDBSourceTest {
     Schema.Field.of("double_column", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
     Schema.Field.of("boolean_column", Schema.nullableOf(Schema.of(Schema.Type.BOOLEAN)))
   );
+  private static final AbstractDBSource.DBSourceConfig TEST_CONFIG = new AbstractDBSource.DBSourceConfig() {
+    @Override
+    public String getConnectionString() {
+      return "";
+    }
+  };
 
   @Test
   public void testValidateSourceSchemaCorrectSchema() {
     MockFailureCollector collector = new MockFailureCollector(MOCK_STAGE);
-    AbstractDBSource.DBSourceConfig.validateSchema(SCHEMA, SCHEMA, collector);
+    TEST_CONFIG.validateSchema(SCHEMA, SCHEMA, collector);
     Assert.assertEquals(0, collector.getValidationFailures().size());
   }
 
@@ -65,7 +71,7 @@ public class AbstractDBSourceTest {
     );
 
     MockFailureCollector collector = new MockFailureCollector(MOCK_STAGE);
-    AbstractDBSource.DBSourceConfig.validateSchema(actualSchema, SCHEMA, collector);
+    TEST_CONFIG.validateSchema(actualSchema, SCHEMA, collector);
     assertPropertyValidationFailed(collector, "boolean_column");
   }
 
@@ -84,7 +90,7 @@ public class AbstractDBSourceTest {
     );
 
     MockFailureCollector collector = new MockFailureCollector(MOCK_STAGE);
-    AbstractDBSource.DBSourceConfig.validateSchema(actualSchema, SCHEMA, collector);
+    TEST_CONFIG.validateSchema(actualSchema, SCHEMA, collector);
     assertPropertyValidationFailed(collector, "boolean_column");
   }
 

--- a/mariadb-plugin/src/main/java/io/cdap/plugin/mariadb/MariadbFieldsValidator.java
+++ b/mariadb-plugin/src/main/java/io/cdap/plugin/mariadb/MariadbFieldsValidator.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.mariadb;
+
+import io.cdap.plugin.mysql.MysqlFieldsValidator;
+
+/**
+ * Field validator for maraidb
+ */
+public class MariadbFieldsValidator extends MysqlFieldsValidator {
+}

--- a/mariadb-plugin/src/main/java/io/cdap/plugin/mariadb/MariadbSink.java
+++ b/mariadb-plugin/src/main/java/io/cdap/plugin/mariadb/MariadbSink.java
@@ -25,6 +25,8 @@ import io.cdap.plugin.db.DBRecord;
 import io.cdap.plugin.db.SchemaReader;
 import io.cdap.plugin.db.config.DBSpecificSinkConfig;
 import io.cdap.plugin.db.sink.AbstractDBSink;
+import io.cdap.plugin.db.sink.FieldsValidator;
+import io.cdap.plugin.mysql.MysqlFieldsValidator;
 import io.cdap.plugin.util.DBUtils;
 
 import java.util.Map;
@@ -68,6 +70,11 @@ public class MariadbSink extends AbstractDBSink<MariadbSink.MariadbSinkConfig> {
   @Override
   protected String getExternalDocumentationLink() {
     return DBUtils.MARIADB_SUPPORTED_DOC_URL;
+  }
+
+  @Override
+  protected FieldsValidator getFieldsValidator() {
+    return new MariadbFieldsValidator();
   }
 
   /**

--- a/mariadb-plugin/src/main/java/io/cdap/plugin/mariadb/MariadbSource.java
+++ b/mariadb-plugin/src/main/java/io/cdap/plugin/mariadb/MariadbSource.java
@@ -19,6 +19,8 @@ package io.cdap.plugin.mariadb;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.batch.BatchSource;
 import io.cdap.cdap.etl.api.batch.BatchSourceContext;
 import io.cdap.plugin.common.Asset;
@@ -171,6 +173,31 @@ public class MariadbSource extends AbstractDBSource<MariadbSource.MariadbSourceC
       // ResultSet.
       arguments.putIfAbsent(MARIADB_TINYINT1_IS_BIT, "false");
       return arguments;
+    }
+
+    @Override
+    protected void validateField(FailureCollector collector,
+                                 Schema.Field field,
+                                 Schema actualFieldSchema,
+                                 Schema expectedFieldSchema) {
+      // Backward compatibility changes to support MySQL YEAR to Date type conversion
+      if (Schema.LogicalType.DATE.equals(expectedFieldSchema.getLogicalType())
+        && Schema.Type.INT.equals(actualFieldSchema.getType())) {
+        return;
+      }
+
+      // Backward compatibility change to support MySQL MEDIUMINT UNSIGNED to Long type conversion
+      if (Schema.Type.LONG.equals(expectedFieldSchema.getType())
+        && Schema.Type.INT.equals(actualFieldSchema.getType())) {
+        return;
+      }
+
+      // Backward compatibility change to support MySQL TINYINT(1) to Bool type conversion
+      if (Schema.Type.BOOLEAN.equals(expectedFieldSchema.getType())
+        && Schema.Type.INT.equals(actualFieldSchema.getType())) {
+        return;
+      }
+      super.validateField(collector, field, actualFieldSchema, expectedFieldSchema);
     }
   }
 }


### PR DESCRIPTION
🍒 [cherrypick]

### Commits :
 - 2a56874ce8f8c8c19db8c1d73af71a1d1ad34141

### PR:
 - #587 [ Reviewer @itsankit-google ]
 
---
https://cdap.atlassian.net/browse/PLUGIN-1888

## Test

- Make a pipeline mariadb 1.10.0 (hub version) source to sink
- upgrade pipeline to new build
- pipeline ran successfully

---

- Hub version pipeline
![image](https://github.com/user-attachments/assets/b8197875-a476-4b26-8839-9b7082bd914c)


- Hub version detected schema
![image](https://github.com/user-attachments/assets/6f51554b-2855-40f4-8bd2-48e44bf6fe9c)


- Pipeline upgrade
<img width="998" alt="image" src="https://github.com/user-attachments/assets/b57a290a-2a65-4461-a58f-134687fb8b97" />


- Successful run
![image](https://github.com/user-attachments/assets/b84a7006-8f28-4d61-b9b7-596921bb7494)


- Data on BQ
<img width="1421" alt="image" src="https://github.com/user-attachments/assets/bbdf7b84-3997-45ee-b644-22f5f13f998f" />


### Known Issue with maria db driver below 3.5.2 (https://cdap.atlassian.net/browse/PLUGIN-1889)
