### PR TITLE
[🍒] Add TRANSACTION_ISOLATION_LEVEL config in cloudsql-postgres and cloudsql-mysql plugins for 1.11

### DIFF
--- a/amazon-redshift-plugin/pom.xml
+++ b/amazon-redshift-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.11.13</version>
+    <version>1.11.14-SNAPSHOT</version>
   </parent>
 
   <name>Amazon Redshift plugin</name>

--- a/aurora-mysql-plugin/pom.xml
+++ b/aurora-mysql-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.11.13</version>
+    <version>1.11.14-SNAPSHOT</version>
   </parent>
 
   <name>Aurora DB MySQL plugin</name>

--- a/aurora-postgresql-plugin/pom.xml
+++ b/aurora-postgresql-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.11.13</version>
+    <version>1.11.14-SNAPSHOT</version>
   </parent>
 
   <name>Aurora DB PostgreSQL plugin</name>

--- a/cloudsql-mysql-plugin/docs/CloudSQLMySQL-batchsink.md
+++ b/cloudsql-mysql-plugin/docs/CloudSQLMySQL-batchsink.md
@@ -42,7 +42,7 @@ Can be found in the instance overview page.
 
 **Password:** Password to use to connect to the specified database.
 
-**Transaction Isolation Level:** Transaction isolation level for queries run by this sink. 
+**Transaction Isolation Level:** Transaction isolation level for queries run by this sink.
 
 **Connection Timeout:** The timeout value (in seconds) used for socket connect operations. If connecting to the server 
 takes longer than this value, the connection is broken. A value of 0 means that it is disabled.

--- a/cloudsql-mysql-plugin/docs/CloudSQLMySQL-batchsource.md
+++ b/cloudsql-mysql-plugin/docs/CloudSQLMySQL-batchsource.md
@@ -52,6 +52,14 @@ For example, 'SELECT MIN(id),MAX(id) FROM table'. Not required if numSplits is s
 
 **Password:** Password to use to connect to the specified database.
 
+**Transaction Isolation Level:** The transaction isolation level of the database connection.
+- TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
+- TRANSACTION_SERIALIZABLE: No dirty reads. Non-repeatable and phantom reads are prevented.
+- TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
+- TRANSACTION_READ_UNCOMMITTED: Allows dirty reads (reading uncommitted changes from other transactions). Non-repeatable reads and phantom reads are possible.
+
+For more details on the Transaction Isolation Levels supported in CloudSQL MySQL, refer to the  [CloudSQL MySQL documentation](https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html)
+
 **Connection Arguments:** A list of arbitrary string key/value pairs as connection arguments. These arguments
 will be passed to the JDBC driver as connection arguments for JDBC drivers that may need additional configurations.
 

--- a/cloudsql-mysql-plugin/docs/CloudSQLMySQL-connector.md
+++ b/cloudsql-mysql-plugin/docs/CloudSQLMySQL-connector.md
@@ -27,6 +27,14 @@ authentication. Optional for databases that do not require authentication.
 
 **Password:** Password to use to connect to the specified database.
 
+**Transaction Isolation Level:** The transaction isolation level of the database connection.
+- TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
+- TRANSACTION_SERIALIZABLE: No dirty reads. Non-repeatable and phantom reads are prevented.
+- TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
+- TRANSACTION_READ_UNCOMMITTED: Allows dirty reads (reading uncommitted changes from other transactions). Non-repeatable reads and phantom reads are possible.
+
+For more details on the Transaction Isolation Levels supported in CloudSQL MySQL, refer to the  [CloudSQL MySQL documentation](https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html)
+
 **Connection Arguments:** A list of arbitrary string tag/value pairs as connection arguments. These arguments
 will be passed to the JDBC driver, as connection arguments, for JDBC drivers that may need additional configurations.
 This is a semicolon-separated list of key-value pairs, where each pair is separated by a equals '=' and specifies

--- a/cloudsql-mysql-plugin/pom.xml
+++ b/cloudsql-mysql-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.11.13</version>
+    <version>1.11.14-SNAPSHOT</version>
   </parent>
 
   <name>CloudSQL MySQL plugin</name>

--- a/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLSource.java
+++ b/cloudsql-mysql-plugin/src/main/java/io/cdap/plugin/cloudsql/mysql/CloudSQLMySQLSource.java
@@ -141,6 +141,13 @@ public class CloudSQLMySQLSource extends AbstractDBSource<CloudSQLMySQLSource.Cl
     @Description("The existing connection to use.")
     private CloudSQLMySQLConnectorConfig connection;
 
+    @Name(TRANSACTION_ISOLATION_LEVEL)
+    @Description("Transaction isolation level for queries run by this source.")
+    @Nullable
+    private String transactionIsolationLevel;
+
+    private static final String DEFAULT_TRANSACTION_ISOLATION_LEVEL = "TRANSACTION_REPEATABLE_READ";
+
     @Override
     protected Map<String, String> getDBSpecificArguments() {
       if (getFetchSize() == null || getFetchSize() <= 0) {
@@ -151,6 +158,11 @@ public class CloudSQLMySQLSource extends AbstractDBSource<CloudSQLMySQLSource.Cl
       // statement will use cursor-based fetching to retrieve rows
       arguments.put("useCursorFetch", "true");
       return arguments;
+    }
+
+    @Override
+    public String getTransactionIsolationLevel() {
+      return transactionIsolationLevel != null ? transactionIsolationLevel : DEFAULT_TRANSACTION_ISOLATION_LEVEL;
     }
 
     @Override

--- a/cloudsql-mysql-plugin/widgets/CloudSQLMySQL-batchsource.json
+++ b/cloudsql-mysql-plugin/widgets/CloudSQLMySQL-batchsource.json
@@ -85,6 +85,20 @@
           "name": "password"
         },
         {
+          "widget-type": "select",
+          "label": "Transaction Isolation Level",
+          "name": "transactionIsolationLevel",
+          "widget-attributes": {
+            "default": "TRANSACTION_REPEATABLE_READ",
+            "values": [
+              "TRANSACTION_REPEATABLE_READ",
+              "TRANSACTION_READ_UNCOMMITTED",
+              "TRANSACTION_READ_COMMITTED",
+              "TRANSACTION_SERIALIZABLE"
+            ]
+          }
+        },
+        {
           "widget-type": "keyvalue",
           "label": "Connection Arguments",
           "name": "connectionArguments",

--- a/cloudsql-mysql-plugin/widgets/CloudSQLMySQL-connector.json
+++ b/cloudsql-mysql-plugin/widgets/CloudSQLMySQL-connector.json
@@ -54,6 +54,20 @@
           "widget-attributes": {
             "default": "3306"
           }
+        },
+        {
+          "widget-type": "select",
+          "label": "Transaction Isolation Level",
+          "name": "transactionIsolationLevel",
+          "widget-attributes": {
+            "default": "TRANSACTION_REPEATABLE_READ",
+            "values": [
+              "TRANSACTION_REPEATABLE_READ",
+              "TRANSACTION_READ_UNCOMMITTED",
+              "TRANSACTION_READ_COMMITTED",
+              "TRANSACTION_SERIALIZABLE"
+            ]
+          }
         }
       ]
     },

--- a/cloudsql-postgresql-plugin/docs/CloudSQLPostgreSQL-batchsink.md
+++ b/cloudsql-postgresql-plugin/docs/CloudSQLPostgreSQL-batchsink.md
@@ -42,7 +42,7 @@ Can be found in the instance overview page.
 
 **Password:** Password to use to connect to the specified database.
 
-**Transaction Isolation Level:** Transaction isolation level for queries run by this sink. 
+**Transaction Isolation Level:** Transaction isolation level for queries run by this sink.
 
 **Connection Arguments:** A list of arbitrary string key/value pairs as connection arguments. These arguments
 will be passed to the JDBC driver as connection arguments for JDBC drivers that may need additional configurations.

--- a/cloudsql-postgresql-plugin/docs/CloudSQLPostgreSQL-batchsource.md
+++ b/cloudsql-postgresql-plugin/docs/CloudSQLPostgreSQL-batchsource.md
@@ -52,6 +52,14 @@ For example, 'SELECT MIN(id),MAX(id) FROM table'. Not required if numSplits is s
 
 **Password:** Password to use to connect to the specified database.
 
+**Transaction Isolation Level:** The transaction isolation level of the database connection.
+- TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
+- TRANSACTION_SERIALIZABLE: No dirty reads. Non-repeatable and phantom reads are prevented.
+- TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
+- Note: PostgreSQL does not implement `TRANSACTION_READ_UNCOMMITTED` as a distinct isolation level. Instead, this mode behaves identically to`TRANSACTION_READ_COMMITTED`, which is why it is not exposed as a separate option.
+
+For more details on the Transaction Isolation Levels supported in CloudSQL PostgreSQL, refer to the [CloudSQL PostgreSQL documentation](https://www.postgresql.org/docs/current/transaction-iso.html)
+
 **Connection Arguments:** A list of arbitrary string key/value pairs as connection arguments. These arguments
 will be passed to the JDBC driver as connection arguments for JDBC drivers that may need additional configurations.
 

--- a/cloudsql-postgresql-plugin/docs/CloudSQLPostgreSQL-connector.md
+++ b/cloudsql-postgresql-plugin/docs/CloudSQLPostgreSQL-connector.md
@@ -27,6 +27,14 @@ authentication. Optional for databases that do not require authentication.
 
 **Password:** Password to use to connect to the specified database.
 
+**Transaction Isolation Level:** The transaction isolation level of the database connection.
+- TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
+- TRANSACTION_SERIALIZABLE: No dirty reads. Non-repeatable and phantom reads are prevented.
+- TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
+- Note: PostgreSQL does not implement `TRANSACTION_READ_UNCOMMITTED` as a distinct isolation level. Instead, this mode behaves identically to`TRANSACTION_READ_COMMITTED`, which is why it is not exposed as a separate option.
+
+For more details on the Transaction Isolation Levels supported in CloudSQL PostgreSQL, refer to the [CloudSQL PostgreSQL documentation](https://www.postgresql.org/docs/current/transaction-iso.html)
+
 **Connection Arguments:** A list of arbitrary string tag/value pairs as connection arguments. These arguments
 will be passed to the JDBC driver, as connection arguments, for JDBC drivers that may need additional configurations.
 This is a semicolon-separated list of key-value pairs, where each pair is separated by a equals '=' and specifies

--- a/cloudsql-postgresql-plugin/pom.xml
+++ b/cloudsql-postgresql-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.11.13</version>
+    <version>1.11.14-SNAPSHOT</version>
   </parent>
 
   <name>CloudSQL PostgreSQL plugin</name>

--- a/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLSource.java
+++ b/cloudsql-postgresql-plugin/src/main/java/io/cdap/plugin/cloudsql/postgres/CloudSQLPostgreSQLSource.java
@@ -142,6 +142,13 @@ public class CloudSQLPostgreSQLSource
     @Description("The existing connection to use.")
     private CloudSQLPostgreSQLConnectorConfig connection;
 
+    @Name(TRANSACTION_ISOLATION_LEVEL)
+    @Description("Transaction isolation level for queries run by this source.")
+    @Nullable
+    private String transactionIsolationLevel;
+
+    private static final String DEFAULT_TRANSACTION_ISOLATION_LEVEL = "TRANSACTION_READ_COMMITTED";
+
     @Override
     protected Map<String, String> getDBSpecificArguments() {
       return Collections.emptyMap();
@@ -156,6 +163,11 @@ public class CloudSQLPostgreSQLSource
     @Override
     protected CloudSQLPostgreSQLConnectorConfig getConnection() {
       return connection;
+    }
+
+    @Override
+    public String getTransactionIsolationLevel() {
+      return transactionIsolationLevel != null ? transactionIsolationLevel : DEFAULT_TRANSACTION_ISOLATION_LEVEL;
     }
 
     @Override

--- a/cloudsql-postgresql-plugin/widgets/CloudSQLPostgreSQL-batchsource.json
+++ b/cloudsql-postgresql-plugin/widgets/CloudSQLPostgreSQL-batchsource.json
@@ -85,6 +85,19 @@
           "name": "password"
         },
         {
+          "widget-type": "select",
+          "label": "Transaction Isolation Level",
+          "name": "transactionIsolationLevel",
+          "widget-attributes": {
+            "default": "TRANSACTION_READ_COMMITTED",
+            "values": [
+              "TRANSACTION_READ_COMMITTED",
+              "TRANSACTION_REPEATABLE_READ",
+              "TRANSACTION_SERIALIZABLE"
+            ]
+          }
+        },
+        {
           "widget-type": "keyvalue",
           "label": "Connection Arguments",
           "name": "connectionArguments",

--- a/cloudsql-postgresql-plugin/widgets/CloudSQLPostgreSQL-connector.json
+++ b/cloudsql-postgresql-plugin/widgets/CloudSQLPostgreSQL-connector.json
@@ -54,6 +54,19 @@
           "widget-attributes": {
             "default": "5432"
           }
+        },
+        {
+          "widget-type": "select",
+          "label": "Transaction Isolation Level",
+          "name": "transactionIsolationLevel",
+          "widget-attributes": {
+            "default": "TRANSACTION_READ_COMMITTED",
+            "values": [
+              "TRANSACTION_READ_COMMITTED",
+              "TRANSACTION_REPEATABLE_READ",
+              "TRANSACTION_SERIALIZABLE"
+            ]
+          }
         }
       ]
     },

--- a/database-commons/pom.xml
+++ b/database-commons/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.11.13</version>
+    <version>1.11.14-SNAPSHOT</version>
   </parent>
 
   <name>Database Commons</name>

--- a/database-commons/src/main/java/io/cdap/plugin/db/config/AbstractDBSpecificSourceConfig.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/config/AbstractDBSpecificSourceConfig.java
@@ -49,6 +49,7 @@ public abstract class AbstractDBSpecificSourceConfig extends PluginConfig implem
   public static final String DATABASE = "database";
   public static final String FETCH_SIZE = "fetchSize";
   public static final String DEFAULT_FETCH_SIZE = "1000";
+  public static final String TRANSACTION_ISOLATION_LEVEL = "transactionIsolationLevel";
 
   @Name(Constants.Reference.REFERENCE_NAME)
   @Description(Constants.Reference.REFERENCE_NAME_DESCRIPTION)

--- a/db2-plugin/pom.xml
+++ b/db2-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.11.13</version>
+    <version>1.11.14-SNAPSHOT</version>
   </parent>
 
   <name>IBM DB2 plugin</name>

--- a/generic-database-plugin/pom.xml
+++ b/generic-database-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.11.13</version>
+    <version>1.11.14-SNAPSHOT</version>
   </parent>
 
   <name>Generic database plugin</name>

--- a/generic-db-argument-setter/pom.xml
+++ b/generic-db-argument-setter/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.11.13</version>
+    <version>1.11.14-SNAPSHOT</version>
   </parent>
 
   <name>Generic database argument setter plugin</name>

--- a/mariadb-plugin/pom.xml
+++ b/mariadb-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.11.13</version>
+    <version>1.11.14-SNAPSHOT</version>
   </parent>
 
   <name>Maria DB plugin</name>

--- a/memsql-plugin/pom.xml
+++ b/memsql-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.11.13</version>
+    <version>1.11.14-SNAPSHOT</version>
   </parent>
 
   <name>Memsql plugin</name>

--- a/mssql-plugin/pom.xml
+++ b/mssql-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.11.13</version>
+    <version>1.11.14-SNAPSHOT</version>
   </parent>
 
   <name>Microsoft SQL Server plugin</name>

--- a/mysql-plugin/pom.xml
+++ b/mysql-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.11.13</version>
+    <version>1.11.14-SNAPSHOT</version>
   </parent>
 
   <name>Mysql plugin</name>

--- a/netezza-plugin/pom.xml
+++ b/netezza-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.11.13</version>
+    <version>1.11.14-SNAPSHOT</version>
   </parent>
 
   <name>Netezza plugin</name>

--- a/oracle-plugin/pom.xml
+++ b/oracle-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.11.13</version>
+    <version>1.11.14-SNAPSHOT</version>
   </parent>
 
   <name>Oracle plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>database-plugins-parent</artifactId>
-  <version>1.11.13</version>
+  <version>1.11.14-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Database Plugins</name>
   <description>Collection of database plugins</description>

--- a/postgresql-plugin/pom.xml
+++ b/postgresql-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.11.13</version>
+    <version>1.11.14-SNAPSHOT</version>
   </parent>
 
   <name>PostgreSQL plugin</name>

--- a/saphana-plugin/pom.xml
+++ b/saphana-plugin/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.11.13</version>
+    <version>1.11.14-SNAPSHOT</version>
   </parent>
 
   <name>SAP HANA plugin</name>

--- a/teradata-plugin/pom.xml
+++ b/teradata-plugin/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>database-plugins-parent</artifactId>
     <groupId>io.cdap.plugin</groupId>
-    <version>1.11.13</version>
+    <version>1.11.14-SNAPSHOT</version>
   </parent>
 
   <artifactId>teradata-plugin</artifactId>


### PR DESCRIPTION
[🍒]

🍒 [cherrypick]

PR : (https://github.com/data-integrations/database-plugins/pull/675)

Description:

Add TRANSACTION_ISOLATION_LEVEL config in cloudsql-postgres and cloudsql-mysql plugins