### PR TITLE
[PLUGIN-1955] Provide XML column type support for oracle plugin

### DIFF
--- a/oracle-plugin/pom.xml
+++ b/oracle-plugin/pom.xml
@@ -121,6 +121,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.oracle.database.xml</groupId>
+      <artifactId>xdb</artifactId>
+      <version>21.1.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle.database.xml</groupId>
+      <artifactId>xmlparserv2</artifactId>
+      <version>21.1.0.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSourceDBRecord.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSourceDBRecord.java
@@ -265,6 +265,7 @@ public class OracleSourceDBRecord extends DBRecord {
     switch (sqlType) {
       case OracleSourceSchemaReader.INTERVAL_YM:
       case OracleSourceSchemaReader.INTERVAL_DS:
+      case OracleSourceSchemaReader.XML:
       case OracleSourceSchemaReader.LONG:
       case Types.NCLOB:
         recordBuilder.set(field.getName(), resultSet.getString(columnIndex));

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSourceSchemaReader.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleSourceSchemaReader.java
@@ -44,6 +44,7 @@ public class OracleSourceSchemaReader extends CommonSchemaReader {
   public static final int BINARY_DOUBLE = 101;
   public static final int BFILE = -13;
   public static final int LONG = -1;
+  public static final int XML = 2009;
   public static final int LONG_RAW = -4;
 
   /**
@@ -61,6 +62,7 @@ public class OracleSourceSchemaReader extends CommonSchemaReader {
     BINARY_DOUBLE,
     BFILE,
     LONG,
+    XML,
     LONG_RAW,
     Types.NUMERIC,
     Types.DECIMAL
@@ -102,6 +104,7 @@ public class OracleSourceSchemaReader extends CommonSchemaReader {
         return Schema.of(Schema.Type.BYTES);
       case INTERVAL_DS:
       case INTERVAL_YM:
+      case XML:
       case LONG:
         return Schema.of(Schema.Type.STRING);
       case Types.NUMERIC:

--- a/oracle-plugin/src/test/java/io/cdap/plugin/oracle/OracleSchemaReaderTest.java
+++ b/oracle-plugin/src/test/java/io/cdap/plugin/oracle/OracleSchemaReaderTest.java
@@ -91,4 +91,22 @@ public class OracleSchemaReaderTest {
     Assert.assertEquals(expectedSchemaFields.get(1).getName(), actualSchemaFields.get(1).getName());
     Assert.assertEquals(expectedSchemaFields.get(1).getSchema(), actualSchemaFields.get(1).getSchema());
   }
+
+  @Test
+  public void getSchema_xmlField_returnString() throws SQLException {
+    OracleSourceSchemaReader schemaReader = new OracleSourceSchemaReader(null, false, false, false);
+    ResultSet resultSet = Mockito.mock(ResultSet.class);
+    ResultSetMetaData metadata = Mockito.mock(ResultSetMetaData.class);
+    Mockito.when(resultSet.getMetaData()).thenReturn(metadata);
+    Mockito.when(metadata.getColumnCount()).thenReturn(1);
+    Mockito.when(metadata.getColumnType(1)).thenReturn(OracleSourceSchemaReader.XML);
+    Mockito.when(metadata.getColumnName(1)).thenReturn("xmlData");
+
+    List<Schema.Field> actualSchemaFields = schemaReader.getSchemaFields(resultSet);
+
+    List<Schema.Field> expectedSchemaFields = Lists.newArrayList();
+    expectedSchemaFields.add(Schema.Field.of("xmlData", Schema.of(Schema.Type.STRING)));
+    Assert.assertEquals(expectedSchemaFields.get(0).getName(), actualSchemaFields.get(0).getName());
+    Assert.assertEquals(expectedSchemaFields.get(0).getSchema(), actualSchemaFields.get(0).getSchema());
+  }
 }


### PR DESCRIPTION
This CL introduces support for the XML data type within the **Oracle** plugin. Previously, columns of type XML were not explicitly handled, leading to transfers failure when encountering tables with XML columns.

Error - Column XML has unsupported SQL type of 2009. | Cause: io.cdap.cdap.api.data.schema.UnsupportedTypeException: Column XML has unsupported SQL type of 2009

To ensure compatibility with BQ, XMLType is now mapped to Schema.Type.STRING. This allows the raw XML content to be captured as a string.
Schema mapping validation is done - https://screenshot.googleplex.com/52L8acSXsVBXpWe