### PR TITLE
Fix: Vulnerability for guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <!-- version properties -->
     <cdap.version>6.11.0</cdap.version>
     <cdap.plugin.version>2.13.1-SNAPSHOT</cdap.plugin.version>
-    <guava.version>13.0.1</guava.version>
+    <guava.version>32.1.3-jre</guava.version>
     <hadoop.version>3.3.6</hadoop.version>
     <hsql.version>2.2.4</hsql.version>
     <junit.version>4.13</junit.version>


### PR DESCRIPTION
Issue:
Resolved a high-severity information disclosure vulnerability (https://github.com/advisories/GHSA-7g45-4rm6-3mm3) related to insecure temporary file handling in the FileBackedOutputStream class of the Guava library (com.google.guava:guava). This vulnerability affects versions 1.0 through 31.1 on Unix-based systems and Android Ice Cream Sandwich. In vulnerable versions, temporary files were created in the system's default temporary directory (/tmp), allowing local users or applications with access to the directory to potentially read or tamper with those files.

Root Cause:
Guava used Java's default temporary directory for storing files without proper isolation, which could expose sensitive data in shared environments.

Fix:
Upgraded guava version from 13.0.1 to 32.1.3-jre