### PR TITLE
[cherry-pick][6.11][PLUGIN-1893] Adding fields in Oracle source and connector which acts like a flag for Backward compatibility issues for Timestamp and number (precisionless)

### DIFF
--- a/amazon-redshift-plugin/pom.xml
+++ b/amazon-redshift-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.2</version>
+    <version>1.12.3-SNAPSHOT</version>
   </parent>
 
   <name>Amazon Redshift plugin</name>

--- a/aurora-mysql-plugin/pom.xml
+++ b/aurora-mysql-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.2</version>
+    <version>1.12.3-SNAPSHOT</version>
   </parent>
 
   <name>Aurora DB MySQL plugin</name>

--- a/aurora-postgresql-plugin/pom.xml
+++ b/aurora-postgresql-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.2</version>
+    <version>1.12.3-SNAPSHOT</version>
   </parent>
 
   <name>Aurora DB PostgreSQL plugin</name>

--- a/cloudsql-mysql-plugin/pom.xml
+++ b/cloudsql-mysql-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.2</version>
+    <version>1.12.3-SNAPSHOT</version>
   </parent>
 
   <name>CloudSQL MySQL plugin</name>

--- a/cloudsql-postgresql-plugin/pom.xml
+++ b/cloudsql-postgresql-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.2</version>
+    <version>1.12.3-SNAPSHOT</version>
   </parent>
 
   <name>CloudSQL PostgreSQL plugin</name>

--- a/database-commons/pom.xml
+++ b/database-commons/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.2</version>
+    <version>1.12.3-SNAPSHOT</version>
   </parent>
 
   <name>Database Commons</name>

--- a/db2-plugin/pom.xml
+++ b/db2-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.2</version>
+    <version>1.12.3-SNAPSHOT</version>
   </parent>
 
   <name>IBM DB2 plugin</name>

--- a/generic-database-plugin/pom.xml
+++ b/generic-database-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.2</version>
+    <version>1.12.3-SNAPSHOT</version>
   </parent>
 
   <name>Generic database plugin</name>

--- a/generic-db-argument-setter/pom.xml
+++ b/generic-db-argument-setter/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.2</version>
+    <version>1.12.3-SNAPSHOT</version>
   </parent>
 
   <name>Generic database argument setter plugin</name>

--- a/mariadb-plugin/pom.xml
+++ b/mariadb-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>database-plugins-parent</artifactId>
         <groupId>io.cdap.plugin</groupId>
-        <version>1.12.2</version>
+        <version>1.12.3-SNAPSHOT</version>
     </parent>
 
     <name>Maria DB plugin</name>

--- a/memsql-plugin/pom.xml
+++ b/memsql-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.2</version>
+    <version>1.12.3-SNAPSHOT</version>
   </parent>
 
   <name>Memsql plugin</name>

--- a/mssql-plugin/pom.xml
+++ b/mssql-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.2</version>
+    <version>1.12.3-SNAPSHOT</version>
   </parent>
 
   <name>Microsoft SQL Server plugin</name>

--- a/mysql-plugin/pom.xml
+++ b/mysql-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.2</version>
+    <version>1.12.3-SNAPSHOT</version>
   </parent>
 
   <name>Mysql plugin</name>

--- a/netezza-plugin/pom.xml
+++ b/netezza-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.2</version>
+    <version>1.12.3-SNAPSHOT</version>
   </parent>
 
   <name>Netezza plugin</name>

--- a/oracle-plugin/pom.xml
+++ b/oracle-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.2</version>
+    <version>1.12.3-SNAPSHOT</version>
   </parent>
 
   <name>Oracle plugin</name>

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnector.java
@@ -112,7 +112,8 @@ public class OracleConnector extends AbstractDBSpecificConnector<OracleSourceDBR
 
   @Override
   protected SchemaReader getSchemaReader(String sessionID) {
-    return new OracleSourceSchemaReader(sessionID);
+    return new OracleSourceSchemaReader(sessionID, config.getTreatAsOldTimestamp(),
+                                        config.getTreatPrecisionlessNumAsDeci());
   }
 
   @Override

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnectorConfig.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnectorConfig.java
@@ -22,8 +22,6 @@ import io.cdap.cdap.api.annotation.Name;
 import io.cdap.plugin.db.TransactionIsolationLevel;
 import io.cdap.plugin.db.connector.AbstractDBSpecificConnectorConfig;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Properties;
 import javax.annotation.Nullable;
 
@@ -43,12 +41,14 @@ public class OracleConnectorConfig extends AbstractDBSpecificConnectorConfig {
 
   public OracleConnectorConfig(String host, int port, String user, String password, String jdbcPluginName,
                                String connectionArguments, String connectionType, String database) {
-    this(host, port, user, password, jdbcPluginName, connectionArguments, connectionType, database, null, null);
+    this(host, port, user, password, jdbcPluginName, connectionArguments, connectionType, database, null, null, null,
+         null);
   }
 
   public OracleConnectorConfig(String host, int port, String user, String password, String jdbcPluginName,
                                String connectionArguments, String connectionType, String database,
-                               String role, Boolean useSSL) {
+                               String role, Boolean useSSL, @Nullable Boolean treatAsOldTimestamp,
+                               @Nullable Boolean treatPrecisionlessNumAsDeci) {
 
     this.host = host;
     this.port = port;
@@ -60,6 +60,8 @@ public class OracleConnectorConfig extends AbstractDBSpecificConnectorConfig {
     this.database = database;
     this.role = role;
     this.useSSL = useSSL;
+    this.treatAsOldTimestamp = treatAsOldTimestamp;
+    this.treatPrecisionlessNumAsDeci = treatPrecisionlessNumAsDeci;
   }
 
   @Override
@@ -86,6 +88,16 @@ public class OracleConnectorConfig extends AbstractDBSpecificConnectorConfig {
   @Nullable
   public Boolean useSSL;
 
+  @Name(OracleConstants.TREAT_AS_OLD_TIMESTAMP)
+  @Description("A hidden field to handle timestamp as CDAP's timestamp micros or string as per old behavior.")
+  @Nullable
+  public Boolean treatAsOldTimestamp;
+
+  @Name(OracleConstants.TREAT_PRECISIONLESSNUM_AS_DECI)
+  @Description("A hidden field to handle precision less number as CDAP's decimal per old behavior.")
+  @Nullable
+  public Boolean treatPrecisionlessNumAsDeci;
+
   @Override
   protected int getDefaultPort() {
     return 1521;
@@ -106,6 +118,14 @@ public class OracleConnectorConfig extends AbstractDBSpecificConnectorConfig {
   public Boolean getSSlMode() {
     // return false if useSSL is null, otherwise return its value
     return useSSL != null && useSSL;
+  }
+
+  public Boolean getTreatAsOldTimestamp() {
+    return Boolean.TRUE.equals(treatAsOldTimestamp);
+  }
+
+  public Boolean getTreatPrecisionlessNumAsDeci() {
+    return Boolean.TRUE.equals(treatPrecisionlessNumAsDeci);
   }
 
   @Override

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConstants.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConstants.java
@@ -43,6 +43,8 @@ public final class OracleConstants {
   public static final String TNS_CONNECTION_TYPE = "tns";
   public static final String TRANSACTION_ISOLATION_LEVEL = "transactionIsolationLevel";
   public static final String USE_SSL = "useSSL";
+  public static final String TREAT_AS_OLD_TIMESTAMP = "treatAsOldTimestamp";
+  public static final String TREAT_PRECISIONLESSNUM_AS_DECI = "treatPrecisionlessNumAsDeci";
 
   /**
    * Constructs the Oracle connection string based on the provided connection type, host, port, and database.

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSource.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSource.java
@@ -63,7 +63,12 @@ public class OracleSource extends AbstractDBSource<OracleSource.OracleSourceConf
 
   @Override
   protected SchemaReader getSchemaReader() {
-    return new OracleSourceSchemaReader();
+    // PLUGIN-1893 : Based on field/properties from Oracle source and Oracle connection we will pass the flag to control
+    // handle schema to make it backward compatible.
+    boolean treatAsOldTimestamp = oracleSourceConfig.getConnection().getTreatAsOldTimestamp();
+    boolean treatPrecisionlessNumAsDeci = oracleSourceConfig.getConnection().getTreatPrecisionlessNumAsDeci();
+
+    return new OracleSourceSchemaReader(null, treatAsOldTimestamp, treatPrecisionlessNumAsDeci);
   }
 
   @Override
@@ -127,9 +132,11 @@ public class OracleSource extends AbstractDBSource<OracleSource.OracleSourceConf
                               String connectionArguments, String connectionType, String database, String role,
                               int defaultBatchValue, int defaultRowPrefetch,
                               String importQuery, Integer numSplits, int fetchSize,
-                              String boundingQuery, String splitBy, Boolean useSSL) {
+                              String boundingQuery, String splitBy, Boolean useSSL, Boolean treatAsOldTimestamp,
+                              Boolean treatPrecisionlessNumAsDeci) {
       this.connection = new OracleConnectorConfig(host, port, user, password, jdbcPluginName, connectionArguments,
-                                                  connectionType, database, role, useSSL);
+                                                  connectionType, database, role, useSSL, treatAsOldTimestamp,
+                                                  treatPrecisionlessNumAsDeci);
       this.defaultBatchValue = defaultBatchValue;
       this.defaultRowPrefetch = defaultRowPrefetch;
       this.fetchSize = fetchSize;

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSourceSchemaReader.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSourceSchemaReader.java
@@ -26,6 +26,7 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Oracle Source schema reader.
@@ -65,14 +66,17 @@ public class OracleSourceSchemaReader extends CommonSchemaReader {
   );
 
   private final String sessionID;
+  private final Boolean isTimestampOldBehavior;
+  private final Boolean isPrecisionlessNumAsDecimal;
 
   public OracleSourceSchemaReader() {
-    this(null);
+    this(null, false, false);
   }
-
-  public OracleSourceSchemaReader(String sessionID) {
-    super();
+  public OracleSourceSchemaReader(@Nullable String sessionID, boolean isTimestampOldBehavior,
+                                  boolean isPrecisionlessNumAsDecimal) {
     this.sessionID = sessionID;
+    this.isTimestampOldBehavior = isTimestampOldBehavior;
+    this.isPrecisionlessNumAsDecimal = isPrecisionlessNumAsDecimal;
   }
 
   @Override
@@ -81,10 +85,12 @@ public class OracleSourceSchemaReader extends CommonSchemaReader {
 
     switch (sqlType) {
       case TIMESTAMP_TZ:
-        return Schema.of(Schema.LogicalType.TIMESTAMP_MICROS);
-      case Types.TIMESTAMP:
+        return isTimestampOldBehavior ? Schema.of(Schema.Type.STRING) : Schema.of(Schema.LogicalType.TIMESTAMP_MICROS);
       case TIMESTAMP_LTZ:
-        return Schema.of(Schema.LogicalType.DATETIME);
+        return isTimestampOldBehavior ? Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)
+          : Schema.of(Schema.LogicalType.DATETIME);
+      case Types.TIMESTAMP:
+        return isTimestampOldBehavior ? super.getSchema(metadata, index) : Schema.of(Schema.LogicalType.DATETIME);
       case BINARY_FLOAT:
         return Schema.of(Schema.Type.FLOAT);
       case BINARY_DOUBLE:
@@ -107,12 +113,24 @@ public class OracleSourceSchemaReader extends CommonSchemaReader {
           // For a Number type without specified precision and scale, precision will be 0 and scale will be -127
           if (precision == 0) {
             // reference : https://docs.oracle.com/cd/B28359_01/server.111/b28318/datatype.htm#CNCPT1832
-            LOG.warn(String.format("Field '%s' is a %s type without precision and scale, "
-                    + "converting into STRING type to avoid any precision loss.",
-                metadata.getColumnName(index),
-                metadata.getColumnTypeName(index),
-                metadata.getColumnName(index)));
-            return Schema.of(Schema.Type.STRING);
+            if (isPrecisionlessNumAsDecimal) {
+              precision = 38;
+              scale = 0;
+              LOG.warn(String.format("%s type with undefined precision and scale is detected, "
+                                       + "there may be a precision loss while running the pipeline. "
+                                       + "Please define an output precision and scale for field '%s' to avoid "
+                                       + "precision loss.",
+                                     metadata.getColumnTypeName(index),
+                                     metadata.getColumnName(index)));
+              return Schema.decimalOf(precision, scale);
+            } else {
+              LOG.warn(String.format("Field '%s' is a %s type without precision and scale, "
+                                       + "converting into STRING type to avoid any precision loss.",
+                                     metadata.getColumnName(index),
+                                     metadata.getColumnTypeName(index),
+                                     metadata.getColumnName(index)));
+              return Schema.of(Schema.Type.STRING);
+            }
           }
           return Schema.decimalOf(precision, scale);
         }

--- a/oracle-plugin/widgets/Oracle-batchsource.json
+++ b/oracle-plugin/widgets/Oracle-batchsource.json
@@ -121,6 +121,44 @@
           }
         },
         {
+          "widget-type": "hidden",
+          "label": "Treat as old timestamp",
+          "name": "treatAsOldTimestamp",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "false",
+            "options": [
+              {
+                "id": "true",
+                "label": "true"
+              },
+              {
+                "id": "false",
+                "label": "false"
+              }
+            ]
+          }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Treat precision less number as Decimal(old behavior)",
+          "name": "treatPrecisionlessNumAsDeci",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "false",
+            "options": [
+              {
+                "id": "true",
+                "label": "true"
+              },
+              {
+                "id": "false",
+                "label": "false"
+              }
+            ]
+          }
+        },
+        {
           "name": "connectionType",
           "label": "Connection Type",
           "widget-type": "radio-group",
@@ -326,6 +364,14 @@
         {
           "type": "property",
           "name": "transactionIsolationLevel"
+        },
+        {
+          "type": "property",
+          "name": "getTreatAsOldTimestampConn"
+        },
+        {
+          "type": "property",
+          "name": "treatPrecisionlessNumAsDeci"
         }
       ]
     },

--- a/oracle-plugin/widgets/Oracle-connector.json
+++ b/oracle-plugin/widgets/Oracle-connector.json
@@ -129,6 +129,44 @@
               }
             ]
           }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Treat as old timestamp",
+          "name": "treatAsOldTimestamp",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "false",
+            "options": [
+              {
+                "id": "true",
+                "label": "true"
+              },
+              {
+                "id": "false",
+                "label": "false"
+              }
+            ]
+          }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Treat precision less number as Decimal(old behavior)",
+          "name": "treatPrecisionlessNumAsDeci",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "false",
+            "options": [
+              {
+                "id": "true",
+                "label": "true"
+              },
+              {
+                "id": "false",
+                "label": "false"
+              }
+            ]
+          }
         }
       ]
     },

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>database-plugins-parent</artifactId>
-  <version>1.12.2</version>
+  <version>1.12.3-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Database Plugins</name>
   <description>Collection of database plugins</description>

--- a/postgresql-plugin/pom.xml
+++ b/postgresql-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.2</version>
+    <version>1.12.3-SNAPSHOT</version>
   </parent>
 
   <name>PostgreSQL plugin</name>

--- a/saphana-plugin/pom.xml
+++ b/saphana-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.2</version>
+    <version>1.12.3-SNAPSHOT</version>
   </parent>
 
   <name>SAP HANA plugin</name>

--- a/teradata-plugin/pom.xml
+++ b/teradata-plugin/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.12.2</version>
+    <version>1.12.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>teradata-plugin</artifactId>


### PR DESCRIPTION
… like a flag for Backward compatibility issues for Timestamp and number (precisionless)

Original PR : https://github.com/data-integrations/database-plugins/pull/601