### PR TITLE
[Cherrypick] [oracle] hide internal configuration fields in sink UI

### DIFF
--- a/oracle-plugin/src/e2e-test/features/sink/OracleDesignTimeValidation.feature
+++ b/oracle-plugin/src/e2e-test/features/sink/OracleDesignTimeValidation.feature
@@ -251,7 +251,6 @@ Feature: Oracle sink- Verify Oracle sink plugin design time validation scenarios
     Then Close the Plugin Properties page
     Then Navigate to the properties page of plugin: "Oracle2"
     Then Select dropdown plugin property: "select-jdbcPluginName" with option value: "driverName"
-    Then Replace input plugin property: "port" with value: "port" for Credentials and Authorization related fields
     Then Replace input plugin property: "database" with value: "databaseName"
     Then Replace input plugin property: "tableName" with value: "targetTable"
     Then Replace input plugin property: "dbSchemaName" with value: "schema"
@@ -259,6 +258,7 @@ Feature: Oracle sink- Verify Oracle sink plugin design time validation scenarios
     Then Enter input plugin property: "referenceName" with value: "targetRef"
     Then Select radio button plugin property: "connectionType" with value: "service"
     Then Select radio button plugin property: "role" with value: "normal"
+    Then Replace input plugin property: "port" with value: "port" for Credentials and Authorization related fields
     Then Click on the Validate button
     Then Verify that the Plugin is displaying an error message: "blank.HostBlank.message" on the header
 

--- a/oracle-plugin/src/e2e-test/resources/errorMessage.properties
+++ b/oracle-plugin/src/e2e-test/resources/errorMessage.properties
@@ -18,5 +18,6 @@ errorMessageInvalidHost=Exception while trying to validate schema of database ta
 errorLogsMessageInvalidBoundingQuery=Spark program 'phase-1' failed with error: Stage 'Oracle' encountered : \
   java.io.IOException: ORA-00936: missing expression . Please check the system logs for more details.
 blank.database.message=Required property 'database' has no value.
-blank.connection.message=Exception while trying to validate schema of database table 
+blank.connection.message=Exception while trying to validate schema of database table
+blank.HostBlank.message=Error encountered while configuring the stage: 'SQL Error occurred, sqlState: '08006', errorCode: '17002', errorMessage: SQL Exception occurred: [Message='IO Error: The Network Adapter could not establish the connection', SQLState='08006', ErrorCode='17002'].'
 errorMessageUpdateUpsertOperationName=Table key must be set if the operation is 'Update' or 'Upsert'.

--- a/oracle-plugin/src/e2e-test/resources/pluginParameters.properties
+++ b/oracle-plugin/src/e2e-test/resources/pluginParameters.properties
@@ -7,6 +7,7 @@ host=ORACLE_HOST
 port=ORACLE_PORT
 username=ORACLE_USERNAME
 password=ORACLE_PASSWORD
+connection.name=dummy
 outputSchema=[{"key":"ID","value":"decimal"},{"key":"LASTNAME","value":"string"}]
 datatypeColumns=(ID VARCHAR2(100) PRIMARY KEY, COL1 CHAR, COL2 CHAR(10), COL3 VARCHAR(3), COL4 VARCHAR2(3), \
   COL5 NCHAR, COL6 NCHAR(12), COL7 NVARCHAR2(12), COL8 CLOB, COL9 NCLOB, COL10 LONG, COL11 ROWID, COL12 NUMBER(4), \
@@ -94,6 +95,8 @@ numberOfSplits=2
 zeroValue=0
 splitByColumn=ID
 importQuery=where $CONDITIONS
+connectionArguments=queryTimeout=50
+transactionIsolationLevel=TRANSACTION_READ_COMMITTED
 operationName=update
 oracleTableKey=ID
 relationTableKey=ID

--- a/oracle-plugin/widgets/Oracle-batchsink.json
+++ b/oracle-plugin/widgets/Oracle-batchsink.json
@@ -121,6 +121,82 @@
           }
         },
         {
+          "widget-type": "hidden",
+          "label": "Treat as old timestamp",
+          "name": "treatAsOldTimestamp",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "false",
+            "options": [
+              {
+                "id": "true",
+                "label": "true"
+              },
+              {
+                "id": "false",
+                "label": "false"
+              }
+            ]
+          }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Treat precision less number as Decimal(old behavior)",
+          "name": "treatPrecisionlessNumAsDeci",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "false",
+            "options": [
+              {
+                "id": "true",
+                "label": "true"
+              },
+              {
+                "id": "false",
+                "label": "false"
+              }
+            ]
+          }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Treat Timestamp_LTZ as Timestamp",
+          "name": "treatTimestampLTZAsTimestamp",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "false",
+            "options": [
+              {
+                "id": "true",
+                "label": "true"
+              },
+              {
+                "id": "false",
+                "label": "false"
+              }
+            ]
+          }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Enable Xml Type",
+          "name": "enableXmlType",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "false",
+            "options": [
+              {
+                "id": "true",
+                "label": "true"
+              },
+              {
+                "id": "false",
+                "label": "false"
+              }
+            ]
+          }
+        },
+        {
           "name": "connectionType",
           "label": "Connection Type",
           "widget-type": "radio-group",


### PR DESCRIPTION
[oracle] hide internal configuration fields in sink UI, these were added for DTS use cases.

Fields are treatAsOldTimestamp, treatPrecisionlessNumAsDeci, treatTimestampLTZAsTimestamp and enableXmlType.

cherrypick PR #673 