### PR TITLE
Update ref branch in github workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,6 +65,7 @@ jobs:
         with:
           repository: cdapio/cdap-e2e-tests
           path: e2e
+          ref: release/6.10
 
       - name: Cache
         uses: actions/cache@v4


### PR DESCRIPTION
In GitHub workflow the step that clones cdapio/cdap-e2e-tests doesn't specify a branch ref due to which GitHub Actions defaults to pulling the develop branch . This resulted in e2e failures for the release branch.
So this change includes introducing a ref branch - `release/6.10` which will fix the cdap-e2e-tests failures.