### PR TITLE
[PLUGIN-1893] Adding fields in Oracle source and connector which acts like a flag for Backward compatibility issues for Timestamp and number (precisionless) 

### DIFF
--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
@@ -112,7 +112,8 @@ public class OracleConnector extends AbstractDBSpecificConnector<OracleSourceDBR
 
   @Override
   protected SchemaReader getSchemaReader(String sessionID) {
-    return new OracleSourceSchemaReader(sessionID);
+    return new OracleSourceSchemaReader(sessionID, config.getTreatAsOldTimestamp(),
+                                        config.getTreatPrecisionlessNumAsDeci());
   }
 
   @Override

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnectorConfig.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnectorConfig.java
@@ -22,8 +22,6 @@ import io.cdap.cdap.api.annotation.Name;
 import io.cdap.plugin.db.TransactionIsolationLevel;
 import io.cdap.plugin.db.connector.AbstractDBSpecificConnectorConfig;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Properties;
 import javax.annotation.Nullable;
 
@@ -43,12 +41,14 @@ public class OracleConnectorConfig extends AbstractDBSpecificConnectorConfig {
 
   public OracleConnectorConfig(String host, int port, String user, String password, String jdbcPluginName,
                                String connectionArguments, String connectionType, String database) {
-    this(host, port, user, password, jdbcPluginName, connectionArguments, connectionType, database, null, null);
+    this(host, port, user, password, jdbcPluginName, connectionArguments, connectionType, database, null, null, null,
+         null);
   }
 
   public OracleConnectorConfig(String host, int port, String user, String password, String jdbcPluginName,
                                String connectionArguments, String connectionType, String database,
-                               String role, Boolean useSSL) {
+                               String role, Boolean useSSL, @Nullable Boolean treatAsOldTimestamp,
+                               @Nullable Boolean treatPrecisionlessNumAsDeci) {
 
     this.host = host;
     this.port = port;
@@ -60,6 +60,8 @@ public class OracleConnectorConfig extends AbstractDBSpecificConnectorConfig {
     this.database = database;
     this.role = role;
     this.useSSL = useSSL;
+    this.treatAsOldTimestamp = treatAsOldTimestamp;
+    this.treatPrecisionlessNumAsDeci = treatPrecisionlessNumAsDeci;
   }
 
   @Override
@@ -86,6 +88,16 @@ public class OracleConnectorConfig extends AbstractDBSpecificConnectorConfig {
   @Nullable
   public Boolean useSSL;
 
+  @Name(OracleConstants.TREAT_AS_OLD_TIMESTAMP)
+  @Description("A hidden field to handle timestamp as CDAP's timestamp micros or string as per old behavior.")
+  @Nullable
+  public Boolean treatAsOldTimestamp;
+
+  @Name(OracleConstants.TREAT_PRECISIONLESSNUM_AS_DECI)
+  @Description("A hidden field to handle precision less number as CDAP's decimal per old behavior.")
+  @Nullable
+  public Boolean treatPrecisionlessNumAsDeci;
+
   @Override
   protected int getDefaultPort() {
     return 1521;
@@ -106,6 +118,14 @@ public class OracleConnectorConfig extends AbstractDBSpecificConnectorConfig {
   public Boolean getSSlMode() {
     // return false if useSSL is null, otherwise return its value
     return useSSL != null && useSSL;
+  }
+
+  public Boolean getTreatAsOldTimestamp() {
+    return Boolean.TRUE.equals(treatAsOldTimestamp);
+  }
+
+  public Boolean getTreatPrecisionlessNumAsDeci() {
+    return Boolean.TRUE.equals(treatPrecisionlessNumAsDeci);
   }
 
   @Override

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConstants.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConstants.java
@@ -43,6 +43,8 @@ public final class OracleConstants {
   public static final String TNS_CONNECTION_TYPE = "tns";
   public static final String TRANSACTION_ISOLATION_LEVEL = "transactionIsolationLevel";
   public static final String USE_SSL = "useSSL";
+  public static final String TREAT_AS_OLD_TIMESTAMP = "treatAsOldTimestamp";
+  public static final String TREAT_PRECISIONLESSNUM_AS_DECI = "treatPrecisionlessNumAsDeci";
 
   /**
    * Constructs the Oracle connection string based on the provided connection type, host, port, and database.

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSource.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSource.java
@@ -63,7 +63,12 @@ public class OracleSource extends AbstractDBSource<OracleSource.OracleSourceConf
 
   @Override
   protected SchemaReader getSchemaReader() {
-    return new OracleSourceSchemaReader();
+    // PLUGIN-1893 : Based on field/properties from Oracle source and Oracle connection we will pass the flag to control
+    // handle schema to make it backward compatible.
+    boolean treatAsOldTimestamp = oracleSourceConfig.getConnection().getTreatAsOldTimestamp();
+    boolean treatPrecisionlessNumAsDeci = oracleSourceConfig.getConnection().getTreatPrecisionlessNumAsDeci();
+
+    return new OracleSourceSchemaReader(null, treatAsOldTimestamp, treatPrecisionlessNumAsDeci);
   }
 
   @Override
@@ -127,9 +132,11 @@ public class OracleSource extends AbstractDBSource<OracleSource.OracleSourceConf
                               String connectionArguments, String connectionType, String database, String role,
                               int defaultBatchValue, int defaultRowPrefetch,
                               String importQuery, Integer numSplits, int fetchSize,
-                              String boundingQuery, String splitBy, Boolean useSSL) {
+                              String boundingQuery, String splitBy, Boolean useSSL, Boolean treatAsOldTimestamp,
+                              Boolean treatPrecisionlessNumAsDeci) {
       this.connection = new OracleConnectorConfig(host, port, user, password, jdbcPluginName, connectionArguments,
-                                                  connectionType, database, role, useSSL);
+                                                  connectionType, database, role, useSSL, treatAsOldTimestamp,
+                                                  treatPrecisionlessNumAsDeci);
       this.defaultBatchValue = defaultBatchValue;
       this.defaultRowPrefetch = defaultRowPrefetch;
       this.fetchSize = fetchSize;

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSourceSchemaReader.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSourceSchemaReader.java
@@ -26,6 +26,7 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Oracle Source schema reader.
@@ -65,14 +66,17 @@ public class OracleSourceSchemaReader extends CommonSchemaReader {
   );
 
   private final String sessionID;
+  private final Boolean isTimestampOldBehavior;
+  private final Boolean isPrecisionlessNumAsDecimal;
 
   public OracleSourceSchemaReader() {
-    this(null);
+    this(null, false, false);
   }
-
-  public OracleSourceSchemaReader(String sessionID) {
-    super();
+  public OracleSourceSchemaReader(@Nullable String sessionID, boolean isTimestampOldBehavior,
+                                  boolean isPrecisionlessNumAsDecimal) {
     this.sessionID = sessionID;
+    this.isTimestampOldBehavior = isTimestampOldBehavior;
+    this.isPrecisionlessNumAsDecimal = isPrecisionlessNumAsDecimal;
   }
 
   @Override
@@ -81,10 +85,12 @@ public class OracleSourceSchemaReader extends CommonSchemaReader {
 
     switch (sqlType) {
       case TIMESTAMP_TZ:
-        return Schema.of(Schema.LogicalType.TIMESTAMP_MICROS);
-      case Types.TIMESTAMP:
+        return isTimestampOldBehavior ? Schema.of(Schema.Type.STRING) : Schema.of(Schema.LogicalType.TIMESTAMP_MICROS);
       case TIMESTAMP_LTZ:
-        return Schema.of(Schema.LogicalType.DATETIME);
+        return isTimestampOldBehavior ? Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)
+          : Schema.of(Schema.LogicalType.DATETIME);
+      case Types.TIMESTAMP:
+        return isTimestampOldBehavior ? super.getSchema(metadata, index) : Schema.of(Schema.LogicalType.DATETIME);
       case BINARY_FLOAT:
         return Schema.of(Schema.Type.FLOAT);
       case BINARY_DOUBLE:
@@ -107,12 +113,24 @@ public class OracleSourceSchemaReader extends CommonSchemaReader {
           // For a Number type without specified precision and scale, precision will be 0 and scale will be -127
           if (precision == 0) {
             // reference : https://docs.oracle.com/cd/B28359_01/server.111/b28318/datatype.htm#CNCPT1832
-            LOG.warn(String.format("Field '%s' is a %s type without precision and scale, "
-                    + "converting into STRING type to avoid any precision loss.",
-                metadata.getColumnName(index),
-                metadata.getColumnTypeName(index),
-                metadata.getColumnName(index)));
-            return Schema.of(Schema.Type.STRING);
+            if (isPrecisionlessNumAsDecimal) {
+              precision = 38;
+              scale = 0;
+              LOG.warn(String.format("%s type with undefined precision and scale is detected, "
+                                       + "there may be a precision loss while running the pipeline. "
+                                       + "Please define an output precision and scale for field '%s' to avoid "
+                                       + "precision loss.",
+                                     metadata.getColumnTypeName(index),
+                                     metadata.getColumnName(index)));
+              return Schema.decimalOf(precision, scale);
+            } else {
+              LOG.warn(String.format("Field '%s' is a %s type without precision and scale, "
+                                       + "converting into STRING type to avoid any precision loss.",
+                                     metadata.getColumnName(index),
+                                     metadata.getColumnTypeName(index),
+                                     metadata.getColumnName(index)));
+              return Schema.of(Schema.Type.STRING);
+            }
           }
           return Schema.decimalOf(precision, scale);
         }

--- a/oracle-plugin/widgets/Oracle-batchsource.json
+++ b/oracle-plugin/widgets/Oracle-batchsource.json
@@ -121,6 +121,44 @@
           }
         },
         {
+          "widget-type": "hidden",
+          "label": "Treat as old timestamp",
+          "name": "treatAsOldTimestamp",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "false",
+            "options": [
+              {
+                "id": "true",
+                "label": "true"
+              },
+              {
+                "id": "false",
+                "label": "false"
+              }
+            ]
+          }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Treat precision less number as Decimal(old behavior)",
+          "name": "treatPrecisionlessNumAsDeci",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "false",
+            "options": [
+              {
+                "id": "true",
+                "label": "true"
+              },
+              {
+                "id": "false",
+                "label": "false"
+              }
+            ]
+          }
+        },
+        {
           "name": "connectionType",
           "label": "Connection Type",
           "widget-type": "radio-group",
@@ -326,6 +364,14 @@
         {
           "type": "property",
           "name": "transactionIsolationLevel"
+        },
+        {
+          "type": "property",
+          "name": "getTreatAsOldTimestampConn"
+        },
+        {
+          "type": "property",
+          "name": "treatPrecisionlessNumAsDeci"
         }
       ]
     },

--- a/oracle-plugin/widgets/Oracle-connector.json
+++ b/oracle-plugin/widgets/Oracle-connector.json
@@ -129,6 +129,44 @@
               }
             ]
           }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Treat as old timestamp",
+          "name": "treatAsOldTimestamp",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "false",
+            "options": [
+              {
+                "id": "true",
+                "label": "true"
+              },
+              {
+                "id": "false",
+                "label": "false"
+              }
+            ]
+          }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Treat precision less number as Decimal(old behavior)",
+          "name": "treatPrecisionlessNumAsDeci",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "false",
+            "options": [
+              {
+                "id": "true",
+                "label": "true"
+              },
+              {
+                "id": "false",
+                "label": "false"
+              }
+            ]
+          }
         }
       ]
     },


### PR DESCRIPTION
[PLUGIN-1893](https://cdap.atlassian.net/browse/PLUGIN-1893)

### Problem / Context 

There were changes in Oracle DB plugin, where had modified the Schema handling. i.e. 
- Oracle `Number ( without precision)` was treated as `CDAP Decimal`, but in [PR_NUM](https://github.com/data-integrations/database-plugins/pull/323) it was changed to `String`
- Oracle `Date` was treated as `CDAP Timestamp micros`, but in [PR_timestamp](https://github.com/data-integrations/database-plugins/pull/386) it was changed to `Datetime` 

This caused issue for users who were already on older version of Oracle plugin, and while upgrading the schema type changed which acted like a blocker for them to upgrade. This was particularly the case where Schema was auto-detected ( i.e. use of macros ) 

This is targeted for Users with existing pipelines mostly. 

### Fix in the PR 

In this PR , we are giving a way to revert back to old behavior by setting a flag either in Connections or Plugin. 

By default : The flags are NOT ENABLED. So, creating a new pipeline will have new schema behavior. 

#### Via Connections 

- If the existing pipelines use connection, then this is easiest way 
- Export the connection json , edit `treatPrecisionlessNumAsDeci` / `treatAsOldTimestamp` to true or false. 
- upload again ( delete old one if needed) 
- Now all pipelines using this connection will handle schema as per old behavior. 

#### Via pipelines (only if connection is not used)

- If connections are not used , then user can edit or add field `treatPrecisionlessNumAsDeci` / `treatAsOldTimestamp` to true or false to the pipeline's json's Oracle plugin. 
- deploy the pipeline and the pipeline will handle schema as per old behavior ( as per flag).

 ### Various Scenarios and Testing Results
 
 All testing are done using a Pipeline ( ORACLE --> BQ ) 

 
#### Pipeline Run : 

`Case 1` : In pipeline : `Conn's flag is False/Default` + `Query -> Macro (auto-detect - schema)`
- BQ Table's Schema : NEW BEHAVIOR (num as String , date as Datetime) 

`Case 2` : In pipeline : `Conn's flag is True` + `Query -> Macro (auto-detect - schema)`
- BQ Table's Schema :  OLD BEHAVIOR (num as Deci --> BIGNUMERIC , date as Timestamp)

`Case 3` : In pipeline : `No Conn` + `Plugin's flag is False` + `Query -> Macro (auto-detect - schema)`
- BQ Table's Schema : NEW BEHAVIOR (num as String , date as Datetime) 

`Case 4` : In pipeline : `No Conn` + `Plugin's flag is True` + `Query -> Macro (auto-detect - schema)`
- BQ Table's Schema : OLD BEHAVIOR (num as Deci --> BIGNUMERIC , date as Timestamp)

---
#### Studio : 

`Case 1` : In Studio : `Conn's flag is False/Default` + `Query provided`
- Get Schema :NEW BEHAVIOR (num as String , date as Datetime)

`Case 2` : In Studio : `Conn's flag is True` + `Query provided`
- Get Schema : OLD BEHAVIOR (num as Deci , date as Timestamp)

`Case 3` : In Studio : `No Conn` + `Query provided`
- Get Schema : NEW BEHAVIOR (num as String , date as Datetime)

`Case 4` : In Studio : `No Conn` + `Query provided` + `Edit oracle plugin's flag to true `
- Get Schema : OLD BEHAVIOR (num as Deci , date as Timestamp)

---
#### Wrangler / Connection : 

`Case 1` : `Conn's flag is False/Default` 
-  Schema : NEW BEHAVIOR (num as String , date as Datetime)

`Case 2` : `Conn's flag is True` 
-  Schema : OLD BEHAVIOR (num as Deci , date as Timestamp)

---
#### Upgrade / Import / export case 

- on 6.11 : Create a pipeline with an  connection + existing plugin + run ( this should give new bahavior )
- Upload new plugin + export connection json + delete the conn and import connection using TRUE with same name. 
- upgrade pipeline as well. Run , this should give OLD schema. 
- Result : The initial pipeline : NEW BEHAVIOR (num as String , date as Datetime) 
- Result : The upgraded conn + upgraded pipeline : OLD BEHAVIOR (num as Deci , date as Timestamp)


[PLUGIN-1893]: https://cdap.atlassian.net/browse/PLUGIN-1893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ